### PR TITLE
Fix PyMuPDF4LLM integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,12 @@ pdf_chunker/
 │   ├── heading_detection.py       # Heading detection heuristics and fallbacks
 │   ├── extraction_fallbacks.py    # Fallback strategies (pdftotext, pdfminer)
 │   ├── page_utils.py              # Page range parsing and validation
+│   ├── pdf_parsing.py             # Core PDF extraction logic
 │   ├── epub_parsing.py            # EPUB extraction with spine exclusion support
+│   ├── pymupdf4llm_integration.py # Optional PyMuPDF4LLM enhancement
+│   ├── page_artifacts.py          # Header/footer detection helpers
+│   ├── env_utils.py               # Environment flag helpers
+│   ├── text_processing.py         # Shared text manipulation utilities
 │   ├── splitter.py                # Semantic Pass: chunk splitting and boundaries
 │   ├── utils.py                   # Metadata mapping and glue logic
 │   └── ai_enrichment.py           # AI Pass: classification and YAML-based tagging

--- a/pdf_chunker/pymupdf4llm_integration.py
+++ b/pdf_chunker/pymupdf4llm_integration.py
@@ -67,9 +67,7 @@ def extract_with_pymupdf4llm(
 
         # Extract with PyMuPDF4LLM, passing the correct pages
         if zero_based_pages:
-            md_text = pymupdf4llm.to_markdown(
-                pdf_path, pages=zero_based_pages, rich_text=False
-            )
+            md_text = pymupdf4llm.to_markdown(pdf_path, pages=zero_based_pages)
         else:
             # If all pages are excluded, return empty
             logger.warning("All pages are excluded; returning empty block list.")
@@ -588,14 +586,14 @@ def _call_pymupdf4llm_api(pdf_path: str, pages: Optional[List[int]] = None) -> s
     api_methods = [
         (
             "to_markdown",
-            lambda: pymupdf4llm.to_markdown(pdf_path, pages=pages, rich_text=False),
+            lambda: pymupdf4llm.to_markdown(pdf_path, pages=pages),
         ),
         ("extract", lambda: pymupdf4llm.extract(pdf_path, pages=pages)),
         ("convert", lambda: pymupdf4llm.convert(pdf_path, pages=pages)),
         ("parse", lambda: pymupdf4llm.parse(pdf_path, pages=pages)),
         (
             "to_markdown_simple",
-            lambda: pymupdf4llm.to_markdown(pdf_path, rich_text=False),
+            lambda: pymupdf4llm.to_markdown(pdf_path),
         ),
         ("extract_simple", lambda: pymupdf4llm.extract(pdf_path)),
         ("convert_simple", lambda: pymupdf4llm.convert(pdf_path)),


### PR DESCRIPTION
## Summary
- patch PyMuPDF4LLM integration to avoid rich_text arg
- document new modules in project tree

## Testing
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: 58 errors in 11 files)*
- `bash scripts/validate_chunks.sh` *(fails: file not found)*
- `pytest tests/`
- `bash tests/run_all_tests.sh` *(fails: some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688ccb89c7bc8325af4f852e84b49e85