### PR TITLE
Refactor utils for functional style

### DIFF
--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,27 @@
+from haystack.dataclasses import Document
+
+from pdf_chunker.utils import _build_char_map, _find_source_block
+
+
+def test_build_char_map_returns_charspan_tuple():
+    blocks = [
+        {"text": "abc", "source": {"page": 1, "filename": "file.pdf"}},
+        {"text": "defg", "source": {"page": 2, "filename": "file.pdf"}},
+    ]
+    result = _build_char_map(blocks)
+    positions = result["char_positions"]
+    assert isinstance(positions, tuple)
+    first, second = positions
+    assert (first.start, first.end, first.original_index) == (0, 3, 0)
+    assert (second.start, second.end, second.original_index) == (5, 9, 1)
+
+
+def test_find_source_block_substring_match():
+    blocks = [
+        {"text": "Hello world", "source": {"page": 1, "filename": "file.pdf"}},
+        {"text": "Another block", "source": {"page": 2, "filename": "file.pdf"}},
+    ]
+    char_map = _build_char_map(blocks)
+    chunk = Document(content="Hello world continues")
+    block = _find_source_block(chunk, char_map, blocks)
+    assert block["source"]["page"] == 1


### PR DESCRIPTION
## Summary
- represent character spans with immutable dataclasses
- refactor source block search into composable predicates
- add unit tests for char map and source block lookup

## Testing
- `black pdf_chunker/utils.py tests/utils_test.py`
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: Missing stubs and numerous type errors)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/` *(fails: ModuleNotFoundError in ai_enrichment_test.py)*
- `bash tests/run_all_tests.sh` *(fails: ModuleNotFoundError and missing test EPUB)*

------
https://chatgpt.com/codex/tasks/task_e_6890149b3830832593b3b052f349d2d4