### PR TITLE
Fix hyphenation with PyMuPDF4LLM cleaning

### DIFF
--- a/pdf_chunker/pymupdf4llm_integration.py
+++ b/pdf_chunker/pymupdf4llm_integration.py
@@ -404,6 +404,7 @@ def clean_text_with_pymupdf4llm(text: str, pdf_path: Optional[str] = None) -> st
         from .text_cleaning import (
             normalize_newlines,
             collapse_single_newlines,
+            fix_hyphenated_linebreaks,
             normalize_ligatures,
             consolidate_whitespace,
         )
@@ -416,6 +417,10 @@ def clean_text_with_pymupdf4llm(text: str, pdf_path: Optional[str] = None) -> st
         logger.debug("Applying collapse_single_newlines in PyMuPDF4LLM path")
         text = collapse_single_newlines(text)
         logger.debug(f"After collapse_single_newlines: {repr(text[:100])}")
+
+        logger.debug("Applying fix_hyphenated_linebreaks in PyMuPDF4LLM path")
+        text = fix_hyphenated_linebreaks(text)
+        logger.debug(f"After fix_hyphenated_linebreaks: {repr(text[:100])}")
         
         # Apply other cleaning steps paragraph by paragraph
         paragraphs = []

--- a/tests/hyphenation_test.py
+++ b/tests/hyphenation_test.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, ".")
+
+from pdf_chunker.text_cleaning import clean_text
+import pdf_chunker.pymupdf4llm_integration as p4l
+
+
+class TestHyphenationFix(unittest.TestCase):
+    def test_hyphenation_fix_with_pymupdf4llm(self):
+        sample = "a con-\n tainer and special-\n ists in man-\n agement"
+        os.environ["PDF_CHUNKER_USE_PYMUPDF4LLM"] = "true"
+        original = p4l.is_pymupdf4llm_available
+        try:
+            p4l.is_pymupdf4llm_available = lambda: True
+            cleaned = clean_text(sample)
+        finally:
+            p4l.is_pymupdf4llm_available = original
+            del os.environ["PDF_CHUNKER_USE_PYMUPDF4LLM"]
+        self.assertIn("container", cleaned)
+        self.assertIn("specialists", cleaned)
+        self.assertIn("management", cleaned)
+        self.assertNotIn("con- tainer", cleaned)
+        self.assertNotIn("special- ists", cleaned)
+        self.assertNotIn("man- agement", cleaned)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- apply `fix_hyphenated_linebreaks` when PyMuPDF4LLM cleaning is enabled
- add regression test for hyphenation handling

## Testing
- `pytest tests/hyphenation_test.py -q`
- `pytest tests/ -q`
- `bash tests/run_all_tests.sh >/tmp/test_run.log && tail -n 20 /tmp/test_run.log`

------
https://chatgpt.com/codex/tasks/task_e_68854fda2918832583273efb60502c29