### PR TITLE
Improve artifact filtering for PyMuPDF4LLM

### DIFF
--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -162,6 +162,13 @@ def extract_blocks_from_page(page, page_num, filename) -> list[dict]:
         if not block_text:
             continue
 
+        # Filter out headers, footers, and similar page artifacts
+        if is_page_artifact({"text": block_text}, page_num):
+            logger.debug(
+                f"Skipping page artifact on page {page_num}: {repr(block_text)}"
+            )
+            continue
+
         # Determine heading via font flags or fallback
         is_heading = False
         if len(block_text.split()) < 15:

--- a/pdf_chunker/pymupdf4llm_integration.py
+++ b/pdf_chunker/pymupdf4llm_integration.py
@@ -206,6 +206,11 @@ def _clean_pymupdf4llm_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if _re2.match(r'^\s*(page|chapter|section)\s+\d+\s*$', text.strip().lower()):
         return None
 
+    # Use shared artifact detection for complex patterns
+    if is_page_artifact_text(text, block.get('source', {}).get('page', 0)):
+        logger.debug(f"Skipping PyMuPDF4LLM page artifact: {repr(text[:50])}")
+        return None
+
     # Update the block with cleaned text
     cleaned_block = block.copy()
     cleaned_block['text'] = text.strip()
@@ -843,6 +848,7 @@ def is_page_artifact_text(text: str, page_num: int) -> bool:
         r'^\d+\s*$',
         r'^chapter\s+\d+$',
         r'^\d+\s+chapter',
+        r'^\d+\s*\|\s*[\w\s:]+$',
         r'^table\s+of\s+contents',
         r'^bibliography',
         r'^index$',


### PR DESCRIPTION
## Summary
- filter page artifacts in PyMuPDF4LLM output using existing heuristics
- extend artifact detection patterns for headers/footers with vertical bar text

## Testing
- `bash tests/run_all_tests.sh` *(fails: litellm API key and missing test PDFs)*

------
https://chatgpt.com/codex/tasks/task_e_6883ceef45588325950a510504d0ea54