### PR TITLE
Fix footer contamination

### DIFF
--- a/pdf_chunker/extraction_fallbacks.py
+++ b/pdf_chunker/extraction_fallbacks.py
@@ -7,12 +7,15 @@ from langdetect import detect, LangDetectException
 try:
     from pdfminer.high_level import extract_text
     from pdfminer.layout import LAParams
+
     PDFMINER_AVAILABLE = True
 except ImportError:
     PDFMINER_AVAILABLE = False
 
 from .text_cleaning import clean_text
+from .page_artifacts import remove_page_artifact_lines
 from .heading_detection import _detect_heading_fallback
+
 
 def _detect_language(text: str) -> str:
     """Detects language of a text block, defaults to 'un' (unknown) on failure."""
@@ -20,6 +23,7 @@ def _detect_language(text: str) -> str:
         return detect(text)
     except LangDetectException:
         return "un"
+
 
 def _assess_text_quality(text: str) -> dict:
     """
@@ -29,7 +33,7 @@ def _assess_text_quality(text: str) -> dict:
     if not text or not text.strip():
         return {"avg_line_length": 0, "space_density": 0, "quality_score": 0}
 
-    lines = text.split('\n')
+    lines = text.split("\n")
     non_empty_lines = [line for line in lines if line.strip()]
 
     if not non_empty_lines:
@@ -40,7 +44,7 @@ def _assess_text_quality(text: str) -> dict:
 
     # Calculate space density (spaces per character)
     total_chars = sum(len(line) for line in non_empty_lines)
-    total_spaces = sum(line.count(' ') for line in non_empty_lines)
+    total_spaces = sum(line.count(" ") for line in non_empty_lines)
     space_density = total_spaces / total_chars if total_chars > 0 else 0
 
     # Quality score: penalize very long lines and very low space density
@@ -53,8 +57,18 @@ def _assess_text_quality(text: str) -> dict:
     return {
         "avg_line_length": avg_line_length,
         "space_density": space_density,
-        "quality_score": quality_score
+        "quality_score": quality_score,
     }
+
+
+def _clean_fallback_text(text: str) -> str:
+    """Remove page artifacts across pages in fallback extraction."""
+    pages = text.split("\f")
+    cleaned_pages = [
+        remove_page_artifact_lines(page, i + 1) for i, page in enumerate(pages)
+    ]
+    return "\f".join(cleaned_pages)
+
 
 def _extract_with_pdftotext(filepath: str, exclude_pages: str = None) -> list[dict]:
     """
@@ -69,57 +83,71 @@ def _extract_with_pdftotext(filepath: str, exclude_pages: str = None) -> list[di
         excluded_pages = set()
         if exclude_pages:
             from .page_utils import parse_page_ranges
+
             try:
                 excluded_pages = parse_page_ranges(exclude_pages)
             except ValueError as e:
-                print(f"Error parsing page exclusions in pdftotext fallback: {e}", file=sys.stderr)
+                print(
+                    f"Error parsing page exclusions in pdftotext fallback: {e}",
+                    file=sys.stderr,
+                )
 
         # Build pdftotext command with page exclusions if needed
-        cmd = ['pdftotext', '-layout']
+        cmd = ["pdftotext", "-layout"]
 
         # pdftotext doesn't have built-in page exclusion, so we'll extract all pages
         # and filter the results afterward
-        cmd.extend([filepath, '-'])
+        cmd.extend([filepath, "-"])
 
         # Try pdftotext with -layout flag
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=60
-        )
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
 
         if result.returncode != 0:
-            print(f"pdftotext failed with return code {result.returncode}", file=sys.stderr)
+            print(
+                f"pdftotext failed with return code {result.returncode}",
+                file=sys.stderr,
+            )
             return []
 
         raw_text = result.stdout
         quality = _assess_text_quality(raw_text)
