### PR TITLE
Improve heading handling for short punctuated lines

### DIFF
--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -109,6 +109,8 @@ def _is_probable_heading(text: str) -> bool:
     if not stripped or len(stripped) > 80:
         return False
 
+    words = [w for w in re.split(r"\s+", stripped) if w]
+
     # Quoted fragments are likely part of sentences, not headings
     opens = stripped.startswith(('"', "'"))
     closes = stripped.endswith(('"', "'"))
@@ -125,7 +127,12 @@ def _is_probable_heading(text: str) -> bool:
     if ":" in stripped and not re.search(r"[.!?]$", stripped):
         return True
 
-    words = [w for w in re.split(r"\s+", stripped) if w]
+    # Short phrases ending with ! or ? are often enthusiastic or question
+    # style headings that should accompany the following section.
+    if re.search(r"[!?]$", stripped):
+        word_count = len(words)
+        if 1 < word_count <= 6 and len(stripped) <= 60:
+            return True
     if not words:
         return False
 

--- a/tests/heading_boundary_test.py
+++ b/tests/heading_boundary_test.py
@@ -14,6 +14,16 @@ class TestHeadingBoundaryFix(unittest.TestCase):
         self.assertTrue(fixed[1].startswith("Next Section"))
         self.assertIn("The section continues", fixed[1])
 
+    def test_heading_with_punctuation(self):
+        chunks = [
+            "Preceding section text.\n\nKeep It Fun!",
+            "This part explains how to keep it fun.",
+        ]
+        fixed = _fix_heading_splitting_issues(chunks)
+        self.assertEqual(len(fixed), 2)
+        self.assertEqual(fixed[0], "Preceding section text.")
+        self.assertTrue(fixed[1].startswith("Keep It Fun!"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- update `_is_probable_heading` to detect short headings ending with punctuation
- ensure headings ending with `!` or `?` attach to the following chunk
- test heading boundary handling with a punctuated heading

## Testing
- `black pdf_chunker/text_cleaning.py tests/heading_boundary_test.py`
- `flake8 pdf_chunker/text_cleaning.py`
- `mypy pdf_chunker` *(fails: several errors)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/`
- `bash tests/run_all_tests.sh` *(terminated due to missing API key)*

------
https://chatgpt.com/codex/tasks/task_e_688990b2387c832591a2d12ea6a1f6a1