### PR TITLE
Fix PDF newline handling

### DIFF
--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -116,12 +116,20 @@ def _is_probable_heading(text: str) -> bool:
     return False
 
 
+def _has_unbalanced_quotes(text: str) -> bool:
+    """Return True if the text contains an odd number of quotes."""
+    return text.count('"') % 2 == 1 or text.count("'") % 2 == 1
+
+
 def merge_spurious_paragraph_breaks(text: str) -> str:
     parts = [p for p in PARAGRAPH_BREAK.split(text) if p.strip()]
     merged: List[str] = []
     for part in parts:
         if merged and not any(_is_probable_heading(seg) for seg in (merged[-1], part)):
             prev = merged[-1]
+            if _has_unbalanced_quotes(prev) and not _has_unbalanced_quotes(prev + part):
+                merged[-1] = f"{prev.rstrip()} {part.lstrip()}"
+                continue
             if len(prev) < 60 or not prev.rstrip().endswith((".", "?", "!")):
                 merged[-1] = f"{prev.rstrip()} {part.lstrip()}"
                 continue

--- a/tests/newline_cleanup_test.py
+++ b/tests/newline_cleanup_test.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from pdf_chunker.text_cleaning import clean_text
+
+
+class TestNewlineCleanup(unittest.TestCase):
+    def test_merge_lowercase_continuation(self):
+        text = "My performance as a\n\nmanager."
+        self.assertEqual(clean_text(text), "My performance as a manager.")
+
+    def test_merge_sentence_continuation(self):
+        text = "be reknit with purpose.\n\nInstead, Stacy listened calmly."
+        self.assertEqual(
+            clean_text(text),
+            "be reknit with purpose. Instead, Stacy listened calmly.",
+        )
+
+    def test_preserve_heading_break(self):
+        text = "Chapter 1\n\nIntroduction paragraph starts here."
+        cleaned = clean_text(text)
+        self.assertIn("\n\n", cleaned)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/newline_cleanup_test.py
+++ b/tests/newline_cleanup_test.py
@@ -21,6 +21,34 @@ class TestNewlineCleanup(unittest.TestCase):
         cleaned = clean_text(text)
         self.assertIn("\n\n", cleaned)
 
+    def test_merge_break_in_quoted_title(self):
+        text = (
+            '" Vulnerability sounds like truth": Brené Brown, '
+            "_Daring Greatly: How the Courage to Be Vulnerable_\n\n"
+            "_Transforms the Way We Live..."
+        )
+        expected = (
+            '" Vulnerability sounds like truth": Brené Brown, '
+            "_Daring Greatly: How the Courage to Be Vulnerable_ _Transforms the Way We Live..."
+        )
+        self.assertEqual(clean_text(text), expected)
+
+    def test_merge_break_in_quoted_phrase(self):
+        text = (
+            'Reese Witherspoon confessing: Reese Witherspoon, " Reese Witherspoon Shares Her Lean In Story," '
+            "Lean\n\nIn."
+        )
+        expected = (
+            'Reese Witherspoon confessing: Reese Witherspoon, " Reese Witherspoon Shares Her Lean In Story," '
+            "Lean In."
+        )
+        self.assertEqual(clean_text(text), expected)
+
+    def test_merge_break_in_quoted_headline(self):
+        text = '" President Draws Planning Moral: Recalls Army Days to Show\n\nValue of Preparedness in Time of Crisis,"'
+        expected = '" President Draws Planning Moral: Recalls Army Days to Show Value of Preparedness in Time of Crisis,"'
+        self.assertEqual(clean_text(text), expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- merge spurious paragraph breaks in text cleaner
- apply same merge in PyMuPDF4LLM integration path
- add regression tests for newline cleanup

## Testing
- `black pdf_chunker/text_cleaning.py pdf_chunker/pymupdf4llm_integration.py tests/newline_cleanup_test.py`
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: 58 errors)*
- `bash scripts/validate_chunks.sh` *(fails: file not found)*
- `pytest tests/`
- `bash tests/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6887ca631e848325a9c5b636289ee547