-        print(f"pdftotext extraction quality: {quality['quality_score']:.2f}", file=sys.stderr)
+        print(
+            f"pdftotext extraction quality: {quality['quality_score']:.2f}",
+            file=sys.stderr,
+        )
 
-        if quality['quality_score'] < 0.7:
+        if quality["quality_score"] < 0.7:
             return []
+
+        raw_text = _clean_fallback_text(raw_text)
 
         # Parse the text into structured blocks
         structured_blocks = []
-        paragraphs = raw_text.split('\n\n')
+        paragraphs = raw_text.split("\n\n")
 
         for paragraph in paragraphs:
             block_text = clean_text(paragraph)
             if block_text:
                 # Simple heuristic: short paragraphs with title case might be headings
-                is_heading = (len(block_text.split()) < 15 and
-                             block_text.istitle() and
-                             not block_text.endswith('.'))
+                is_heading = (
+                    len(block_text.split()) < 15
+                    and block_text.istitle()
+                    and not block_text.endswith(".")
+                )
 
                 block_type = "heading" if is_heading else "paragraph"
                 lang = _detect_language(block_text)
-                structured_blocks.append({
-                    "type": block_type,
-                    "text": block_text,
-                    "language": lang,
-                    "source": {"filename": os.path.basename(filepath), "method": "pdftotext"}
-                })
+                structured_blocks.append(
+                    {
+                        "type": block_type,
+                        "text": block_text,
+                        "language": lang,
+                        "source": {
+                            "filename": os.path.basename(filepath),
+                            "method": "pdftotext",
+                        },
+                    }
+                )
 
         return structured_blocks
 
