### PR TITLE
fix: preserve multiline bullet lists

### DIFF
--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -30,6 +30,13 @@ from .pymupdf4llm_integration import (
 from typing import List, Dict, Any, Tuple
 
 
+BULLET_CHARS = "•*"
+
+
+def _is_bullet_continuation(curr: str, nxt: str) -> bool:
+    return curr.rstrip().endswith(tuple(BULLET_CHARS)) and nxt[:1].islower()
+
+
 def _should_merge_blocks(
     curr_block: Dict[str, Any], next_block: Dict[str, Any]
 ) -> Tuple[bool, str]:
@@ -65,7 +72,10 @@ def _should_merge_blocks(
             logger.debug("Merge decision: QUOTE_CONTINUATION")
             return True, "quote_continuation"
 
-    # Case 1: Hyphenated word continuation
+    if _is_bullet_continuation(curr_text, next_text):
+        logger.debug("Merge decision: BULLET_CONTINUATION")
+        return True, "bullet_continuation"
+
     hyphen_pattern = rf"[{HYPHEN_CHARS_ESC}]$"
     double_hyphen_pattern = rf"[{HYPHEN_CHARS_ESC}]{{2,}}$"
     if (
@@ -77,7 +87,6 @@ def _should_merge_blocks(
         logger.debug("Merge decision: HYPHENATED_CONTINUATION")
         return True, "hyphenated_continuation"
 
-    # Case 2: Same page, sentence continuation (no punctuation at end)
     elif (
         curr_page == next_page
         and not curr_text.endswith((".", "!", "?", ":", ";"))
@@ -295,10 +304,10 @@ def merge_continuation_blocks(blocks: List[Dict[str, Any]]) -> List[Dict[str, An
                         re.sub(rf"[{HYPHEN_CHARS_ESC}]$", "", current_text) + next_text
                     )
                 elif merge_reason == "sentence_continuation":
-                    # Merge with space for sentence continuation
                     merged_text = current_text + " " + next_text
+                elif merge_reason == "bullet_continuation":
+                    merged_text = current_text.rstrip(" *•") + " " + next_text
                 else:
-                    # Default merge with space
                     merged_text = current_text + " " + next_text
 
                 after_merge = merged_text[:50].replace(chr(10), "\n")
@@ -500,7 +509,7 @@ def extract_text_blocks_from_pdf(
                     logger.info(
                         f"PyMuPDF4LLM enhancement successful: {enhancement_stats}"
                     )
-                    merged_blocks = enhanced_blocks
+                    merged_blocks = merge_continuation_blocks(enhanced_blocks)
                 else:
                     logger.warning(
                         "PyMuPDF4LLM enhancement quality degraded, falling back to traditional text cleaning"

--- a/pdf_chunker/pymupdf4llm_integration.py
+++ b/pdf_chunker/pymupdf4llm_integration.py
@@ -24,6 +24,13 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _is_meaningful_text(text: str) -> bool:
+    stripped = text.strip()
+    return bool(stripped) and (
+        len(stripped) >= 10 or any(ch.isalpha() for ch in stripped)
+    )
+
+
 class PyMuPDF4LLMExtractionError(Exception):
     """Exception raised when PyMuPDF4LLM extraction fails"""
 
@@ -258,8 +265,7 @@ def _clean_pymupdf4llm_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         consolidate_whitespace,
     )
 
-    # Skip blocks that are too short or look like artifacts
-    if len(text.strip()) < 10:
+    if not _is_meaningful_text(text):
         return None
 
     # Skip blocks that look like page numbers or headers/footers

--- a/tests/bullet_list_test.py
+++ b/tests/bullet_list_test.py
@@ -1,0 +1,21 @@
+import sys
+
+sys.path.insert(0, ".")
+
+import re
+
+from pdf_chunker.pdf_parsing import extract_text_blocks_from_pdf
+
+
+def test_bullet_list_preservation():
+    blocks = extract_text_blocks_from_pdf("sample_book3.pdf")
+    text = "\n".join(b["text"] for b in blocks)
+    items = [
+        line[line.index("•") :].strip() for line in text.splitlines() if "•" in line
+    ]
+    assert len(items) == 3
+    assert (
+        "• How platform engineering manages this complexity and so frees us from the swamp"
+        in items
+    )
+    assert all(not item.rstrip().endswith(".") for item in items)


### PR DESCRIPTION
## Summary
- handle bullet continuations during block merging and after PyMuPDF4LLM enhancement
- retain short non-artifact blocks in PyMuPDF4LLM cleaning
- cover bullet-list extraction with a regression test

## Testing
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: Need type annotation for "heading_stack" and more)*
- `pytest tests/`
- `bash tests/run_all_tests.sh` *(fails: Known-good test EPUB not found at test_data/sample_test.epub)*
- `bash scripts/validate_chunks.sh output_chunks.jsonl` *(fails: Chunk starts mid-sentence on line 1)*

------
https://chatgpt.com/codex/tasks/task_e_688e53f0e83883258ff844ce72184a2a