### PR TITLE
Allow dependency injection in process_document

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ pdf_chunker/
     ├── epub_spine_test.py         # EPUB spine exclusion tests
     ├── cross_page_sentence_test.py # Cross-page continuation merging tests
     ├── numbered_list_chunk_test.py # Numbered list chunking preservation
+    ├── process_document_override_test.py # Callable override injection test
     └── run_all_tests.sh           # Orchestrates all test modules
 
 `````

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -11,6 +11,7 @@ Test modules validating behavior of parsing, chunking, and enrichment layers.
 - `semantic_chunking_test.py`: Boundary conditions and oversize protection
 - `page_exclusion_test.py`: Page range and filter correctness
 - `epub_spine_test.py`: Spine index parsing and exclusion logic
+- `process_document_override_test.py`: Callable override injection
 - `run_all_tests.sh`: Orchestrates full suite
 - Duplicate detection thresholds (via `detect_duplicates.py`).
 

--- a/tests/process_document_override_test.py
+++ b/tests/process_document_override_test.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+from pdf_chunker.core import process_document
+
+
+def _extractor(fp: str, ex: str | None) -> list[dict]:
+    return [
+        {"text": "alpha", "source": {"page": 1}},
+        {"text": "beta", "source": {"page": 2}},
+    ]
+
+
+def _chunker(
+    blocks: list[dict],
+    chunk_size: int,
+    overlap: int,
+    *,
+    min_chunk_size: int,
+    enable_dialogue_detection: bool,
+) -> list[str]:
+    return [" ".join(block["text"] for block in blocks)]
+
+
+def _enricher(docs, blocks, **_):
+    return [{"text": docs[0].content, "metadata": {"custom": True}}]
+
+
+def test_callable_overrides():
+    result = process_document(
+        "dummy.pdf",
+        chunk_size=100,
+        overlap=0,
+        generate_metadata=False,
+        ai_enrichment=False,
+        extractor=_extractor,
+        chunker=_chunker,
+        enricher=_enricher,
+    )
+    assert result == [{"text": "alpha beta", "metadata": {"custom": True}}]


### PR DESCRIPTION
## Summary
- refactor `process_document` to accept injectable extractor, chunker, and enricher callables
- add `setup_enrichment` helper for functional AI enrichment initialization
- cover callable override usage in new `process_document_override_test.py`

## Testing
- `black --check pdf_chunker/ scripts/ tests/` *(fails: would reformat 21 files)*
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: Argument 1 to "maketrans" has incompatible type)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/` *(fails: ModuleNotFoundError: No module named 'pdf_chunker')*
- `bash tests/run_all_tests.sh` *(fails: ModuleNotFoundError: No module named 'pdf_chunker')*


------
https://chatgpt.com/codex/tasks/task_e_68912b6e89a48325aadd1bbf5669631b