@@ -132,6 +160,7 @@ def _extract_with_pdftotext(filepath: str, exclude_pages: str = None) -> list[di
     except Exception as e:
         print(f"pdftotext extraction failed: {e}", file=sys.stderr)
         return []
+
 
 def _extract_with_pdfminer(filepath: str, exclude_pages: str = None) -> list[dict]:
     """
@@ -146,18 +175,21 @@ def _extract_with_pdfminer(filepath: str, exclude_pages: str = None) -> list[dic
         excluded_pages = set()
         if exclude_pages:
             from .page_utils import parse_page_ranges
+
             try:
                 excluded_pages = parse_page_ranges(exclude_pages)
             except ValueError as e:
-                print(f"Error parsing page exclusions in pdfminer fallback: {e}", file=sys.stderr)
+                print(
+                    f"Error parsing page exclusions in pdfminer fallback: {e}",
+                    file=sys.stderr,
+                )
 
         # Try different LAParams configurations
         configs = [
             LAParams(char_margin=1.5, word_margin=0.5, line_margin=0.5),
             LAParams(char_margin=2.0, word_margin=0.3, line_margin=0.3),
-            LAParams(char_margin=1.0, word_margin=0.8, line_margin=0.8)
+            LAParams(char_margin=1.0, word_margin=0.8, line_margin=0.8),
         ]
-
 
         for i, laparams in enumerate(configs):
             print(f"Trying pdfminer config {i+1}/3", file=sys.stderr)
@@ -165,31 +197,42 @@ def _extract_with_pdfminer(filepath: str, exclude_pages: str = None) -> list[dic
 
             # Apply post-processing to fix missing spaces
             repaired_text = re.sub(r"([a-z])([A-Z])", r"\1 \2", raw_text)
+            repaired_text = _clean_fallback_text(repaired_text)
 
             quality = _assess_text_quality(repaired_text)
-            print(f"pdfminer config {i+1} quality: {quality['quality_score']:.2f}", file=sys.stderr)
+            print(
+                f"pdfminer config {i+1} quality: {quality['quality_score']:.2f}",
+                file=sys.stderr,
+            )
 
-            if quality['quality_score'] >= 0.7:
+            if quality["quality_score"] >= 0.7:
                 # Parse the text into structured blocks
                 structured_blocks = []
-                paragraphs = repaired_text.split('\n\n')
+                paragraphs = repaired_text.split("\n\n")
 
                 for paragraph in paragraphs:
                     block_text = clean_text(paragraph)
                     if block_text:
                         # Simple heuristic for headings
-                        is_heading = (len(block_text.split()) < 15 and
-                                     block_text.istitle() and
-                                     not block_text.endswith('.'))
+                        is_heading = (
+                            len(block_text.split()) < 15
+                            and block_text.istitle()
+                            and not block_text.endswith(".")
+                        )
 
                         block_type = "heading" if is_heading else "paragraph"
                         lang = _detect_language(block_text)
-                        structured_blocks.append({
-                            "type": block_type,
-                            "text": block_text,
-                            "language": lang,
-                            "source": {"filename": os.path.basename(filepath), "method": "pdfminer"}
-                        })
+                        structured_blocks.append(
+                            {
+                                "type": block_type,
+                                "text": block_text,
+                                "language": lang,
+                                "source": {
+                                    "filename": os.path.basename(filepath),
+                                    "method": "pdfminer",
+                                },
+                            }
+                        )
 
                 return structured_blocks
 
@@ -199,6 +242,7 @@ def _extract_with_pdfminer(filepath: str, exclude_pages: str = None) -> list[dic
     except Exception as e:
         print(f"pdfminer extraction failed: {e}", file=sys.stderr)
         return []
+
 
 def should_use_pymupdf4llm_cleaning(text: str) -> bool:
     """
@@ -228,19 +272,25 @@ def should_use_pymupdf4llm_cleaning(text: str) -> bool:
     import re
 
     # Look for potential ligature issues
-    has_ligatures = bool(re.search(r'[ﬁﬂﬁﬃﬄﬆﬅ]', text))
+    has_ligatures = bool(re.search(r"[ﬁﬂﬁﬃﬄﬆﬅ]", text))
 
     # Look for potential word joining issues
-    has_joining_issues = bool(re.search(r'[a-z][A-Z]', text))
+    has_joining_issues = bool(re.search(r"[a-z][A-Z]", text))
 
     # Look for excessive whitespace
-    has_whitespace_issues = bool(re.search(r'  +|\n{3,}', text))
+    has_whitespace_issues = bool(re.search(r"  +|\n{3,}", text))
 
     # Look for hyphenation issues
-    has_hyphenation_issues = bool(re.search(r'-\s*\n\s*[a-z]', text))
+    has_hyphenation_issues = bool(re.search(r"-\s*\n\s*[a-z]", text))
 
     # Use PyMuPDF4LLM if any potential issues are detected
-    return has_ligatures or has_joining_issues or has_whitespace_issues or has_hyphenation_issues
+    return (
+        has_ligatures
+        or has_joining_issues
+        or has_whitespace_issues
+        or has_hyphenation_issues
+    )
+
 
 def assess_text_cleaning_quality(original_text: str, cleaned_text: str) -> dict:
     """
@@ -258,7 +308,7 @@ def assess_text_cleaning_quality(original_text: str, cleaned_text: str) -> dict:
             "quality_score": 0.0,
             "has_content": False,
             "cleaning_effective": False,
-            "issues": ["No cleaned text produced"]
+            "issues": ["No cleaned text produced"],
         }
 
     issues = []
@@ -297,10 +347,13 @@ def assess_text_cleaning_quality(original_text: str, cleaned_text: str) -> dict:
         "has_content": len(cleaned_text.strip()) > 0,
         "cleaning_effective": cleaned_text != original_text,
         "length_ratio": cleaned_length / original_length if original_length > 0 else 0,
-        "issues": issues
+        "issues": issues,
     }
 
-def execute_fallback_extraction(filepath: str, exclude_pages: str = None, fallback_reason: str = None) -> list[dict]:
+
+def execute_fallback_extraction(
+    filepath: str, exclude_pages: str = None, fallback_reason: str = None
+) -> list[dict]:
     """
     Execute the traditional three-tier fallback extraction system.
 
@@ -313,10 +366,13 @@ def execute_fallback_extraction(filepath: str, exclude_pages: str = None, fallba
         List of extracted text blocks using traditional methods
     """
     import logging
+
     logger = logging.getLogger(__name__)
 
     if fallback_reason:
-        logger.info(f"Executing fallback extraction for {os.path.basename(filepath)}: {fallback_reason}")
+        logger.info(
+            f"Executing fallback extraction for {os.path.basename(filepath)}: {fallback_reason}"
+        )
     else:
         logger.info(f"Executing fallback extraction for {os.path.basename(filepath)}")
 
@@ -332,7 +388,9 @@ def execute_fallback_extraction(filepath: str, exclude_pages: str = None, fallba
         logger.debug("Attempting pdfminer extraction")
         pdfminer_blocks = _extract_with_pdfminer(filepath, exclude_pages)
         if pdfminer_blocks:
-            logger.info(f"pdfminer extraction successful: {len(pdfminer_blocks)} blocks")
+            logger.info(
+                f"pdfminer extraction successful: {len(pdfminer_blocks)} blocks"
+            )
             return pdfminer_blocks
     else:
         logger.warning("pdfminer.six not available for fallback extraction")

--- a/pdf_chunker/page_artifacts.py
+++ b/pdf_chunker/page_artifacts.py
@@ -1,5 +1,7 @@
-import re
 import logging
+import re
+
+from .text_cleaning import clean_text
 
 logger = logging.getLogger(__name__)
 
@@ -75,3 +77,21 @@ def strip_page_artifact_suffix(text: str, page_num: int) -> str:
         return text[: match.start()].rstrip()
 
     return text
+
+
+def remove_page_artifact_lines(text: str, page_num: int) -> str:
+    """Remove header or footer artifact lines from a block."""
+
+    lines = text.splitlines()
+
+    def _is_artifact(idx: int) -> bool:
+        ln = clean_text(lines[idx])
+        return is_page_artifact_text(ln, page_num)
+
+    cleaned_lines = [
+        strip_page_artifact_suffix(ln, page_num)
+        for idx, ln in enumerate(lines)
+        if not _is_artifact(idx)
+    ]
+
+    return "\n".join(cleaned_lines)

--- a/pdf_chunker/page_artifacts.py
+++ b/pdf_chunker/page_artifacts.py
@@ -62,12 +62,16 @@ def is_page_artifact_text(text: str, page_num: int) -> bool:
 
 
 def strip_page_artifact_suffix(text: str, page_num: int) -> str:
-    """Remove trailing footer text like "Foo | 123" if it matches the page."""
+    """Return the line with any trailing ``"| N"`` footer fragment removed."""
+
     pattern = re.compile(r"\|\s*(\d{1,3})\s*$")
     match = pattern.search(text)
-    if match:
-        trailing = int(match.group(1))
-        if abs(trailing - page_num) <= 1 or len(text) - match.start() <= 40:
-            logger.info(f"strip_page_artifact_suffix() removed: {text[:30]}…")
-            return text[: match.start()].rstrip()
+    if not match:
+        return text
+
+    trailing = int(match.group(1))
+    if abs(trailing - page_num) <= 1 or len(text) - match.start() <= 40:
+        logger.info("strip_page_artifact_suffix removed footer fragment: %s", text[:30])
+        return text[: match.start()].rstrip()
+
     return text

--- a/pdf_chunker/page_artifacts.py
+++ b/pdf_chunker/page_artifacts.py
@@ -59,3 +59,15 @@ def is_page_artifact_text(text: str, page_num: int) -> bool:
         return True
 
     return False
+
+
+def strip_page_artifact_suffix(text: str, page_num: int) -> str:
+    """Remove trailing footer text like "Foo | 123" if it matches the page."""
+    pattern = re.compile(r"\|\s*(\d{1,3})\s*$")
+    match = pattern.search(text)
+    if match:
+        trailing = int(match.group(1))
+        if abs(trailing - page_num) <= 1 or len(text) - match.start() <= 40:
+            logger.info(f"strip_page_artifact_suffix() removed: {text[:30]}…")
+            return text[: match.start()].rstrip()
+    return text

--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -188,18 +188,13 @@ def _remove_page_artifact_lines(text: str, page_num: int) -> str:
         ln = clean_text(lines[idx])
         return is_page_artifact_text(ln, page_num)
 
-    cleaned = [
+    cleaned_lines = [
         strip_page_artifact_suffix(ln, page_num)
-        for i, ln in enumerate(lines)
-        if not (_is_artifact(i) and (i == len(lines) - 1 or _is_artifact(i + 1)))
+        for idx, ln in enumerate(lines)
+        if not _is_artifact(idx)
     ]
 
-    return "\n".join(cleaned)
-
-    """I like this implementation with a comprehension a lot more. Please, stick to declarative and functional"""
-    # lines = text.splitlines()
-    # kept = [ln for ln in lines if not is_page_artifact({"text": clean_text(ln)}, page_num)]
-    # return "\n".join(kept)
+    return "\n".join(cleaned_lines)
 
 
 def extract_blocks_from_page(page, page_num, filename) -> list[dict]:

--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -7,7 +7,7 @@ import fitz  # PyMuPDF
 from .text_cleaning import clean_text, HYPHEN_CHARS_ESC
 from .heading_detection import _detect_heading_fallback
 from .page_utils import parse_page_ranges, validate_page_exclusions
-from .page_artifacts import is_page_artifact_text
+from .page_artifacts import is_page_artifact_text, strip_page_artifact_suffix
 from .extraction_fallbacks import (
     _detect_language,
     _assess_text_quality,
@@ -188,13 +188,13 @@ def _remove_page_artifact_lines(text: str, page_num: int) -> str:
         ln = clean_text(lines[idx])
         return is_page_artifact_text(ln, page_num)
 
-    filtered = [
-        ln
+    cleaned = [
+        strip_page_artifact_suffix(ln, page_num)
         for i, ln in enumerate(lines)
         if not (_is_artifact(i) and (i == len(lines) - 1 or _is_artifact(i + 1)))
     ]
 
-    return "\n".join(filtered)
+    return "\n".join(cleaned)
 
     """I like this implementation with a comprehension a lot more. Please, stick to declarative and functional"""
     # lines = text.splitlines()

--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -7,7 +7,11 @@ import fitz  # PyMuPDF
 from .text_cleaning import clean_text, HYPHEN_CHARS_ESC
 from .heading_detection import _detect_heading_fallback
 from .page_utils import parse_page_ranges, validate_page_exclusions
-from .page_artifacts import is_page_artifact_text, strip_page_artifact_suffix
+from .page_artifacts import (
+    is_page_artifact_text,
+    remove_page_artifact_lines,
+    strip_page_artifact_suffix,
+)
 from .extraction_fallbacks import (
     _detect_language,
     _assess_text_quality,
@@ -179,24 +183,6 @@ def is_artifact_block(block, page_height, frac=0.15, max_words=6):
     return False
 
 
-def _remove_page_artifact_lines(text: str, page_num: int) -> str:
-    """Strip lines that look like page artifacts or footnotes."""
-
-    lines = text.splitlines()
-
-    def _is_artifact(idx: int) -> bool:
-        ln = clean_text(lines[idx])
-        return is_page_artifact_text(ln, page_num)
-
-    cleaned_lines = [
-        strip_page_artifact_suffix(ln, page_num)
-        for idx, ln in enumerate(lines)
-        if not _is_artifact(idx)
-    ]
-
-    return "\n".join(cleaned_lines)
-
-
 def extract_blocks_from_page(page, page_num, filename) -> list[dict]:
     """
     Extract and classify text blocks from a PDF page,
@@ -212,7 +198,7 @@ def extract_blocks_from_page(page, page_num, filename) -> list[dict]:
         logger.debug(f"Raw block text before cleaning: {repr(raw_text[:50])}")
 
         # Remove obvious header/footer lines before full cleaning
-        raw_text = _remove_page_artifact_lines(raw_text, page_num)
+        raw_text = remove_page_artifact_lines(raw_text, page_num)
 
         block_text = clean_text(raw_text)
         logger.debug(f"Block text after cleaning: {repr(block_text[:50])}")

--- a/tests/page_artifact_detection_test.py
+++ b/tests/page_artifact_detection_test.py
@@ -3,8 +3,8 @@ import unittest
 from pdf_chunker.page_artifacts import (
     is_page_artifact_text,
     strip_page_artifact_suffix,
+    remove_page_artifact_lines,
 )
-from pdf_chunker.pdf_parsing import _remove_page_artifact_lines
 
 
 class TestPageArtifactDetection(unittest.TestCase):
@@ -27,7 +27,7 @@ class TestPageArtifactDetection(unittest.TestCase):
 
     def test_remove_page_artifact_lines(self):
         text = "Hello\nA Successful Implementation: How To Do It | 123\nWorld"
-        cleaned = _remove_page_artifact_lines(text, 123)
+        cleaned = remove_page_artifact_lines(text, 123)
         self.assertEqual(cleaned, "Hello\nWorld")
 
 

--- a/tests/page_artifact_detection_test.py
+++ b/tests/page_artifact_detection_test.py
@@ -1,6 +1,9 @@
 import unittest
 
-from pdf_chunker.page_artifacts import is_page_artifact_text
+from pdf_chunker.page_artifacts import (
+    is_page_artifact_text,
+    strip_page_artifact_suffix,
+)
 
 
 class TestPageArtifactDetection(unittest.TestCase):
@@ -15,6 +18,11 @@ class TestPageArtifactDetection(unittest.TestCase):
     def test_non_artifact_line(self):
         line = "This is page 5 of our analysis"
         self.assertFalse(is_page_artifact_text(line, 5))
+
+    def test_strip_page_artifact_suffix(self):
+        line = "An Introduction to Something | 123"
+        stripped = strip_page_artifact_suffix(line, 123)
+        self.assertEqual(stripped, "An Introduction to Something")
 
 
 if __name__ == "__main__":

--- a/tests/page_artifact_detection_test.py
+++ b/tests/page_artifact_detection_test.py
@@ -4,6 +4,7 @@ from pdf_chunker.page_artifacts import (
     is_page_artifact_text,
     strip_page_artifact_suffix,
 )
+from pdf_chunker.pdf_parsing import _remove_page_artifact_lines
 
 
 class TestPageArtifactDetection(unittest.TestCase):
@@ -23,6 +24,11 @@ class TestPageArtifactDetection(unittest.TestCase):
         line = "An Introduction to Something | 123"
         stripped = strip_page_artifact_suffix(line, 123)
         self.assertEqual(stripped, "An Introduction to Something")
+
+    def test_remove_page_artifact_lines(self):
+        text = "Hello\nA Successful Implementation: How To Do It | 123\nWorld"
+        cleaned = _remove_page_artifact_lines(text, 123)
+        self.assertEqual(cleaned, "Hello\nWorld")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove page footer fragments
- clean page artifact lines when parsing
- test page artifact suffix stripping

## Testing
- `black pdf_chunker/page_artifacts.py pdf_chunker/pdf_parsing.py tests/page_artifact_detection_test.py`
- `flake8 pdf_chunker/` *(fails: E302 expected 2 blank lines, etc.)*
- `mypy pdf_chunker/` *(fails: Found 58 errors in 11 files)*
- `bash scripts/validate_chunks.sh` *(fails: file not found)*
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_688a3cb326548325969b4cfada263ef3