### PR TITLE
Implement underscore emphasis cleaner

### DIFF
--- a/pdf_chunker/pymupdf4llm_integration.py
+++ b/pdf_chunker/pymupdf4llm_integration.py
@@ -221,7 +221,12 @@ def _validate_enhancement_quality(blocks: List[Dict[str, Any]]) -> float:
 
 
 def _clean_pymupdf4llm_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """Clean and validate a block from PyMuPDF4LLM output."""
+    """Clean and validate a block from PyMuPDF4LLM output.
+
+    The cleaning pipeline strips markdown emphasis, removes underscore
+    wrappers, fixes hyphenated line breaks, normalizes quotes, and collapses
+    extraneous whitespace before validating the block.
+    """
     text = block.get("text", "")
 
     if not text or not text.strip():
@@ -230,6 +235,7 @@ def _clean_pymupdf4llm_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     import re as _re2
     from .text_cleaning import (
         pipe,
+        remove_underscore_emphasis,
         fix_hyphenated_linebreaks,
         normalize_ligatures,
         normalize_quotes,
@@ -245,6 +251,7 @@ def _clean_pymupdf4llm_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         lambda s: _re2.sub(r"\[([^\]]+)\]\([^\)]+\)", r"\1", s),
         lambda s: _re2.sub(r"\n{3,}", "\n\n", s),
         lambda s: _re2.sub(r" {2,}", " ", s),
+        remove_underscore_emphasis,
         fix_hyphenated_linebreaks,
         normalize_ligatures,
         normalize_quotes,

--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -92,6 +92,12 @@ def normalize_quotes(text: str) -> str:
     return text
 
 
+def remove_underscore_emphasis(text: str) -> str:
+    """Remove single or double underscore emphasis markers."""
+
+    return re.sub(r"_{1,2}([^_]+)_{1,2}", r"\1", text)
+
+
 def normalize_newlines(text: str) -> str:
     # Convert all CRLF and CR to LF, and unicode separators to LF as well
     text = text.replace("\r\n", "\n").replace("\r", "\n")


### PR DESCRIPTION
## Summary
- add `remove_underscore_emphasis` to `text_cleaning`
- incorporate underscore cleaning in `_clean_pymupdf4llm_block`
- document underscore cleaning behavior

## Testing
- `black pdf_chunker/pymupdf4llm_integration.py pdf_chunker/text_cleaning.py`
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: Need type annotation for "heading_stack" ...)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_688cd98bbea883258f40e2053628cf27