### PR TITLE
Fix hyphenation in PyMuPDF4LLM cleaning

### DIFF
--- a/pdf_chunker/pymupdf4llm_integration.py
+++ b/pdf_chunker/pymupdf4llm_integration.py
@@ -180,20 +180,29 @@ def _clean_pymupdf4llm_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         return None
 
     import re as _re2
+    from .text_cleaning import (
+        pipe,
+        fix_hyphenated_linebreaks,
+        normalize_ligatures,
+        normalize_quotes,
+        remove_control_characters,
+        consolidate_whitespace,
+    )
 
-    # Remove markdown headers that weren't converted properly
-    text = _re2.sub(r'^#{1,6}\s*', '', text, flags=_re2.MULTILINE)
-
-    # Remove markdown emphasis that wasn't converted
-    text = _re2.sub(r'\*\*(.*?)\*\*', r'\1', text)  # Bold
-    text = _re2.sub(r'\*(.*?)\*', r'\1', text)      # Italic
-
-    # Remove markdown links
-    text = _re2.sub(r'\[([^\]]+)\]\([^\)]+\)', r'\1', text)
-
-    # Clean up excessive whitespace
-    text = _re2.sub(r'\n{3,}', '\n\n', text)
-    text = _re2.sub(r' {2,}', ' ', text)
+    text = pipe(
+        text,
+        lambda s: _re2.sub(r'^#{1,6}\s*', '', s, flags=_re2.MULTILINE),
+        lambda s: _re2.sub(r'\*\*(.*?)\*\*', r'\1', s),
+        lambda s: _re2.sub(r'\*(.*?)\*', r'\1', s),
+        lambda s: _re2.sub(r'\[([^\]]+)\]\([^\)]+\)', r'\1', s),
+        lambda s: _re2.sub(r'\n{3,}', '\n\n', s),
+        lambda s: _re2.sub(r' {2,}', ' ', s),
+        fix_hyphenated_linebreaks,
+        normalize_ligatures,
+        normalize_quotes,
+        remove_control_characters,
+        consolidate_whitespace,
+    )
 
     # Skip blocks that are too short or look like artifacts
     if len(text.strip()) < 10:

--- a/tests/hyphenation_test.py
+++ b/tests/hyphenation_test.py
@@ -26,6 +26,12 @@ class TestHyphenationFix(unittest.TestCase):
         self.assertNotIn("special- ists", cleaned)
         self.assertNotIn("man- agement", cleaned)
 
+    def test_clean_block_hyphen_fix(self):
+        block = {"text": "Storage engi-\nneer", "source": {"page": 1}}
+        cleaned = p4l._clean_pymupdf4llm_block(block)
+        self.assertIsNotNone(cleaned)
+        self.assertEqual(cleaned["text"], "Storage engineer")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure `_clean_pymupdf4llm_block` joins hyphenated linebreaks
- test hyphen handling for PyMuPDF4LLM block cleaning

## Testing
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: "Found 58 errors" in 11 files)*
- `bash scripts/validate_chunks.sh /tmp/sample.jsonl`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_68866687048083258fa1606ce97c1546