### PR TITLE
Add underscore cleanup hyphenation test

### DIFF
--- a/pdf_chunker/pymupdf4llm_integration.py
+++ b/pdf_chunker/pymupdf4llm_integration.py
@@ -253,6 +253,7 @@ def _clean_pymupdf4llm_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         lambda s: _re2.sub(r" {2,}", " ", s),
         remove_underscore_emphasis,
         fix_hyphenated_linebreaks,
+        remove_underscore_emphasis,
         normalize_ligatures,
         normalize_quotes,
         remove_control_characters,

--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -93,9 +93,10 @@ def normalize_quotes(text: str) -> str:
 
 
 def remove_underscore_emphasis(text: str) -> str:
-    """Remove single or double underscore emphasis markers."""
+    """Remove single/double underscore emphasis markers and stray edges."""
 
-    return re.sub(r"_{1,2}([^_]+)_{1,2}", r"\1", text)
+    cleaned = re.sub(r"_{1,2}([^_]+)_{1,2}", r"\1", text)
+    return cleaned.strip("_")
 
 
 def normalize_newlines(text: str) -> str:

--- a/tests/hyphenation_test.py
+++ b/tests/hyphenation_test.py
@@ -44,6 +44,13 @@ class TestHyphenationFix(unittest.TestCase):
         self.assertIn("ambiguous", cleaned)
         self.assertEqual(cleaned.count("*"), 1)
 
+    def test_underscore_hyphen_cleanup(self):
+        """Ensure underscore emphasis and hyphen breaks are cleaned."""
+        block = {"text": "_respon-\n_sibility_", "source": {"page": 1}}
+        cleaned = p4l._clean_pymupdf4llm_block(block)
+        self.assertIsNotNone(cleaned)
+        self.assertEqual(cleaned["text"], "responsibility")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- improve underscore cleanup in text cleaning
- ensure PyMuPDF4LLM block cleaning removes stray underscores
- test underscore removal from hyphenated words

## Testing
- `pytest tests/`
- `pytest tests/hyphenation_test.py::TestHyphenationFix::test_underscore_hyphen_cleanup -q`
- `bash tests/run_all_tests.sh`
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: Found 58 errors)*
- `bash scripts/validate_chunks.sh output_chunks.json` *(fails: Duplicate detection failed)*

------
https://chatgpt.com/codex/tasks/task_e_688cddcbf90483258d87d352f572ad16