### PR TITLE
Fix cross-page sentence continuation handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ pdf_chunker/
     ├── semantic_chunking_test.py  # Chunk size and semantic rules tests
     ├── page_exclusion_test.py     # PDF page exclusion tests
     ├── epub_spine_test.py         # EPUB spine exclusion tests
+    ├── cross_page_sentence_test.py # Cross-page continuation merging tests
     └── run_all_tests.sh           # Orchestrates all test modules
 
 `````

--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -27,7 +27,7 @@ from .pymupdf4llm_integration import (
     PyMuPDF4LLMExtractionError,
 )
 
-from typing import List, Dict, Any, Tuple
+from typing import List, Dict, Any, Tuple, Optional
 
 
 BULLET_CHARS = "*•◦▪‣·●◉○‧"
@@ -95,13 +95,19 @@ def _is_indented_continuation(curr: dict, nxt: dict) -> bool:
 
 
 def _is_cross_page_continuation(
-    curr_text: str, next_text: str, curr_page: int, next_page: int
+    curr_text: str,
+    next_text: str,
+    curr_page: Optional[int],
+    next_page: Optional[int],
 ) -> bool:
     """Return True when text likely continues across a page break."""
 
     if not all((curr_text, next_text)):
         return False
-    if curr_page == next_page:
+    if (
+        all(page is not None for page in (curr_page, next_page))
+        and curr_page == next_page
+    ):
         return False
     if curr_text.endswith((".", "!", "?")):
         return False
@@ -181,7 +187,8 @@ def _should_merge_blocks(
         return True, "hyphenated_continuation"
 
     elif (
-        curr_page == next_page
+        all(page is not None for page in (curr_page, next_page))
+        and curr_page == next_page
         and not curr_text.endswith((".", "!", "?", ":", ";"))
         and next_text
         and next_text[0].islower()

--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -34,6 +34,32 @@ BULLET_CHARS = "*•◦▪‣·●◉○‧"
 BULLET_CHARS_ESC = re.escape(BULLET_CHARS)
 MIN_WORDS_FOR_CONTINUATION = 6
 
+COMMON_SENTENCE_STARTERS = {
+    "The",
+    "This",
+    "That",
+    "A",
+    "An",
+    "In",
+    "On",
+    "At",
+    "As",
+    "By",
+    "For",
+    "From",
+    "If",
+    "When",
+    "While",
+    "After",
+    "Before",
+    "It",
+    "He",
+    "She",
+    "They",
+    "We",
+    "I",
+}
+
 
 def _word_count(text: str) -> int:
     return sum(1 for _ in text.split())
@@ -41,6 +67,14 @@ def _word_count(text: str) -> int:
 
 def _has_sufficient_context(text: str) -> bool:
     return _word_count(text) >= MIN_WORDS_FOR_CONTINUATION
+
+
+def _fragment_tail(text: str) -> str:
+    return re.split(r"[.!?]\s*", text)[-1]
+
+
+def _is_common_sentence_starter(word: str) -> bool:
+    return word in COMMON_SENTENCE_STARTERS
 
 
 def _is_bullet_continuation(curr: str, nxt: str) -> bool:
@@ -114,6 +148,14 @@ def _is_cross_page_continuation(
     if _looks_like_quote_boundary(curr_text, next_text):
         return False
     if _detect_heading_fallback(next_text) and not _has_sufficient_context(curr_text):
+        return False
+    tail_words = _word_count(_fragment_tail(curr_text))
+    if tail_words > 12:
+        return False
+    first_word = next_text.split()[0]
+    if first_word[0].islower():
+        return True
+    if _is_common_sentence_starter(first_word):
         return False
     return True
 

--- a/tests/cross_page_sentence_test.py
+++ b/tests/cross_page_sentence_test.py
@@ -20,3 +20,19 @@ def test_cross_page_sentence_with_proper_name():
     merged = merge_continuation_blocks(blocks)
     assert len(merged) == 1
     assert "Gini coefficient" in merged[0]["text"]
+
+
+def test_cross_page_sentence_with_min_word_context():
+    blocks = [
+        {
+            "text": "Economic inequality is measured by the",
+            "source": {"page": 1},
+        },
+        {
+            "text": "Gini coefficient spans pages.",
+            "source": {"page": 2},
+        },
+    ]
+    merged = merge_continuation_blocks(blocks)
+    assert len(merged) == 1
+    assert "Gini coefficient" in merged[0]["text"]

--- a/tests/cross_page_sentence_test.py
+++ b/tests/cross_page_sentence_test.py
@@ -46,3 +46,23 @@ def test_cross_page_sentence_without_page_numbers():
     merged = merge_continuation_blocks(blocks)
     assert len(merged) == 1
     assert "Gini coefficient" in merged[0]["text"]
+
+
+def test_cross_page_does_not_merge_entire_document():
+    blocks = [
+        {
+            "text": "Economic inequality is usually measured by the",
+            "source": {"page": 1},
+        },
+        {
+            "text": "Gini coefficient completes the sentence.",
+            "source": {"page": 2},
+        },
+        {
+            "text": "New paragraph begins here with its own sentence.",
+            "source": {"page": 3},
+        },
+    ]
+    merged = merge_continuation_blocks(blocks)
+    assert len(merged) == 2
+    assert merged[1]["text"].startswith("New paragraph")

--- a/tests/cross_page_sentence_test.py
+++ b/tests/cross_page_sentence_test.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+
+sys.path.insert(0, ".")
+
+from pdf_chunker.pdf_parsing import merge_continuation_blocks
+
+
+def test_cross_page_sentence_with_proper_name():
+    blocks = [
+        {
+            "text": "Economic inequality is usually measured by the",
+            "source": {"page": 1},
+        },
+        {"text": "Gini", "source": {"page": 2}},
+        {"text": "coefficient extends across pages.", "source": {"page": 2}},
+    ]
+    merged = merge_continuation_blocks(blocks)
+    assert len(merged) == 1
+    assert "Gini coefficient" in merged[0]["text"]

--- a/tests/cross_page_sentence_test.py
+++ b/tests/cross_page_sentence_test.py
@@ -36,3 +36,13 @@ def test_cross_page_sentence_with_min_word_context():
     merged = merge_continuation_blocks(blocks)
     assert len(merged) == 1
     assert "Gini coefficient" in merged[0]["text"]
+
+
+def test_cross_page_sentence_without_page_numbers():
+    blocks = [
+        {"text": "Economic inequality is usually measured by the"},
+        {"text": "Gini coefficient carries on."},
+    ]
+    merged = merge_continuation_blocks(blocks)
+    assert len(merged) == 1
+    assert "Gini coefficient" in merged[0]["text"]


### PR DESCRIPTION
## Summary
- factor out cross-page continuation detection to avoid splitting mid-sentence at page breaks
- add regression test for proper-name page transitions

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: Need type annotation for "heading_stack" and other typing issues)*
- `pytest tests/` *(fails: ModuleNotFoundError: No module named 'pdf_chunker')*
- `pytest tests/cross_page_sentence_test.py -q`
- `bash tests/run_all_tests.sh` *(fails: Some tests failed. Please check the output above.)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890c28c39b08325852fe550edf0df0f