### PR TITLE
Fix hyphenation cleanup

### DIFF
--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -7,14 +7,16 @@ from typing import List, Callable, Tuple
 
 logger = logging.getLogger(__name__)
 
+
 def pipe(value, *funcs):
     for fn in funcs:
         value = fn(value)
     return value
 
+
 # Patterns
-PARAGRAPH_BREAK = re.compile(r'\n{2,}')
-CONTROL_CHARS = re.compile(r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]')
+PARAGRAPH_BREAK = re.compile(r"\n{2,}")
+CONTROL_CHARS = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]")
 
 # Quote normalization patterns
 QUOTE_PATTERNS: List[Tuple[re.Pattern, str]] = [
@@ -31,65 +33,75 @@ HYPHEN_CHARS_ESC = re.escape("\u2010\u2011\u002d\u00ad\u1400\ufe63‐-")
 # HYPHEN_CHARS = "-\u2010\u2011\u002d\u00ad\u1400\ufe63"
 # HYPHEN_CHARS = "\u2010\u2011\u002d\u00ad\u1400\ufe63"
 
+SOFT_HYPHEN_RE = re.compile("\u00ad")
+
+
+def _join_broken_words(text: str) -> str:
+    pattern_break = rf"(\w)[{HYPHEN_CHARS_ESC}]\s*\n\s*(\w)"
+    pattern_space = rf"(\w)[{HYPHEN_CHARS_ESC}]\s+([a-z])"
+    text = re.sub(pattern_break, r"\1\2", text)
+    return re.sub(pattern_space, r"\1\2", text)
+
+
+def _remove_soft_hyphens(text: str) -> str:
+    return SOFT_HYPHEN_RE.sub("", text)
+
 
 def fix_hyphenated_linebreaks(text: str) -> str:
-    """Join words split across lines by hyphen-like characters."""
+    """Join words split across lines without removing valid hyphens."""
 
-    pattern_break = rf"(\w)[{HYPHEN_CHARS_ESC}]\s*\n\s*(\w)"
-    text = re.sub(pattern_break, r"\1\2", text)
+    return pipe(text, _join_broken_words, _remove_soft_hyphens)
 
-    pattern_space = rf"(\w)[{HYPHEN_CHARS_ESC}]\s+([a-z])"
-    text = re.sub(pattern_space, r"\1\2", text)
-
-    text = re.sub(r"[\u00ad\u2010\u2011\u002d\u1400\ufe63‐-]", "", text)
-
-    return text
 
 def collapse_artifact_breaks(text: str) -> str:
     # Remove unwanted breaks after ., _, etc. (e.g., systems._\nThis → systems. This)
-    return re.sub(r'([._])\n(\w)', r'\1 \2', text)
+    return re.sub(r"([._])\n(\w)", r"\1 \2", text)
+
 
 def collapse_single_newlines(text: str) -> str:
     logger.debug(f"collapse_single_newlines called with {len(text)} chars")
     logger.debug(f"Input text preview: {repr(text[:100])}")
 
     # First, protect paragraph breaks (2+ newlines) by replacing with placeholder
-    text = re.sub(r'\n{2,}', '[[PARAGRAPH_BREAK]]', text)
+    text = re.sub(r"\n{2,}", "[[PARAGRAPH_BREAK]]", text)
     # Replace all remaining single newlines with spaces
-    text = text.replace('\n', ' ')
+    text = text.replace("\n", " ")
     # Restore paragraph breaks
-    text = text.replace('[[PARAGRAPH_BREAK]]', '\n\n')
+    text = text.replace("[[PARAGRAPH_BREAK]]", "\n\n")
 
     logger.debug(f"Output text preview: {repr(text[:100])}")
     return text
 
+
 def normalize_ligatures(text: str) -> str:
     return ftfy.fix_text(text)
+
 
 def normalize_quotes(text: str) -> str:
     if not text:
         return text
-    mapping = {
-        '“': '"', '”': '"', '„': '"', '‚': '"',
-        '‘': "'", '’': "'", '`': "'"
-    }
+    mapping = {"“": '"', "”": '"', "„": '"', "‚": '"', "‘": "'", "’": "'", "`": "'"}
     for smart, ascii_q in mapping.items():
         text = text.replace(smart, ascii_q)
     for pattern, repl in QUOTE_PATTERNS:
         text = pattern.sub(repl, text)
     return text
 
+
 def normalize_newlines(text: str) -> str:
     # Convert all CRLF and CR to LF, and unicode separators to LF as well
-    text = text.replace('\r\n', '\n').replace('\r', '\n')
-    text = text.replace('\u2028', '\n').replace('\u2029', '\n')
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = text.replace("\u2028", "\n").replace("\u2029", "\n")
     return text
 
+
 def remove_control_characters(text: str) -> str:
-    return CONTROL_CHARS.sub('', text)
+    return CONTROL_CHARS.sub("", text)
+
 
 def consolidate_whitespace(text: str) -> str:
-    return re.sub(r'[ \t\r\f\v]+', ' ', text).strip()
+    return re.sub(r"[ \t\r\f\v]+", " ", text).strip()
+
 
 def validate_json_safety(text: str) -> Tuple[bool, List[str]]:
     issues: List[str] = []
@@ -103,18 +115,19 @@ def validate_json_safety(text: str) -> Tuple[bool, List[str]]:
     dq = text.count('"')
     if dq % 2 != 0:
         issues.append(f"Unbalanced double quotes: {dq}")
-    if re.search(r'^[\",]', text.strip()):
+    if re.search(r"^[\",]", text.strip()):
         issues.append("Text starts with problematic punctuation")
-    if re.search(r'[\",]$', text.strip()):
+    if re.search(r"[\",]$", text.strip()):
         issues.append("Text ends with problematic punctuation")
     try:
-        text.encode('utf-8').decode('utf-8')
+        text.encode("utf-8").decode("utf-8")
     except UnicodeError:
         issues.append("Unicode encoding issues detected")
     return (len(issues) == 0, issues)
 
+
 def apply_json_safety_fixes(text: str) -> str:
-    fixed = CONTROL_CHARS.sub('', text)
+    fixed = CONTROL_CHARS.sub("", text)
     if fixed.startswith('", '):
         fixed = fixed[3:]
     elif fixed.startswith('"') and len(fixed) > 1 and fixed[1].islower():
@@ -122,15 +135,16 @@ def apply_json_safety_fixes(text: str) -> str:
     if fixed.endswith(', "') or fixed.endswith(',"'):
         fixed = fixed[:-2]
     try:
-        fixed = fixed.encode('utf-8', errors='replace').decode('utf-8')
+        fixed = fixed.encode("utf-8", errors="replace").decode("utf-8")
     except UnicodeError:
-        fixed = ''.join(ch for ch in fixed if ord(ch) < 128)
+        fixed = "".join(ch for ch in fixed if ord(ch) < 128)
     if fixed.count('"') % 2 != 0:
         if fixed.endswith('"'):
             fixed = fixed[:-1]
         elif fixed.startswith('"'):
             fixed = fixed[1:]
     return fixed
+
 
 def clean_paragraph(paragraph: str) -> str:
     """
@@ -141,12 +155,13 @@ def clean_paragraph(paragraph: str) -> str:
         paragraph,
         fix_hyphenated_linebreaks,
         collapse_artifact_breaks,
-        lambda t: t.replace('\n', ' '),    # any internal newlines to space
+        lambda t: t.replace("\n", " "),  # any internal newlines to space
         normalize_ligatures,
         normalize_quotes,
         remove_control_characters,
         consolidate_whitespace,
     )
+
 
 def clean_text(text: str) -> str:
     """
@@ -154,7 +169,7 @@ def clean_text(text: str) -> str:
     using clean_paragraph() for each paragraph.
     """
     if not text or not text.strip():
-        return ''
+        return ""
 
     logger.debug(f"clean_text called with {len(text)} chars")
     logger.debug(f"Input text preview: {repr(text[:100])}")
@@ -170,16 +185,24 @@ def clean_text(text: str) -> str:
     if enabled:
         logger.debug("Using PyMuPDF4LLM text cleaning path")
         try:
-            from .pymupdf4llm_integration import is_pymupdf4llm_available, clean_text_with_pymupdf4llm
+            from .pymupdf4llm_integration import (
+                is_pymupdf4llm_available,
+                clean_text_with_pymupdf4llm,
+            )
+
             if is_pymupdf4llm_available():
-                logger.debug("PyMuPDF4LLM is available, calling clean_text_with_pymupdf4llm")
+                logger.debug(
+                    "PyMuPDF4LLM is available, calling clean_text_with_pymupdf4llm"
+                )
                 result = clean_text_with_pymupdf4llm(text)
                 logger.debug(f"PyMuPDF4LLM result preview: {repr(result[:100])}")
                 return result
             else:
                 logger.debug("PyMuPDF4LLM not available, falling back to traditional")
         except Exception as e:
-            logger.debug(f"PyMuPDF4LLM cleaning failed with exception: {e}, falling back to traditional")
+            logger.debug(
+                f"PyMuPDF4LLM cleaning failed with exception: {e}, falling back to traditional"
+            )
             pass
 
     logger.debug("Using traditional text cleaning path")

--- a/tests/hyphenation_test.py
+++ b/tests/hyphenation_test.py
@@ -32,6 +32,11 @@ class TestHyphenationFix(unittest.TestCase):
         self.assertIsNotNone(cleaned)
         self.assertEqual(cleaned["text"], "Storage engineer")
 
+    def test_preserve_existing_hyphens(self):
+        text = "We sell business-critical, off-the-shelf solutions."
+        cleaned = clean_text(text)
+        self.assertIn("business-critical", cleaned)
+        self.assertIn("off-the-shelf", cleaned)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- preserve valid hyphens when rejoining line breaks
- add regression test for existing hyphen words

## Testing
- `mypy pdf_chunker/text_cleaning.py`
- `flake8 pdf_chunker/text_cleaning.py tests/hyphenation_test.py`
- `pytest tests/hyphenation_test.py::TestHyphenationFix::test_preserve_existing_hyphens -q`
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886920f446c8325afa05152d5d622b7