### PR TITLE
Improve cross-page merge heuristic

### DIFF
--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -67,11 +67,14 @@ def _should_merge_blocks(curr_block: Dict[str, Any], next_block: Dict[str, Any])
 
     # Case 3: Cross-page sentence continuation (no punctuation at end)
     # Enhanced to be more careful with quoted text
-    elif (curr_text and next_text and
-          not curr_text.endswith(('.', '!', '?')) and
-          not next_text[0].isupper() and
-          curr_page != next_page and
-          not _looks_like_quote_boundary(curr_text, next_text)):
+    elif (
+        curr_text
+        and next_text
+        and not curr_text.endswith((".", "!", "?"))
+        and curr_page != next_page
+        and not _looks_like_quote_boundary(curr_text, next_text)
+        and not _detect_heading_fallback(next_text)
+    ):
         logger.debug("Merge decision: CROSS_PAGE_CONTINUATION")
         return True, "sentence_continuation"
 
@@ -160,6 +163,13 @@ def extract_blocks_from_page(page, page_num, filename) -> list[dict]:
         logger.debug(f"Block text after cleaning: {repr(block_text[:50])}")
 
         if not block_text:
+            continue
+
+        # Filter out headers, footers, and similar page artifacts
+        if is_page_artifact({"text": block_text}, page_num):
+            logger.debug(
+                f"Skipping page artifact on page {page_num}: {repr(block_text)}"
+            )
             continue
 
         # Determine heading via font flags or fallback

--- a/pdf_chunker/pymupdf4llm_integration.py
+++ b/pdf_chunker/pymupdf4llm_integration.py
@@ -206,6 +206,11 @@ def _clean_pymupdf4llm_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if _re2.match(r'^\s*(page|chapter|section)\s+\d+\s*$', text.strip().lower()):
         return None
 
+    # Use shared artifact detection for complex patterns
+    if is_page_artifact_text(text, block.get('source', {}).get('page', 0)):
+        logger.debug(f"Skipping PyMuPDF4LLM page artifact: {repr(text[:50])}")
+        return None
+
     # Update the block with cleaned text
     cleaned_block = block.copy()
     cleaned_block['text'] = text.strip()
@@ -843,6 +848,7 @@ def is_page_artifact_text(text: str, page_num: int) -> bool:
         r'^\d+\s*$',
         r'^chapter\s+\d+$',
         r'^\d+\s+chapter',
+        r'^\d+\s*\|\s*[\w\s:]+$',
         r'^table\s+of\s+contents',
         r'^bibliography',
         r'^index$',


### PR DESCRIPTION
## Summary
- relax cross-page merge logic to allow continuation when next block starts with uppercase unless it resembles a heading
- include heading fallback check to avoid merging headings mistakenly

## Testing
- `./_apply.sh pdf` *(fails: sample-local-pdf.pdf missing)*
- `bash tests/run_all_tests.sh` *(fails: ModuleNotFoundError: No module named 'langdetect')*

------
https://chatgpt.com/codex/tasks/task_e_6883ceef45588325950a510504d0ea54