### PR TITLE
refactor: modularize document processing pipeline

### DIFF
--- a/pdf_chunker/core.py
+++ b/pdf_chunker/core.py
@@ -1,263 +1,261 @@
-from .parsing import extract_structured_text
-from .splitter import semantic_chunker
-from .ai_enrichment import init_llm
-from .utils import format_chunks_with_metadata as utils_format_chunks_with_metadata
+"""Core orchestration logic for PDF chunking."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Set
+
 from haystack.dataclasses import Document
 
-import sys
+from .ai_enrichment import init_llm
+from .splitter import semantic_chunker
+from .utils import format_chunks_with_metadata as utils_format_chunks_with_metadata
+
 import logging
+
 logger = logging.getLogger(__name__)
 
-def process_document(
-    filepath: str,
+
+def parse_exclusions(exclude_pages: str | None) -> Set[int]:
+    """Parse a comma-separated page range string into a set of integers."""
+    if not exclude_pages:
+        return set()
+    try:
+        from .page_utils import parse_page_ranges
+
+        excluded = parse_page_ranges(exclude_pages)
+        logger.debug("Parsed excluded pages: %s", sorted(excluded))
+        return excluded
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Error parsing exclude_pages: %s", exc)
+        return set()
+
+
+def extract_blocks(filepath: str, exclude_pages: str | None) -> List[dict]:
+    """Extract structured text blocks from the PDF."""
+    from .pdf_parsing import extract_text_blocks_from_pdf
+
+    logger.debug("Starting PDF extraction for %s", filepath)
+    blocks = extract_text_blocks_from_pdf(filepath, exclude_pages=exclude_pages)
+    logger.debug("PDF extraction complete: %d blocks", len(blocks))
+    for i, block in enumerate(blocks[:3]):
+        text_preview = block.get("text", "")[:100].replace("\n", "\\n")
+        logger.debug("Block %d text preview: %r", i, text_preview)
+    return blocks
+
+
+def filter_blocks(blocks: Iterable[dict], excluded_pages: Set[int]) -> List[dict]:
+    """Remove blocks that originate from excluded pages."""
+    filtered = [
+        block
+        for block in blocks
+        if block.get("source", {}).get("page") not in excluded_pages
+    ]
+    logger.debug("After filtering excluded pages, have %d blocks", len(filtered))
+
+    remaining_pages = {
+        block.get("source", {}).get("page")
+        for block in filtered
+        if block.get("source", {}).get("page") is not None
+    }
+    logger.debug("Remaining pages after filtering: %s", sorted(remaining_pages))
+    leaked_pages = remaining_pages & excluded_pages
+    if leaked_pages:
+        logger.error(
+            "Excluded pages still present after filtering: %s", sorted(leaked_pages)
+        )
+    else:
+        logger.debug("No excluded pages found in structured blocks")
+    return filtered
+
+
+def chunk_text(
+    blocks: Iterable[dict],
     chunk_size: int,
     overlap: int,
-    generate_metadata: bool = True,
-    ai_enrichment: bool = True,  # New flag to control AI calls
-    exclude_pages: str = None,  # New parameter for page exclusion
-    min_chunk_size: int = None,  # New parameter for conversational text handling
-    enable_dialogue_detection: bool = True  # New parameter to control dialogue pattern detection
-) -> list[dict]:
-    """
-    Core pipeline for processing a document with optional AI enrichment and conversational text handling.
-
-    Args:
-        filepath: Path to the document to process
-        chunk_size: Target chunk size in words
-        overlap: Overlap size in words
-        generate_metadata: Whether to generate metadata
-        ai_enrichment: Whether to perform AI enrichment
-        exclude_pages: Page ranges to exclude (e.g., "1,3,5-10,15-20")
-        min_chunk_size: Minimum chunk size in words (defaults to max(8, chunk_size // 10))
-        enable_dialogue_detection: Whether to enable dialogue pattern detection for conversational text
-
-    """
-    
-    logger.debug(f"process_document called with filepath={filepath}, chunk_size={chunk_size}, overlap={overlap}")
-    logger.debug(f"generate_metadata={generate_metadata}, ai_enrichment={ai_enrichment}, exclude_pages={exclude_pages}")
-    
-    # Set default minimum chunk size if not provided
-    
-    if min_chunk_size is None:
-        min_chunk_size = max(8, chunk_size // 10)  # Minimum 8 words or 10% of target size
-
-    # Determine if AI enrichment should be performed
-    perform_ai_enrichment = generate_metadata and ai_enrichment
-
-    if perform_ai_enrichment:
-        try:
-            init_llm()
-        except ValueError as e:
-            print(f"AI Enrichment disabled: {e}", file=sys.stderr)
-            perform_ai_enrichment = False
-
-
-    # Parse excluded pages as a set of integers
-    excluded_pages_set = set()
-    if exclude_pages:
-        try:
-            from .page_utils import parse_page_ranges
-            excluded_pages_set = parse_page_ranges(exclude_pages)
-            print(f"DEBUG: Parsed excluded pages: {sorted(excluded_pages_set)}", file=sys.stderr)
-        except Exception as e:
-            print(f"Error parsing exclude_pages: {e}", file=sys.stderr)
-            excluded_pages_set = set()
-
-    # 1. Structural Pass: Extract text into structured blocks, passing excluded pages
-    from .pdf_parsing import extract_text_blocks_from_pdf
-    logger.debug(f"Starting PDF extraction for {filepath}")
-    structured_blocks = extract_text_blocks_from_pdf(filepath, exclude_pages=exclude_pages)
-    logger.debug(f"PDF extraction complete: got {len(structured_blocks)} blocks")
-
-    # Debug: Show sample text from first few blocks to trace text cleaning
-    for i, block in enumerate(structured_blocks[:3]):
-        text_preview = block.get('text', '')[:100].replace('\n', '\\n')
-        logger.debug(f"Block {i} text preview: {repr(text_preview)}")
-
-    print(f"DEBUG: After PDF extraction, got {len(structured_blocks)} blocks", file=sys.stderr)
-
-    # Filter out any blocks from excluded pages (defensive, in case enhancement/fallbacks leak them)
-    filtered_blocks = []
-    for block in structured_blocks:
-        page = block.get("source", {}).get("page")
-        if page is not None and page in excluded_pages_set:
-            print(f"DEBUG: Filtering out block from excluded page {page}", file=sys.stderr)
-            continue
-        filtered_blocks.append(block)
-
-    print(f"DEBUG: After filtering excluded pages, have {len(filtered_blocks)} blocks", file=sys.stderr)
-    structured_blocks = filtered_blocks
-
-    # Verify no excluded pages remain
-    remaining_pages = set()
-    for block in structured_blocks:
-        page = block.get("source", {}).get("page")
-        if page is not None:
-            remaining_pages.add(page)
-
-    print(f"DEBUG: Remaining pages after filtering: {sorted(remaining_pages)}", file=sys.stderr)
-
-    # Check for any intersection with excluded pages
-    leaked_pages = remaining_pages.intersection(excluded_pages_set)
-    if leaked_pages:
-        print(f"DEBUG: ERROR - Excluded pages still present after filtering: {sorted(leaked_pages)}", file=sys.stderr)
-    else:
-        print(f"DEBUG: SUCCESS - No excluded pages found in structured blocks", file=sys.stderr)
-    
-
-    # Debug: Show what we got from the structural pass
-    print(f"Extracted {len(structured_blocks)} structured blocks", file=sys.stderr)
-    total_block_chars = 0
-    for i, block in enumerate(structured_blocks[:5]):  # First 5 blocks
-        block_text = block.get("text", "")
-        block_chars = len(block_text)
-        total_block_chars += block_chars
-        preview = block_text[:50] if block_text else "Empty text"
-        page_info = f"page {block.get('source', {}).get('page', 'unknown')}" if "source" in block else "unknown page"
-        print(f"Block {i} ({page_info}): {block_chars} chars - {preview}...", file=sys.stderr)
-
-    # Calculate total characters in all blocks
-    total_all_chars = sum(len(block.get("text", "")) for block in structured_blocks)
-    print(f"Total characters in all blocks: {total_all_chars}", file=sys.stderr)
-
-    # 2. Semantic Pass: Chunk the blocks into coherent documents with conversational text handling
-    full_text = "\n\n".join(block.get("text", "") for block in structured_blocks if block.get("text", ""))
-    haystack_chunks = semantic_chunker(
+    *,
+    min_chunk_size: int,
+    enable_dialogue_detection: bool,
+) -> List[str]:
+    """Chunk blocks of text into semantic units."""
+    full_text = "\n\n".join(
+        block.get("text", "") for block in blocks if block.get("text", "")
+    )
+    chunks = semantic_chunker(
         full_text,
         chunk_size,
         overlap,
         min_chunk_size=min_chunk_size,
-        enable_dialogue_detection=enable_dialogue_detection
+        enable_dialogue_detection=enable_dialogue_detection,
     )
-
-    # Debug: Validate chunk sizes after conversational text handling
-    print(f"Semantic chunking with conversational text handling produced {len(haystack_chunks)} chunks", file=sys.stderr)
-    
-    if haystack_chunks:
-        chunk_sizes = [len(chunk) for chunk in haystack_chunks]
-        word_counts = [len(chunk.split()) for chunk in haystack_chunks]
+    logger.debug(
+        "Semantic chunking with conversational text handling produced %d chunks",
+        len(chunks),
+    )
+    if chunks:
+        chunk_sizes = [len(c) for c in chunks]
+        word_counts = [len(c.split()) for c in chunks]
         avg_size = sum(chunk_sizes) / len(chunk_sizes)
         avg_words = sum(word_counts) / len(word_counts)
-        max_size = max(chunk_sizes)
-        min_size = min(chunk_sizes)
-        max_words = max(word_counts)
-        min_words = min(word_counts)
-
-        print(f"Chunk size statistics after conversational text handling:", file=sys.stderr)
-        print(f"  Average: {avg_size:.0f} characters ({avg_words:.1f} words)", file=sys.stderr)
-        print(f"  Maximum: {max_size} characters ({max_words} words)", file=sys.stderr)
-        print(f"  Minimum: {min_size} characters ({min_words} words)", file=sys.stderr)
-
-        # Check for problematic chunks after conversational text handling
+        logger.debug(
+            "Chunk size statistics: average %.0f characters (%.1f words)",
+            avg_size,
+            avg_words,
+        )
+        logger.debug(
+            "Maximum: %d characters (%d words)",
+            max(chunk_sizes),
+            max(word_counts),
+        )
+        logger.debug(
+            "Minimum: %d characters (%d words)",
+            min(chunk_sizes),
+            min(word_counts),
+        )
         short_chunks = [i for i, words in enumerate(word_counts) if words <= 7]
         very_short_chunks = [i for i, words in enumerate(word_counts) if words <= 3]
-
         if short_chunks:
-            print(f"  Short chunks (≤7 words): {len(short_chunks)} chunks", file=sys.stderr)
-            if len(short_chunks) <= 3:  # Show examples if not too many
+            logger.debug("Short chunks (≤7 words): %d", len(short_chunks))
+            if len(short_chunks) <= 3:
                 for i in short_chunks:
-                    chunk_preview = haystack_chunks[i][:50].replace('\n', ' ')
-                    print(f"    Chunk {i}: {word_counts[i]} words - '{chunk_preview}...'", file=sys.stderr)
-
+                    preview = chunks[i][:50].replace("\n", " ")
+                    logger.debug("Chunk %d: %d words - %r", i, word_counts[i], preview)
         if very_short_chunks:
-            print(f"  Very short chunks (≤3 words): {len(very_short_chunks)} chunks", file=sys.stderr)
+            logger.warning("Very short chunks (≤3 words): %d", len(very_short_chunks))
             for i in very_short_chunks:
-                chunk_preview = haystack_chunks[i][:50].replace('\n', ' ')
-                print(f"    Chunk {i}: {word_counts[i]} words - '{chunk_preview}...'", file=sys.stderr)
-
+                preview = chunks[i][:50].replace("\n", " ")
+                logger.debug("Chunk %d: %d words - %r", i, word_counts[i], preview)
         oversized_chunks = [i for i, size in enumerate(chunk_sizes) if size > 10000]
         if oversized_chunks:
-            print(f"  WARNING: {len(oversized_chunks)} chunks exceed 10k characters", file=sys.stderr)
-            for i in oversized_chunks[:3]:  # Show first 3 oversized
-                print(f"    Chunk {i}: {chunk_sizes[i]} characters", file=sys.stderr)
-
+            logger.warning("%d chunks exceed 10k characters", len(oversized_chunks))
+            for i in oversized_chunks[:3]:
+                logger.debug("Chunk %d: %d characters", i, chunk_sizes[i])
         extreme_chunks = [i for i, size in enumerate(chunk_sizes) if size > 25000]
         if extreme_chunks:
-            print(f"  CRITICAL: {len(extreme_chunks)} chunks exceed 25k characters!", file=sys.stderr)
+            logger.error("%d chunks exceed 25k characters!", len(extreme_chunks))
             for i in extreme_chunks:
-                print(f"    Chunk {i}: {chunk_sizes[i]} characters", file=sys.stderr)
+                logger.debug("Chunk %d: %d characters", i, chunk_sizes[i])
+    return chunks
 
-    # 3. Convert text chunks to Haystack Document objects for utils compatibility
-    haystack_documents = []
-    for i, chunk_text in enumerate(haystack_chunks):
-        doc = Document(content=chunk_text, id=f"chunk_{i}")
-        haystack_documents.append(doc)
 
-    # 4. Final Formatting and AI Enrichment using utils function with proper schema
-    final_chunks = utils_format_chunks_with_metadata(
-        haystack_documents,
-        structured_blocks,
-        generate_metadata=generate_metadata,
-        perform_ai_enrichment=perform_ai_enrichment,
-        max_workers=10,
-        min_chunk_size=min_chunk_size,
-        enable_dialogue_detection=enable_dialogue_detection
-    )
-
-    # Debug: Validate that excluded pages don't appear in final chunks
+def validate_chunks(
+    final_chunks: List[dict],
+    exclude_pages: str | None,
+    generate_metadata: bool,
+) -> List[dict]:
+    """Validate final chunks for exclusions and size limits."""
     if exclude_pages and generate_metadata:
-        print(f"DEBUG: Validating page exclusions in final chunks...", file=sys.stderr)
-
-        # Parse the excluded pages for validation
+        logger.debug("Validating page exclusions in final chunks")
         try:
             from .page_utils import parse_page_ranges
+
             excluded_pages = parse_page_ranges(exclude_pages)
-            print(f"DEBUG: Should exclude pages: {sorted(excluded_pages)}", file=sys.stderr)
-
-            # Check what pages appear in final chunks
-            final_chunk_pages = set()
-            for i, chunk in enumerate(final_chunks):
-                if chunk and 'metadata' in chunk:
-                    page = chunk['metadata'].get('page')
-                    if page:
-                        final_chunk_pages.add(page)
-                        if page in excluded_pages:
-                            print(f"DEBUG: ERROR - Excluded page {page} found in final chunk {i}!", file=sys.stderr)
-
-            print(f"DEBUG: Final chunks contain pages: {sorted(final_chunk_pages)}", file=sys.stderr)
-
-            # Check for intersection
-            leaked_pages = final_chunk_pages.intersection(excluded_pages)
+            logger.debug("Should exclude pages: %s", sorted(excluded_pages))
+            final_chunk_pages = {
+                chunk["metadata"].get("page")
+                for chunk in final_chunks
+                if chunk.get("metadata") and chunk["metadata"].get("page")
+            }
+            logger.debug("Final chunks contain pages: %s", sorted(final_chunk_pages))
+            leaked_pages = final_chunk_pages & excluded_pages
             if leaked_pages:
-                print(f"DEBUG: CRITICAL ERROR - Excluded pages leaked into final output: {sorted(leaked_pages)}", file=sys.stderr)
+                logger.error(
+                    "Excluded pages leaked into final output: %s",
+                    sorted(leaked_pages),
+                )
             else:
-                print(f"DEBUG: SUCCESS - No excluded pages found in final output", file=sys.stderr)
+                logger.debug("No excluded pages found in final output")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Error validating page exclusions: %s", exc)
 
-        except Exception as e:
-            print(f"DEBUG: Error validating page exclusions: {e}", file=sys.stderr)
-
-    # Final validation of chunk sizes
-    print(f"Final pipeline output: {len(final_chunks)} chunks", file=sys.stderr)
-
+    logger.debug("Final pipeline output: %d chunks", len(final_chunks))
     if final_chunks:
         final_sizes = [len(chunk.get("text", "")) for chunk in final_chunks]
         final_avg = sum(final_sizes) / len(final_sizes)
         final_max = max(final_sizes)
         final_min = min(final_sizes)
-
-        print(f"Final chunk size statistics:", file=sys.stderr)
-        print(f"  Average: {final_avg:.0f} characters", file=sys.stderr)
-        print(f"  Maximum: {final_max} characters", file=sys.stderr)
-        print(f"  Minimum: {final_min} characters", file=sys.stderr)
-
-        # Critical validation for JSONL output
+        logger.debug("Final chunk size statistics: average %.0f characters", final_avg)
+        logger.debug("Maximum: %d characters", final_max)
+        logger.debug("Minimum: %d characters", final_min)
         oversized_final = [i for i, size in enumerate(final_sizes) if size > 10000]
         if oversized_final:
-            print(f"  ERROR: {len(oversized_final)} final chunks exceed 10k characters!", file=sys.stderr)
+            logger.error("%d final chunks exceed 10k characters!", len(oversized_final))
             for i in oversized_final[:3]:
-                print(f"    Final chunk {i}: {final_sizes[i]} characters", file=sys.stderr)
-
+                logger.debug("Final chunk %d: %d characters", i, final_sizes[i])
         extreme_final = [i for i, size in enumerate(final_sizes) if size > 25000]
         if extreme_final:
-            print(f"  CRITICAL ERROR: {len(extreme_final)} final chunks exceed 25k characters!", file=sys.stderr)
-            print(f"  These will create extremely long JSONL lines!", file=sys.stderr)
+            logger.critical(
+                "%d final chunks exceed 25k characters!", len(extreme_final)
+            )
             for i in extreme_final:
-                print(f"    Final chunk {i}: {final_sizes[i]} characters", file=sys.stderr)
-
-    for i, chunk in enumerate(final_chunks[:3]):  # First 3 chunks
-        text_len = len(chunk.get("text", ""))
-        print(f"Final chunk {i}: {text_len} characters", file=sys.stderr)
-        if text_len > 10000:
-            print(f"ERROR: Final chunk {i} is still oversized ({text_len} characters)!", file=sys.stderr)
-
+                logger.debug("Final chunk %d: %d characters", i, final_sizes[i])
+        for i, chunk in enumerate(final_chunks[:3]):
+            text_len = len(chunk.get("text", ""))
+            logger.debug("Final chunk %d: %d characters", i, text_len)
+            if text_len > 10000:
+                logger.error(
+                    "Final chunk %d is still oversized (%d characters)!", i, text_len
+                )
     return final_chunks
+
+
+def process_document(
+    filepath: str,
+    chunk_size: int,
+    overlap: int,
+    *,
+    generate_metadata: bool = True,
+    ai_enrichment: bool = True,
+    exclude_pages: str | None = None,
+    min_chunk_size: int | None = None,
+    enable_dialogue_detection: bool = True,
+) -> List[dict]:
+    """Process a document through extraction, chunking and enrichment."""
+
+    logger.debug(
+        "process_document called with filepath=%s, chunk_size=%d, overlap=%d",
+        filepath,
+        chunk_size,
+        overlap,
+    )
+    logger.debug(
+        "generate_metadata=%s, ai_enrichment=%s, exclude_pages=%s",
+        generate_metadata,
+        ai_enrichment,
+        exclude_pages,
+    )
+
+    if min_chunk_size is None:
+        min_chunk_size = max(8, chunk_size // 10)
+
+    perform_ai_enrichment = generate_metadata and ai_enrichment
+    if perform_ai_enrichment:
+        try:
+            init_llm()
+        except ValueError as exc:
+            logger.warning("AI Enrichment disabled: %s", exc)
+            perform_ai_enrichment = False
+
+    excluded_pages = parse_exclusions(exclude_pages)
+    blocks = extract_blocks(filepath, exclude_pages)
+    filtered_blocks = filter_blocks(blocks, excluded_pages)
+    haystack_chunks = chunk_text(
+        filtered_blocks,
+        chunk_size,
+        overlap,
+        min_chunk_size=min_chunk_size,
+        enable_dialogue_detection=enable_dialogue_detection,
+    )
+    haystack_documents = [
+        Document(content=text, id=f"chunk_{i}")
+        for i, text in enumerate(haystack_chunks)
+    ]
+    final_chunks = utils_format_chunks_with_metadata(
+        haystack_documents,
+        filtered_blocks,
+        generate_metadata=generate_metadata,
+        perform_ai_enrichment=perform_ai_enrichment,
+        max_workers=10,
+        min_chunk_size=min_chunk_size,
+        enable_dialogue_detection=enable_dialogue_detection,
+    )
+    return validate_chunks(final_chunks, exclude_pages, generate_metadata)


### PR DESCRIPTION
## Summary
- split PDF processing into modular helpers: parse exclusions, extract/filter blocks, chunk text, and validate results
- replace loops with list/set comprehensions and funnel diagnostics through `logging`
- streamline `process_document` into a functional orchestrator

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: Need type annotation for "heading_stack" etc.)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/`
- `bash tests/run_all_tests.sh` *(fails: Some tests failed. Please check the output above.)*


------
https://chatgpt.com/codex/tasks/task_e_688fc96919cc8325aebb4b6b7672b893