### PR TITLE
Fix bullet hyphenation and update tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,8 @@ All CLI scripts follow these conventions:
 * Some code descriptions in `AGENTS.md` may be outdated due to drift
 * **Footnote handling improved**: footnote lines detected and removed to prevent mid-sentence splits; detection tuned to avoid false positives
 * **Header/footer cleanup**: headers and footers stripped when they appear at page breaks or within paragraphs, including trailing "|" fragments
-* **Hyphenation defect**: carried-over hyphens (e.g. `con‐ tainer`) not rejoined <- this has been fixed. Make sure you update AGENTS.md whenever you make changes. This file must reflect the reality.
+* **Hyphenation defect**: carried-over hyphens (e.g. `con‐ tainer`) not rejoined <- fixed.
+* **Bullet hyphen fix**: words split at line breaks within bullet lists now rejoin correctly without duplicating the bullet marker.
 * Possible regression where `text_cleaning.py` updated logic not applied
 * Overlap detection threshold may need tuning
 * Tag classification may not cover nested or multi-domain contexts

--- a/pdf_chunker/AGENTS.md
+++ b/pdf_chunker/AGENTS.md
@@ -28,6 +28,7 @@ Please, keep this file up-to-date with the latest code structure. If you notice 
 - Footnote anchors may appear in the middle of chunks.
 - Page exclusion feature is not working reliably.
 - Metadata fields sometimes missing when fallback triggers.
+- Hyphenated continuation lines starting with bullet markers were not rejoined; this is now fixed in `text_cleaning._join_broken_words`.
 ```
 
 ---

--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -267,8 +267,9 @@ def merge_continuation_blocks(blocks: List[Dict[str, Any]]) -> List[Dict[str, An
         current_block = blocks[i]
         current_text = current_block.get("text", "").strip()
 
+        preview = current_text[:50].replace(chr(10), "\n")
         logger.debug(
-            f"Processing block {i}: {len(current_text)} chars, preview: '{current_text[:50].replace(chr(10), '\\n')}'"
+            f"Processing block {i}: {len(current_text)} chars, preview: {preview}"
         )
 
         # Look ahead for potential merges
@@ -283,12 +284,10 @@ def merge_continuation_blocks(blocks: List[Dict[str, Any]]) -> List[Dict[str, An
 
             if should_merge:
                 logger.debug(f"MERGE: Block {i} + Block {j} (reason: {merge_reason})")
-                logger.debug(
-                    f"  Before merge - Block {i}: '{current_text[:30].replace(chr(10), '\\n')}'"
-                )
-                logger.debug(
-                    f"  Before merge - Block {j}: '{next_text[:30].replace(chr(10), '\\n')}'"
-                )
+                before_i = current_text[:30].replace(chr(10), "\n")
+                logger.debug("  Before merge - Block %s: %s", i, before_i)
+                before_j = next_text[:30].replace(chr(10), "\n")
+                logger.debug("  Before merge - Block %s: %s", j, before_j)
 
                 # Perform the merge
                 if merge_reason == "hyphenated_continuation":
@@ -302,11 +301,8 @@ def merge_continuation_blocks(blocks: List[Dict[str, Any]]) -> List[Dict[str, An
                     # Default merge with space
                     merged_text = current_text + " " + next_text
 
-                logger.debug(
-                    f"  After merge: '{merged_text[:50].replace(chr(10), '\\n')}'"
-                )
-
-                # Update current block with merged content
+                after_merge = merged_text[:50].replace(chr(10), "\n")
+                logger.debug("  After merge: %s", after_merge)
                 current_block["text"] = merged_text
                 current_text = merged_text
                 merge_count += 1

--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -36,9 +36,13 @@ HYPHEN_CHARS_ESC = re.escape("\u2010\u2011\u002d\u00ad\u1400\ufe63‐-")
 SOFT_HYPHEN_RE = re.compile("\u00ad")
 
 
+BULLET_CHARS_ESC = re.escape("*•")
+
+
 def _join_broken_words(text: str) -> str:
-    pattern_break = rf"(\w)[{HYPHEN_CHARS_ESC}]\s*\n\s*(\w)"
-    pattern_space = rf"(\w)[{HYPHEN_CHARS_ESC}]\s+([a-z])"
+    bullet_opt = rf"(?:[{BULLET_CHARS_ESC}]\s*)?"
+    pattern_break = rf"(\w)[{HYPHEN_CHARS_ESC}]\s*\n\s*{bullet_opt}(\w)"
+    pattern_space = rf"(\w)[{HYPHEN_CHARS_ESC}]\s+{bullet_opt}([a-z])"
     text = re.sub(pattern_break, r"\1\2", text)
     return re.sub(pattern_space, r"\1\2", text)
 

--- a/tests/hyphenation_test.py
+++ b/tests/hyphenation_test.py
@@ -38,6 +38,12 @@ class TestHyphenationFix(unittest.TestCase):
         self.assertIn("business-critical", cleaned)
         self.assertIn("off-the-shelf", cleaned)
 
+    def test_bullet_hyphen_continuation(self):
+        text = "* Some text before ambig-\n* uous word"
+        cleaned = clean_text(text)
+        self.assertIn("ambiguous", cleaned)
+        self.assertEqual(cleaned.count("*"), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- handle hyphenated breaks that start a new bullet
- test bullet hyphen rejoining
- document bullet fix in AGENTS files
- avoid illegal backslashes in debug logs

## Testing
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: Need type annotation for "heading_stack" and many others)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `bash tests/run_all_tests.sh` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_688b89a3029c8325a50483b20c421b5d