### PR TITLE
Improve PDF footer detection

### DIFF
--- a/pdf_chunker/page_artifacts.py
+++ b/pdf_chunker/page_artifacts.py
@@ -1,0 +1,61 @@
+import re
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _match_common_patterns(text_lower: str) -> bool:
+    """Return True if text matches common header/footer patterns."""
+    patterns = [
+        r"^\d+$",
+        r"^page\s+\d+",
+        r"^\d+\s*$",
+        r"^chapter\s+\d+$",
+        r"^\d+\s+chapter",
+        r"^\w+\s*\|\s*\d+$",
+        r"^\d+\s*\|\s*[\w\s:]+$",
+        r"^[0-9]{1,3}[.)]?\s+[A-Z]",
+        r"^table\s+of\s+contents",
+        r"^bibliography",
+        r"^index$",
+        r"^appendix\s+[a-z]$",
+    ]
+    return any(re.match(p, text_lower) for p in patterns)
+
+
+def _match_page_number_suffix(text: str, page_num: int) -> bool:
+    """Detect trailing page numbers that align with the page number."""
+    m = re.search(r"(\d{1,3})\s*$", text)
+    if m:
+        trailing = int(m.group(1))
+        if abs(trailing - page_num) <= 1:
+            words = text.split()
+            if "|" in text or len(words) <= 8:
+                return True
+    return False
+
+
+def is_page_artifact_text(text: str, page_num: int) -> bool:
+    """Return True if the text looks like a header or footer artifact."""
+    text_lower = text.lower().strip()
+    if not text_lower:
+        return True
+
+    if _match_common_patterns(text_lower):
+        logger.info(f"is_page_artifact_text() pattern match: {text[:30]}…")
+        return True
+
+    if _match_page_number_suffix(text, page_num):
+        logger.info(
+            f"is_page_artifact_text() page number suffix: {text[:30]}… (page {page_num})"
+        )
+        return True
+
+    if (
+        len(text.split()) <= 3
+        and len(text) <= 30
+        and any(char.isdigit() for char in text)
+    ):
+        return True
+
+    return False

--- a/pdf_chunker/pymupdf4llm_integration.py
+++ b/pdf_chunker/pymupdf4llm_integration.py
@@ -11,6 +11,7 @@ import re
 import time
 from typing import List, Dict, Any, Optional, Tuple
 import logging
+from . import page_artifacts
 
 try:
     import pymupdf4llm
@@ -953,44 +954,8 @@ def _has_page_boundary_issues(blocks: List[Dict[str, Any]]) -> bool:
 
 
 def is_page_artifact_text(text: str, page_num: int) -> bool:
-    """
-    Check if text appears to be a page artifact (header, footer, page number).
-
-    Args:
-        text: Text to check
-        page_num: Page number for context
-
-    Returns:
-        True if text appears to be a page artifact
-    """
-    import re as _re6
-
-    text_lower = text.lower().strip()
-
-    if _re6.match(r"^\d+$", text_lower):
-        return True
-
-    artifact_patterns = [
-        r"^page\s+\d+",
-        r"^\d+\s*$",
-        r"^chapter\s+\d+$",
-        r"^\d+\s+chapter",
-        r"^\d+\s*\|\s*[\w\s:]+$",
-        r"^[0-9]{1,3}[.)]?\s+[A-Z]",
-        r"^table\s+of\s+contents",
-        r"^bibliography",
-        r"^index$",
-        r"^appendix\s+[a-z]$",
-    ]
-
-    for pattern in artifact_patterns:
-        if _re6.match(pattern, text_lower):
-            return True
-
-    if len(text.split()) <= 3 and len(text) <= 30:
-        return any(char.isdigit() for char in text)
-
-    return False
+    """Delegate to shared page artifact detection logic."""
+    return page_artifacts.is_page_artifact_text(text, page_num)
 
 
 def is_text_already_clean(text: str) -> bool:

--- a/tests/page_artifact_detection_test.py
+++ b/tests/page_artifact_detection_test.py
@@ -1,0 +1,21 @@
+import unittest
+
+from pdf_chunker.page_artifacts import is_page_artifact_text
+
+
+class TestPageArtifactDetection(unittest.TestCase):
+    def test_footer_with_pipe(self):
+        line = "Creating the Platform Teams That Replace Cooperation | 55"
+        self.assertTrue(is_page_artifact_text(line, 55))
+
+    def test_footer_without_pipe(self):
+        line = "4.1 Develop Project Charter 43"
+        self.assertTrue(is_page_artifact_text(line, 43))
+
+    def test_non_artifact_line(self):
+        line = "This is page 5 of our analysis"
+        self.assertFalse(is_page_artifact_text(line, 5))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add shared page artifact detection helpers
- filter page artifact lines using the new helper
- delegate PyMuPDF4LLM footer detection to shared logic
- add regression tests for footer artifacts

## Testing
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/`
- `bash scripts/validate_chunks.sh`
- `pytest tests/`
- `bash tests/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6887e7ab159083259987fd899677c0a7