### PR TITLE
Improve footnote detection

### DIFF
--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -67,11 +67,14 @@ def _should_merge_blocks(curr_block: Dict[str, Any], next_block: Dict[str, Any])
 
     # Case 3: Cross-page sentence continuation (no punctuation at end)
     # Enhanced to be more careful with quoted text
-    elif (curr_text and next_text and
-          not curr_text.endswith(('.', '!', '?')) and
-          not next_text[0].isupper() and
-          curr_page != next_page and
-          not _looks_like_quote_boundary(curr_text, next_text)):
+    elif (
+        curr_text
+        and next_text
+        and not curr_text.endswith((".", "!", "?"))
+        and curr_page != next_page
+        and not _looks_like_quote_boundary(curr_text, next_text)
+        and not _detect_heading_fallback(next_text)
+    ):
         logger.debug("Merge decision: CROSS_PAGE_CONTINUATION")
         return True, "sentence_continuation"
 
@@ -142,6 +145,30 @@ def is_artifact_block(block, page_height, frac=0.15, max_words=6):
             return True
     return False
 
+
+def _remove_page_artifact_lines(text: str, page_num: int) -> str:
+    """Strip lines that look like page artifacts or footnotes."""
+
+    lines = text.splitlines()
+
+    def _is_artifact(idx: int) -> bool:
+        ln = clean_text(lines[idx])
+        return is_page_artifact({"text": ln}, page_num)
+
+    filtered = [
+        ln
+        for i, ln in enumerate(lines)
+        if not (
+            _is_artifact(i)
+            and (
+                i == len(lines) - 1
+                or _is_artifact(i + 1)
+            )
+        )
+    ]
+
+    return "\n".join(filtered)
+
 def extract_blocks_from_page(page, page_num, filename) -> list[dict]:
     """
     Extract and classify text blocks from a PDF page,
@@ -156,10 +183,20 @@ def extract_blocks_from_page(page, page_num, filename) -> list[dict]:
         raw_text = b[4]
         logger.debug(f"Raw block text before cleaning: {repr(raw_text[:50])}")
 
+        # Remove obvious header/footer lines before full cleaning
+        raw_text = _remove_page_artifact_lines(raw_text, page_num)
+
         block_text = clean_text(raw_text)
         logger.debug(f"Block text after cleaning: {repr(block_text[:50])}")
 
         if not block_text:
+            continue
+
+        # Filter out headers, footers, and similar page artifacts
+        if is_page_artifact({"text": block_text}, page_num):
+            logger.debug(
+                f"Skipping page artifact on page {page_num}: {repr(block_text)}"
+            )
             continue
 
         # Determine heading via font flags or fallback
@@ -208,16 +245,14 @@ def is_page_artifact(block: dict, page_num: int) -> bool:
 
     # Check for common header/footer patterns
     header_footer_patterns = [
-        r'^\d+$',  # Just page numbers
-        r'^page\s+\d+',  # "Page 1", "Page 2", etc.
-        r'^\d+\s*$',  # Page numbers with whitespace
-        r'^chapter\s+\d+$',  # Standalone "Chapter X"
-        r'^\d+\s+chapter',  # "1 Chapter", "2 Chapter", etc.
-        # "Introduction | 1"
-        r'^\w+\s*\|\s*\d+$',  # "Introduction | 1", "Summary | 2"
-        # "60 | Chapter 3: How and When to Get Started"
-        r'^\d+\s*\|\s*[\w\s:]+$',  # "60 | Chapter 3: How and When to Get Started"
-
+        r'^\d+$',                     # Just page numbers
+        r'^page\s+\d+',              # "Page 1", "Page 2", etc.
+        r'^\d+\s*$',                 # Page numbers with whitespace
+        r'^chapter\s+\d+$',          # Standalone "Chapter X"
+        r'^\d+\s+chapter',           # "1 Chapter", "2 Chapter", etc.
+        r'^\w+\s*\|\s*\d+$',      # "Introduction | 1", "Summary | 2"
+        r'^\d+\s*\|\s*[\w\s:]+$', # "60 | Chapter 3: How and When to Get Started"
+        r'^[0-9]{1,3}[.)]?\s+[A-Z]', # Footnotes like "1 See example"
     ]
 
     text_lower = text.lower()

--- a/pdf_chunker/pymupdf4llm_integration.py
+++ b/pdf_chunker/pymupdf4llm_integration.py
@@ -206,6 +206,11 @@ def _clean_pymupdf4llm_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if _re2.match(r'^\s*(page|chapter|section)\s+\d+\s*$', text.strip().lower()):
         return None
 
+    # Use shared artifact detection for complex patterns
+    if is_page_artifact_text(text, block.get('source', {}).get('page', 0)):
+        logger.debug(f"Skipping PyMuPDF4LLM page artifact: {repr(text[:50])}")
+        return None
+
     # Update the block with cleaned text
     cleaned_block = block.copy()
     cleaned_block['text'] = text.strip()
@@ -843,6 +848,8 @@ def is_page_artifact_text(text: str, page_num: int) -> bool:
         r'^\d+\s*$',
         r'^chapter\s+\d+$',
         r'^\d+\s+chapter',
+        r'^\d+\s*\|\s*[\w\s:]+$',
+        r'^[0-9]{1,3}[.)]?\s+[A-Z]',
         r'^table\s+of\s+contents',
         r'^bibliography',
         r'^index$',

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,3 +89,6 @@ ftfy
 pymupdf4llm
 reportlab
 lxml
+
+langdetect
+textstat

--- a/sample-local-pdf.pdf
+++ b/sample-local-pdf.pdf
@@ -1,0 +1,112 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 12 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250725210814+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250725210814+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 3 /Kids [ 4 0 R 5 0 R 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 482
+>>
+stream
+Gas2F_,#\;(rbt@/)F,t6qS;+*mIr!U<*n)-SGYGW.VOP7E9mrWKUc-(.o*EqRte`qFV=1O8(kVJ1$50/HL\n99;,h6!s.U(VUrA,egu&U2ulq,Z^%3+_ZKIb)OA0j^#d#7B'JW2I#NOQ#gGggu!^4K&2L(o>$3%P/b8RPq[08_%):\&!=>k=^H@&(TU!@XM]:_*iUPLR9QA\4(.sD^POBj:-Is_kpgD8O9SE\>G5gBc1]rN>M'::-qiD,Gh["8<2DhJ$d'E9S7dp;75@R'+<P.%!p)o[pUABD6d@O3KQATP\Lb!jLI$;'GoJ<k&,mn3?g1>6+?aq`ZW=$M386rq=Mq5RhB/qQaTsuZZ@0o<"XXW,6?6ThP_5CG3qQS$5G;XJ8UAV4<2uu,AE.>Ul`>lD\Bd.<3dDPT2SHB.)6X!]RhnGPdrgas;T"oE]k(:F%\M9$58ZW)kp^T_RcL5tk/3#(2h]-\S:gAA~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 571
+>>
+stream
+Gas2F>Ap#c&;B$5.us2M<%GOV6FM;XP")R\OeS/.5'kHVSFm'=-GB?RNe-P7V%R3f1t^\GF2g5kr8cmB)W83H]=T&.Jbft(R?a_[pfsGNon"](]ui7RH9NRV$=7Mt#&eB?d7<cK5N9:/]dDMo)p-)-e5*%#*f-n^O2UcqnR#b5.7[k'WIS<^"N_p_Cd=B/Oa]a;:.,q1PRR%,1`@_H_h-olrau0[T.3f/2JIPu:fckTTd8_glUB]b'cJC*CBn$/fET[=.lW,Q[hk2([,DaI;9en-0;Q![YubgsQ[%cQ^d%">C3Tj>;>Cb8H4kSqYL(m4)F^D#TJ3]6dXC],J/:$\MBns;Q:3q/>1',ZL]_CX"YQk#/F\YQ5mr09AkF3-X6`)Cel.<C:ue1p\Nr1,d5&AI8n2LYn"$6cfT\qC=Q^,(nL1fo:@;3M2O,K,j./d@QdNc`<fQ<1"CgPcBt;]5o3jiQaZ;n`G5>.V%`+QTgLOr^A90kW';3mInF6=(GdtF;\(gdkHo8m1Y0_95VO!Ka+a!$49/&$1BlH1[ai;jQNhk\kReNA!a4Xh;KGS%~>endstream
+endobj
+12 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 397
+>>
+stream
+GasbV4`A1k&;GCX`OkeQ0X3?(`!@hk2`u6iM*kP0"2u(Ur;.O,BW+lYMO!.rk;g;kP6grIrBIE7[D@5@+VdZ\WJ-(Pa.&LiFiBW[*f>3Bb>Aj#4on?2k=q'YagP"rm&9;Ll<9Zce'qoDH@bmFH2Y!g2q_CO6N(U-A)1?`iB3.B_1Ja9%mR&B6&fC/Ut0lo+'-/2>jHLel_M>I[@U3=e_ZlLNbihW;kY&rT`fP)4(aP:JJLVrK`HmA*sJ!>4G)n%/1nnX>YY2e[.o$`V2ij)aN0-qU+tU*MS@-2V$JGlbkNS+kQr7rr_IQ(*QHQI04Q!a98/'aH%)G7O(@]O7jh,c,,qos,'/%TDg9U10-__=7FSuTNJ$=e>9u\M/%ej"lWSXTV8DR<%P?:o~>endstream
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000527 00000 n 
+0000000721 00000 n 
+0000000915 00000 n 
+0000000983 00000 n 
+0000001279 00000 n 
+0000001350 00000 n 
+0000001923 00000 n 
+0000002585 00000 n 
+trailer
+<<
+/ID 
+[<693ae6675ce496ec1d6c6d5b2f32ea0f><693ae6675ce496ec1d6c6d5b2f32ea0f>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 13
+>>
+startxref
+3073
+%%EOF

--- a/test_data/sample_test.pdf
+++ b/test_data/sample_test.pdf
@@ -1,0 +1,112 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 12 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250725210814+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250725210814+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 3 /Kids [ 4 0 R 5 0 R 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 482
+>>
+stream
+Gas2F_,#\;(rbt@/)F,t6qS;+*mIr!U<*n)-SGYGW.VOP7E9mrWKUc-(.o*EqRte`qFV=1O8(kVJ1$50/HL\n99;,h6!s.U(VUrA,egu&U2ulq,Z^%3+_ZKIb)OA0j^#d#7B'JW2I#NOQ#gGggu!^4K&2L(o>$3%P/b8RPq[08_%):\&!=>k=^H@&(TU!@XM]:_*iUPLR9QA\4(.sD^POBj:-Is_kpgD8O9SE\>G5gBc1]rN>M'::-qiD,Gh["8<2DhJ$d'E9S7dp;75@R'+<P.%!p)o[pUABD6d@O3KQATP\Lb!jLI$;'GoJ<k&,mn3?g1>6+?aq`ZW=$M386rq=Mq5RhB/qQaTsuZZ@0o<"XXW,6?6ThP_5CG3qQS$5G;XJ8UAV4<2uu,AE.>Ul`>lD\Bd.<3dDPT2SHB.)6X!]RhnGPdrgas;T"oE]k(:F%\M9$58ZW)kp^T_RcL5tk/3#(2h]-\S:gAA~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 571
+>>
+stream
+Gas2F>Ap#c&;B$5.us2M<%GOV6FM;XP")R\OeS/.5'kHVSFm'=-GB?RNe-P7V%R3f1t^\GF2g5kr8cmB)W83H]=T&.Jbft(R?a_[pfsGNon"](]ui7RH9NRV$=7Mt#&eB?d7<cK5N9:/]dDMo)p-)-e5*%#*f-n^O2UcqnR#b5.7[k'WIS<^"N_p_Cd=B/Oa]a;:.,q1PRR%,1`@_H_h-olrau0[T.3f/2JIPu:fckTTd8_glUB]b'cJC*CBn$/fET[=.lW,Q[hk2([,DaI;9en-0;Q![YubgsQ[%cQ^d%">C3Tj>;>Cb8H4kSqYL(m4)F^D#TJ3]6dXC],J/:$\MBns;Q:3q/>1',ZL]_CX"YQk#/F\YQ5mr09AkF3-X6`)Cel.<C:ue1p\Nr1,d5&AI8n2LYn"$6cfT\qC=Q^,(nL1fo:@;3M2O,K,j./d@QdNc`<fQ<1"CgPcBt;]5o3jiQaZ;n`G5>.V%`+QTgLOr^A90kW';3mInF6=(GdtF;\(gdkHo8m1Y0_95VO!Ka+a!$49/&$1BlH1[ai;jQNhk\kReNA!a4Xh;KGS%~>endstream
+endobj
+12 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 397
+>>
+stream
+GasbV4`A1k&;GCX`OkeQ0X3?(`!@hk2`u6iM*kP0"2u(Ur;.O,BW+lYMO!.rk;g;kP6grIrBIE7[D@5@+VdZ\WJ-(Pa.&LiFiBW[*f>3Bb>Aj#4on?2k=q'YagP"rm&9;Ll<9Zce'qoDH@bmFH2Y!g2q_CO6N(U-A)1?`iB3.B_1Ja9%mR&B6&fC/Ut0lo+'-/2>jHLel_M>I[@U3=e_ZlLNbihW;kY&rT`fP)4(aP:JJLVrK`HmA*sJ!>4G)n%/1nnX>YY2e[.o$`V2ij)aN0-qU+tU*MS@-2V$JGlbkNS+kQr7rr_IQ(*QHQI04Q!a98/'aH%)G7O(@]O7jh,c,,qos,'/%TDg9U10-__=7FSuTNJ$=e>9u\M/%ej"lWSXTV8DR<%P?:o~>endstream
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000527 00000 n 
+0000000721 00000 n 
+0000000915 00000 n 
+0000000983 00000 n 
+0000001279 00000 n 
+0000001350 00000 n 
+0000001923 00000 n 
+0000002585 00000 n 
+trailer
+<<
+/ID 
+[<693ae6675ce496ec1d6c6d5b2f32ea0f><693ae6675ce496ec1d6c6d5b2f32ea0f>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 13
+>>
+startxref
+3073
+%%EOF


### PR DESCRIPTION
## Summary
- refine `_remove_page_artifact_lines` to skip consecutive artifact lines
- tighten artifact regex to handle footnotes beginning with uppercase letters
- update PyMuPDF integration with new artifact pattern

## Testing
- `./_apply.sh pdf` *(fails: Python interpreter './pdf-env/bin/python' not found)*
- `bash tests/run_all_tests.sh` *(fails: missing `langdetect` module and API key)*

------
https://chatgpt.com/codex/tasks/task_e_6883ceef45588325950a510504d0ea54