### PR TITLE
Fix mid-sentence double newline regression

### DIFF
--- a/pdf_chunker/pymupdf4llm_integration.py
+++ b/pdf_chunker/pymupdf4llm_integration.py
@@ -495,6 +495,12 @@ def clean_text_with_pymupdf4llm(text: str, pdf_path: Optional[str] = None) -> st
         text = fix_hyphenated_linebreaks(text)
         logger.debug(f"After fix_hyphenated_linebreaks: {repr(text[:100])}")
 
+        from .text_cleaning import collapse_spurious_double_newlines
+
+        logger.debug("Applying collapse_spurious_double_newlines in PyMuPDF4LLM path")
+        text = collapse_spurious_double_newlines(text)
+        logger.debug(f"After collapse_spurious_double_newlines: {repr(text[:100])}")
+
         # Apply other cleaning steps paragraph by paragraph
         paragraphs = []
         for p in text.split("\n\n"):

--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -193,6 +193,15 @@ def merge_spurious_paragraph_breaks(text: str) -> str:
     return "\n\n".join(merged)
 
 
+SPURIOUS_DOUBLE_NL = re.compile(r"(?<=[a-z,;:])\n{2}(?=[a-z])")
+
+
+def collapse_spurious_double_newlines(text: str) -> str:
+    """Collapse double newlines that interrupt clauses."""
+
+    return SPURIOUS_DOUBLE_NL.sub(" ", text)
+
+
 def validate_json_safety(text: str) -> Tuple[bool, List[str]]:
     issues: List[str] = []
     try:
@@ -310,6 +319,10 @@ def clean_text(text: str) -> str:
     logger.debug("Calling merge_spurious_paragraph_breaks")
     text = merge_spurious_paragraph_breaks(text)
     logger.debug(f"After merge_spurious_paragraph_breaks: {repr(text[:100])}")
+
+    logger.debug("Calling collapse_spurious_double_newlines")
+    text = collapse_spurious_double_newlines(text)
+    logger.debug(f"After collapse_spurious_double_newlines: {repr(text[:100])}")
 
     # Split on paragraph breaks, clean each
     paragraphs = [p for p in PARAGRAPH_BREAK.split(text) if p.strip()]

--- a/tests/newline_cleanup_test.py
+++ b/tests/newline_cleanup_test.py
@@ -49,6 +49,13 @@ class TestNewlineCleanup(unittest.TestCase):
         expected = '" President Draws Planning Moral: Recalls Army Days to Show Value of Preparedness in Time of Crisis,"'
         self.assertEqual(clean_text(text), expected)
 
+    def test_collapse_mid_sentence_double_newline(self):
+        text = "Moving to modern\n\nenvironments requires care."
+        self.assertEqual(
+            clean_text(text),
+            "Moving to modern environments requires care.",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- improve newline cleanup by removing spurious double newlines
- apply the cleanup in the PyMuPDF4LLM path as well
- test mid-sentence double newline removal

## Testing
- `black pdf_chunker/pymupdf4llm_integration.py pdf_chunker/text_cleaning.py tests/newline_cleanup_test.py`
- `flake8 pdf_chunker/text_cleaning.py pdf_chunker/pymupdf4llm_integration.py`
- `mypy pdf_chunker/` *(fails: Found 58 errors)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `PYTHONPATH=. pytest tests/newline_cleanup_test.py::TestNewlineCleanup::test_collapse_mid_sentence_double_newline -q`
- `PYTHONPATH=. pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce79ddb34832582089ffdf6da6b8b