### PR TITLE
Refactor page range parsing with comprehensions

### DIFF
--- a/pdf_chunker/page_utils.py
+++ b/pdf_chunker/page_utils.py
@@ -1,14 +1,73 @@
 import re
 import sys
+from typing import Iterable, Tuple
+
+
+def _parse_single_page(part: str) -> int:
+    """Convert a single page specifier into an integer."""
+    try:
+        page_num = int(part)
+    except ValueError:
+        raise ValueError(
+            f"Invalid page number: '{part}'. Page numbers must be integers"
+        )
+
+    if page_num < 1:
+        raise ValueError(f"Invalid page number: '{part}'. Page numbers must be >= 1")
+
+    print(f"DEBUG: Individual page '{part}' parsed as: {page_num}", file=sys.stderr)
+    return page_num
+
+
+def _parse_page_range(part: str) -> Tuple[int, int]:
+    """Return start and end integers for a range specifier like '5-10'."""
+    range_parts = part.split("-")
+    if len(range_parts) != 2:
+        raise ValueError(f"Invalid page range format: '{part}'. Use format like '5-10'")
+
+    try:
+        start = int(range_parts[0].strip())
+        end = int(range_parts[1].strip())
+    except ValueError:
+        raise ValueError(
+            f"Invalid page numbers in range: '{part}'. Page numbers must be integers"
+        )
+
+    print(f"DEBUG: Range '{part}' parsed as start={start}, end={end}", file=sys.stderr)
+
+    if start > end:
+        raise ValueError(
+            f"Invalid page range: '{part}'. Start page must be <= end page"
+        )
+
+    if start < 1 or end < 1:
+        raise ValueError(f"Invalid page range: '{part}'. Page numbers must be >= 1")
+
+    return start, end
+
+
+def _expand_part(part: str) -> Iterable[int]:
+    """Yield page numbers represented by a single specification part."""
+    if "-" in part:
+        start, end = _parse_page_range(part)
+        range_pages = range(start, end + 1)
+        print(
+            f"DEBUG: Range '{part}' expands to pages: {list(range_pages)}",
+            file=sys.stderr,
+        )
+        return range_pages
+
+    page = _parse_single_page(part)
+    return (page,)
+
 
 def parse_page_ranges(page_spec: str) -> set:
-    """
-    Parse page range specification into a set of page numbers to exclude.
+    """Parse a comma-delimited page specification into a set of numbers.
 
     Supports formats like:
-    - "1,3,5" (individual pages)
-    - "1-5" (page ranges)
-    - "1,3,5-10,15-20" (mixed individual and ranges)
+      - "1,3,5" (individual pages)
+      - "1-5" (page ranges)
+      - "1,3,5-10,15-20" (mixed individual and ranges)
 
     Args:
         page_spec: String specification of pages to exclude
@@ -22,68 +81,22 @@ def parse_page_ranges(page_spec: str) -> set:
     if not page_spec or not page_spec.strip():
         return set()
 
-    excluded_pages = set()
+    parts = [p.strip() for p in page_spec.split(",") if p.strip()]
 
-    # Split by commas and process each part
-    parts = [part.strip() for part in page_spec.split(',')]
-
-    # Debug logging
     print(f"DEBUG: Parsing page specification: '{page_spec}'", file=sys.stderr)
     print(f"DEBUG: Split into parts: {parts}", file=sys.stderr)
 
