### PR TITLE
Restore page artifact filtering

### DIFF
--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -162,6 +162,13 @@ def extract_blocks_from_page(page, page_num, filename) -> list[dict]:
         if not block_text:
             continue
 
+        # Filter out headers, footers, and similar page artifacts
+        if is_page_artifact({"text": block_text}, page_num):
+            logger.debug(
+                f"Skipping page artifact on page {page_num}: {repr(block_text)}"
+            )
+            continue
+
         # Determine heading via font flags or fallback
         is_heading = False
         if len(block_text.split()) < 15:


### PR DESCRIPTION
## Summary
- hook `is_page_artifact` into `extract_blocks_from_page` so headers and
  footers are removed during initial PDF parsing

## Testing
- `bash tests/run_all_tests.sh` *(fails: ModuleNotFoundError: No module named 'langdetect')*

------
https://chatgpt.com/codex/tasks/task_e_6883ceef45588325950a510504d0ea54