### PR TITLE
fix: preserve multiline bullet lists and indented blocks

### DIFF
--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -30,6 +30,39 @@ from .pymupdf4llm_integration import (
 from typing import List, Dict, Any, Tuple
 
 
+BULLET_CHARS = "•*"
+BULLET_CHARS_ESC = re.escape(BULLET_CHARS)
+
+
+def _is_bullet_continuation(curr: str, nxt: str) -> bool:
+    return curr.rstrip().endswith(tuple(BULLET_CHARS)) and nxt[:1].islower()
+
+
+def _starts_with_bullet(text: str) -> bool:
+    return text.lstrip().startswith(tuple(BULLET_CHARS))
+
+
+def _is_bullet_list_pair(curr: str, nxt: str) -> bool:
+    colon_bullet = re.search(rf":\s*[{BULLET_CHARS_ESC}]", curr)
+    return _starts_with_bullet(nxt) and (
+        _starts_with_bullet(curr)
+        or any(_starts_with_bullet(line) for line in curr.splitlines())
+        or colon_bullet is not None
+    )
+
+
+def _is_indented_continuation(curr: dict, nxt: dict) -> bool:
+    curr_bbox = curr.get("bbox")
+    next_bbox = nxt.get("bbox")
+    if not curr_bbox or not next_bbox:
+        return False
+    curr_x0, _, _, curr_y1 = curr_bbox
+    next_x0, next_y0, _, _ = next_bbox
+    vertical_gap = next_y0 - curr_y1
+    indent_diff = next_x0 - curr_x0
+    return indent_diff > 10 and vertical_gap < 8
+
+
 def _should_merge_blocks(
     curr_block: Dict[str, Any], next_block: Dict[str, Any]
 ) -> Tuple[bool, str]:
@@ -65,7 +98,20 @@ def _should_merge_blocks(
             logger.debug("Merge decision: QUOTE_CONTINUATION")
             return True, "quote_continuation"
 
-    # Case 1: Hyphenated word continuation
+    if _is_bullet_continuation(curr_text, next_text):
+        logger.debug("Merge decision: BULLET_CONTINUATION")
+        return True, "bullet_continuation"
+
+    if _is_bullet_list_pair(curr_text, next_text):
+        logger.debug("Merge decision: BULLET_LIST")
+        return True, "bullet_list"
+
+    if _is_indented_continuation(
+        curr_block, next_block
+    ) and not _detect_heading_fallback(next_text):
+        logger.debug("Merge decision: INDENTED_CONTINUATION")
+        return True, "indented_continuation"
+
     hyphen_pattern = rf"[{HYPHEN_CHARS_ESC}]$"
     double_hyphen_pattern = rf"[{HYPHEN_CHARS_ESC}]{{2,}}$"
     if (
@@ -77,7 +123,6 @@ def _should_merge_blocks(
         logger.debug("Merge decision: HYPHENATED_CONTINUATION")
         return True, "hyphenated_continuation"
 
-    # Case 2: Same page, sentence continuation (no punctuation at end)
     elif (
         curr_page == next_page
         and not curr_text.endswith((".", "!", "?", ":", ";"))
@@ -224,13 +269,13 @@ def extract_blocks_from_page(page, page_num, filename) -> list[dict]:
                 is_heading = _detect_heading_fallback(block_text)
 
         block_type = "heading" if is_heading else "paragraph"
-        # Always include a source dictionary with filename, page, and location (None for PDFs)
         structured.append(
             {
                 "type": block_type,
                 "text": block_text,
                 "language": _detect_language(block_text),
                 "source": {"filename": filename, "page": page_num, "location": None},
+                "bbox": b[:4],
             }
         )
 
@@ -295,10 +340,17 @@ def merge_continuation_blocks(blocks: List[Dict[str, Any]]) -> List[Dict[str, An
                         re.sub(rf"[{HYPHEN_CHARS_ESC}]$", "", current_text) + next_text
                     )
                 elif merge_reason == "sentence_continuation":
-                    # Merge with space for sentence continuation
                     merged_text = current_text + " " + next_text
+                elif merge_reason == "bullet_continuation":
+                    merged_text = current_text.rstrip(" *•") + " " + next_text
+                elif merge_reason == "bullet_list":
+                    current_text = re.sub(
+                        rf":\s*(?=[{BULLET_CHARS_ESC}])", ":\n", current_text
+                    )
+                    merged_text = current_text + "\n" + next_text
+                elif merge_reason == "indented_continuation":
+                    merged_text = current_text + "\n" + next_text
                 else:
-                    # Default merge with space
                     merged_text = current_text + " " + next_text
 
                 after_merge = merged_text[:50].replace(chr(10), "\n")
@@ -434,7 +486,7 @@ def extract_text_blocks_from_pdf(
         )
     all_blocks = filtered_blocks
 
-    # Apply improved continuation merging with page boundary handling
+    pre_merge_blocks = all_blocks
     logger.debug("Starting block merging process")
     merged_blocks = merge_continuation_blocks(all_blocks)
 
@@ -496,11 +548,15 @@ def extract_text_blocks_from_pdf(
 
             # If enhancement was successful and high quality, use enhanced blocks
             if enhanced_blocks and enhancement_stats.get("enhanced", 0) > 0:
+                if pre_merge_blocks and len(pre_merge_blocks) == len(enhanced_blocks):
+                    for eb, ob in zip(enhanced_blocks, pre_merge_blocks):
+                        if "bbox" not in eb and ob.get("bbox"):
+                            eb["bbox"] = ob["bbox"]
                 if enhancement_stats.get("degraded", 0) == 0:
                     logger.info(
                         f"PyMuPDF4LLM enhancement successful: {enhancement_stats}"
                     )
-                    merged_blocks = enhanced_blocks
+                    merged_blocks = merge_continuation_blocks(enhanced_blocks)
                 else:
                     logger.warning(
                         "PyMuPDF4LLM enhancement quality degraded, falling back to traditional text cleaning"

--- a/pdf_chunker/pymupdf4llm_integration.py
+++ b/pdf_chunker/pymupdf4llm_integration.py
@@ -24,6 +24,13 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _is_meaningful_text(text: str) -> bool:
+    stripped = text.strip()
+    return bool(stripped) and (
+        len(stripped) >= 10 or any(ch.isalpha() for ch in stripped)
+    )
+
+
 class PyMuPDF4LLMExtractionError(Exception):
     """Exception raised when PyMuPDF4LLM extraction fails"""
 
@@ -258,8 +265,7 @@ def _clean_pymupdf4llm_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         consolidate_whitespace,
     )
 
-    # Skip blocks that are too short or look like artifacts
-    if len(text.strip()) < 10:
+    if not _is_meaningful_text(text):
         return None
 
     # Skip blocks that look like page numbers or headers/footers

--- a/tests/bullet_list_test.py
+++ b/tests/bullet_list_test.py
@@ -1,0 +1,23 @@
+import sys
+
+sys.path.insert(0, ".")
+
+import re
+
+from pdf_chunker.pdf_parsing import extract_text_blocks_from_pdf
+
+
+def test_bullet_list_preservation():
+    blocks = extract_text_blocks_from_pdf("sample_book3.pdf")
+    blob = "\n\n".join(b["text"] for b in blocks)
+    items = [
+        line[line.index("•") :].strip() for line in blob.splitlines() if "•" in line
+    ]
+    assert len(items) == 3
+    assert (
+        "• How platform engineering manages this complexity and so frees us from the swamp"
+        in items
+    )
+    assert all(not item.rstrip().endswith(".") for item in items)
+    assert "\n\n•" not in blob
+    assert "•\n\n•" not in blob

--- a/tests/indented_block_test.py
+++ b/tests/indented_block_test.py
@@ -1,0 +1,13 @@
+import sys
+
+sys.path.insert(0, ".")
+
+from pdf_chunker.pdf_parsing import extract_text_blocks_from_pdf
+
+
+def test_indented_block_no_double_newline():
+    blocks = extract_text_blocks_from_pdf("sample_book3.pdf")
+    blob = "\n\n".join(b["text"] for b in blocks)
+    snippet = "reduced coordination.\nA corollary here"
+    assert snippet in blob
+    assert "reduced coordination.\n\nA corollary here" not in blob


### PR DESCRIPTION
## Summary
- merge vertically tight, indented PDF blocks to avoid spurious paragraph breaks
- attach bounding boxes to extracted blocks so indentation heuristics can trigger after PyMuPDF4LLM enhancement
- add regression test ensuring indented blocks no longer gain double blank lines

## Testing
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: Need type annotation for "heading_stack" and more)*
- `pytest tests/`
- `bash tests/run_all_tests.sh` *(fails: Known-good test EPUB not found at test_data/sample_test.epub)*
- `bash scripts/validate_chunks.sh output_chunks.jsonl` *(fails: Chunk starts mid-sentence on line 1)*

------
https://chatgpt.com/codex/tasks/task_e_688e53f0e83883258ff844ce72184a2a