-    for part in parts:
-        if not part:
-            continue
-
-        print(f"DEBUG: Processing part: '{part}'", file=sys.stderr)
-
-        # Check if it's a range (contains hyphen)
-        if '-' in part:
-            # Handle range like "5-10"
-            range_parts = part.split('-')
-            if len(range_parts) != 2:
-                raise ValueError(f"Invalid page range format: '{part}'. Use format like '5-10'")
-
-            try:
-                start = int(range_parts[0].strip())
-                end = int(range_parts[1].strip())
-            except ValueError:
-                raise ValueError(f"Invalid page numbers in range: '{part}'. Page numbers must be integers")
-
-            print(f"DEBUG: Range '{part}' parsed as start={start}, end={end}", file=sys.stderr)
-
-            if start > end:
-                raise ValueError(f"Invalid page range: '{part}'. Start page must be <= end page")
-
-            if start < 1 or end < 1:
-                raise ValueError(f"Invalid page range: '{part}'. Page numbers must be >= 1")
-
-            # Add all pages in the range
-            range_pages = list(range(start, end + 1))
-            print(f"DEBUG: Range '{part}' expands to pages: {range_pages}", file=sys.stderr)
-            excluded_pages.update(range_pages)
-
-            excluded_pages.update(range(start, end + 1))
-
-        else:
-            # Handle individual page
-            try:
-                page_num = int(part)
-            except ValueError:
-                raise ValueError(f"Invalid page number: '{part}'. Page numbers must be integers")
-
-            if page_num < 1:
-                raise ValueError(f"Invalid page number: '{part}'. Page numbers must be >= 1")
-
-            print(f"DEBUG: Individual page '{part}' parsed as: {page_num}", file=sys.stderr)
-            excluded_pages.add(page_num)
+    excluded_pages = {page for part in parts for page in _expand_part(part)}
 
     final_pages = sorted(excluded_pages)
     print(f"DEBUG: Final excluded pages set: {final_pages}", file=sys.stderr)
 
     return excluded_pages
 
-def validate_page_exclusions(excluded_pages: set, total_pages: int, filename: str) -> set:
+
+def validate_page_exclusions(
+    excluded_pages: set, total_pages: int, filename: str
+) -> set:
     """
     Validate page exclusions against the actual document and log warnings.
 
@@ -105,16 +118,25 @@ def validate_page_exclusions(excluded_pages: set, total_pages: int, filename: st
     invalid_pages = excluded_pages - valid_exclusions
     if invalid_pages:
         invalid_list = sorted(invalid_pages)
-        print(f"Warning: Excluding pages beyond document bounds in '{filename}': {invalid_list} (document has {total_pages} pages)", file=sys.stderr)
+        print(
+            f"Warning: Excluding pages beyond document bounds in '{filename}': {invalid_list} (document has {total_pages} pages)",
+            file=sys.stderr,
+        )
 
     # Log what pages are being excluded
     if valid_exclusions:
         excluded_list = sorted(valid_exclusions)
-        print(f"Excluding {len(excluded_list)} pages from '{filename}': {excluded_list}", file=sys.stderr)
+        print(
+            f"Excluding {len(excluded_list)} pages from '{filename}': {excluded_list}",
+            file=sys.stderr,
+        )
 
     # Check if all pages would be excluded
     if len(valid_exclusions) >= total_pages:
-        print(f"Warning: Page exclusions would exclude all pages in '{filename}'. Processing will continue with no exclusions.", file=sys.stderr)
+        print(
+            f"Warning: Page exclusions would exclude all pages in '{filename}'. Processing will continue with no exclusions.",
+            file=sys.stderr,
+        )
         return set()
 
     return valid_exclusions

--- a/tests/page_utils_test.py
+++ b/tests/page_utils_test.py
@@ -1,0 +1,18 @@
+import sys
+
+sys.path.insert(0, ".")
+
+import pytest
+from pdf_chunker.page_utils import parse_page_ranges
+
+
+def test_parse_individual_pages():
+    assert parse_page_ranges("1,3,5") == {1, 3, 5}
+
+
+def test_parse_page_ranges_function():
+    assert parse_page_ranges("2-4") == {2, 3, 4}
+
+
+def test_parse_mixed_pages_and_ranges():
+    assert parse_page_ranges("1,3-4,6") == {1, 3, 4, 6}


### PR DESCRIPTION
## Summary
- replace manual page parsing loops with comprehensions
- add helper methods for single pages and ranges
- add tests for individual pages and page ranges

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: missing stubs and other errors)*
- `bash scripts/validate_chunks.sh sample.jsonl`
- `pytest tests/page_utils_test.py -q`
- `pytest tests/ -q`
- `bash tests/run_all_tests.sh` *(fails: some tests could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_688beeafacd48325a1d45ab54dc08941