### PR TITLE
refactor: use logger and functional truncation

### DIFF
--- a/pdf_chunker/utils.py
+++ b/pdf_chunker/utils.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import textstat
 from typing import Callable
@@ -5,6 +6,9 @@ from itertools import accumulate
 from haystack.dataclasses import Document
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -43,58 +47,55 @@ def _generate_chunk_id(filename: str, page: int, chunk_index: int) -> str:
 
 
 def _truncate_chunk(text: str, max_chunk_size: int = 8000) -> str:
-    """Truncate `text` to ``max_chunk_size`` using soft boundaries."""
+    """Truncate ``text`` to ``max_chunk_size`` using soft boundaries."""
     if len(text) <= max_chunk_size:
         return text
 
-    import sys
-
-    print(
-        f"WARNING: chunk oversized ({len(text)} chars), applying strict truncation",
-        file=sys.stderr,
-    )
+    logger.warning("chunk oversized (%s chars), applying strict truncation", len(text))
 
     truncate_point = max_chunk_size - 100
     sentence_endings = [". ", ".\n", "! ", "!\n", "? ", "?\n"]
-    best_break = max(
+
+    strategies = (
         (
-            text.rfind(ending, 0, truncate_point)
-            for ending in sentence_endings
-            if text.rfind(ending, 0, truncate_point) > truncate_point * 0.7
+            "sentence boundary",
+            lambda: (
+                (
+                    best := max(
+                        (
+                            text.rfind(e, 0, truncate_point)
+                            for e in sentence_endings
+                            if text.rfind(e, 0, truncate_point) > truncate_point * 0.7
+                        ),
+                        default=-1,
+                    )
+                )
+                > 0
+                and text[: best + 1].strip()
+            ),
         ),
-        default=-1,
+        (
+            "paragraph break",
+            lambda: (
+                (idx := text.rfind("\n\n", 0, truncate_point)) > truncate_point * 0.7
+                and text[:idx].strip()
+            ),
+        ),
+        (
+            "word boundary",
+            lambda: (
+                (idx := text.rfind(" ", 0, truncate_point)) > truncate_point * 0.8
+                and text[:idx].strip()
+            ),
+        ),
     )
-    if best_break > 0:
-        truncated = text[: best_break + 1].strip()
-        print(
-            f"DEBUG: truncated at sentence boundary to {len(truncated)} chars",
-            file=sys.stderr,
-        )
-        return truncated
 
-    last_paragraph = text.rfind("\n\n", 0, truncate_point)
-    if last_paragraph > truncate_point * 0.7:
-        truncated = text[:last_paragraph].strip()
-        print(
-            f"DEBUG: truncated at paragraph break to {len(truncated)} chars",
-            file=sys.stderr,
-        )
-        return truncated
-
-    last_space = text.rfind(" ", 0, truncate_point)
-    if last_space > truncate_point * 0.8:
-        truncated = text[:last_space].strip()
-        print(
-            f"DEBUG: truncated at word boundary to {len(truncated)} chars",
-            file=sys.stderr,
-        )
-        return truncated
-
-    truncated = text[:truncate_point].strip()
-    print(
-        f"DEBUG: truncated at character limit to {len(truncated)} chars",
-        file=sys.stderr,
+    truncated, label = next(
+        ((result, lbl) for lbl, fn in strategies if (result := fn())),
+        (text[:truncate_point].strip(), "character limit"),
     )
+
+    logger.debug("truncated at %s to %s chars", label, len(truncated))
     return truncated
 
 
@@ -113,9 +114,7 @@ def _enrich_chunk(
             "tags": result.get("tags", []),
         }
     except Exception as exc:  # pragma: no cover - defensive
-        import sys
-
-        print(f"DEBUG: AI enrichment failed: {exc}", file=sys.stderr)
+        logger.debug("AI enrichment failed: %s", exc)
         return {"classification": "error", "tags": []}
 
 
@@ -165,15 +164,15 @@ def format_chunks_with_metadata(
     Formats final chunks, enriching them in parallel with detailed metadata.
     Follows the canonical schema from README.ai with all required fields.
     """
-    import sys
-
-    print(
-        f"DEBUG: format_chunks_with_metadata called with {len(haystack_chunks)} chunks and {len(original_blocks)} original blocks",
-        file=sys.stderr,
+    logger.debug(
+        "format_chunks_with_metadata called with %s chunks and %s original blocks",
+        len(haystack_chunks),
+        len(original_blocks),
     )
-    print(
-        f"DEBUG: min_chunk_size={min_chunk_size}, enable_dialogue_detection={enable_dialogue_detection}",
-        file=sys.stderr,
+    logger.debug(
+        "min_chunk_size=%s, enable_dialogue_detection=%s",
+        min_chunk_size,
+        enable_dialogue_detection,
     )
 
     # Debug: Check what pages are in the original blocks
@@ -182,38 +181,30 @@ def format_chunks_with_metadata(
         for block in original_blocks
         if block.get("source", {}).get("page")
     }
-    print(
-        f"DEBUG: Original blocks contain pages: {sorted(original_pages)}",
-        file=sys.stderr,
-    )
+    logger.debug("Original blocks contain pages: %s", sorted(original_pages))
 
     char_map = _build_char_map(original_blocks)
 
     def process_chunk(chunk, chunk_index):
-        import sys
-
-        print(f"DEBUG: process_chunk() ENTRY - chunk {chunk_index}", file=sys.stderr)
+        logger.debug("process_chunk() ENTRY - chunk %s", chunk_index)
 
         final_text = _truncate_chunk(chunk.content.strip())
         if not final_text:
-            print(
-                f"DEBUG: process_chunk() EXIT - chunk {chunk_index} - EMPTY CONTENT",
-                file=sys.stderr,
-            )
+            logger.debug("process_chunk() EXIT - chunk %s - EMPTY CONTENT", chunk_index)
             return None
 
         if not generate_metadata:
-            print(
-                f"DEBUG: process_chunk() EXIT - chunk {chunk_index} - NO METADATA MODE",
-                file=sys.stderr,
+            logger.debug(
+                "process_chunk() EXIT - chunk %s - NO METADATA MODE",
+                chunk_index,
             )
             return {"text": final_text}
 
         source_block = _find_source_block(chunk, char_map, original_blocks)
         if not source_block:
-            print(
-                f"DEBUG: process_chunk() EXIT - chunk {chunk_index} - NO SOURCE BLOCK FOUND",
-                file=sys.stderr,
+            logger.debug(
+                "process_chunk() EXIT - chunk %s - NO SOURCE BLOCK FOUND",
+                chunk_index,
             )
             return None
 
@@ -226,9 +217,10 @@ def format_chunks_with_metadata(
         )
 
         result = {"text": final_text, "metadata": metadata}
-        print(
-            f"DEBUG: process_chunk() EXIT - chunk {chunk_index} SUCCESS - result has {len(result.get('text', ''))} chars",
-            file=sys.stderr,
+        logger.debug(
+            "process_chunk() EXIT - chunk %s SUCCESS - result has %s chars",
+            chunk_index,
+            len(result.get("text", "")),
         )
         return result
 
@@ -249,23 +241,18 @@ def format_chunks_with_metadata(
 
 def _build_char_map(blocks: list[dict]) -> dict:
     """Build a character position mapping for locating chunks in original blocks."""
-    import sys
-
     if not blocks:
-        print("DEBUG: _build_char_map called with empty blocks list", file=sys.stderr)
+        logger.debug("_build_char_map called with empty blocks list")
         return {"char_positions": ()}
 
-    print(f"DEBUG: Building character map for {len(blocks)} blocks", file=sys.stderr)
+    logger.debug("Building character map for %s blocks", len(blocks))
 
     block_pages = {
         block.get("source", {}).get("page")
         for block in blocks
         if block.get("source", {}).get("page")
     }
-    print(
-        f"DEBUG: Character map includes pages: {sorted(block_pages)}",
-        file=sys.stderr,
-    )
+    logger.debug("Character map includes pages: %s", sorted(block_pages))
 
     lengths = (len(block["text"]) + 2 for block in blocks[:-1])
     starts = list(accumulate(lengths, initial=0))
@@ -273,9 +260,13 @@ def _build_char_map(blocks: list[dict]) -> dict:
     for i, (block, start) in enumerate(zip(blocks, starts)):
         text_len = len(block["text"])
         page = block.get("source", {}).get("page", "unknown")
-        print(
-            f"DEBUG: Block {i} (page {page}): {text_len} chars at position {start}-{start + text_len}",
-            file=sys.stderr,
+        logger.debug(
+            "Block %s (page %s): %s chars at position %s-%s",
+            i,
+            page,
+            text_len,
+            start,
+            start + text_len,
         )
 
     char_positions = tuple(
@@ -283,10 +274,7 @@ def _build_char_map(blocks: list[dict]) -> dict:
         for i, (block, start) in enumerate(zip(blocks, starts))
     )
 
-    print(
-        f"DEBUG: Character map built with {len(char_positions)} entries",
-        file=sys.stderr,
-    )
+    logger.debug("Character map built with %s entries", len(char_positions))
     return {"char_positions": char_positions}
 
 
@@ -294,7 +282,6 @@ def _find_source_block(
     chunk: Document, _char_map: dict, original_blocks: list[dict]
 ) -> dict | None:
     """Find the original source block for a chunk using multiple heuristics."""
-    import sys
 
     def ensure_source(block):
         if "source" not in block or not isinstance(block["source"], dict):
@@ -306,17 +293,18 @@ def _find_source_block(
         return block
 
     if not (chunk and chunk.content and original_blocks):
-        print(
-            f"DEBUG: _find_source_block early return - chunk: {bool(chunk)}, content: {bool(chunk.content if chunk else False)}, blocks: {len(original_blocks) if original_blocks else 0}",
-            file=sys.stderr,
+        logger.debug(
+            "_find_source_block early return - chunk: %s, content: %s, blocks: %s",
+            bool(chunk),
+            bool(chunk.content if chunk else False),
+            len(original_blocks) if original_blocks else 0,
         )
         return None
 
     chunk_text = chunk.content.strip()
     chunk_start = chunk_text[:50].replace("\n", " ").strip()
-    print(
-        f"DEBUG: Looking for source block for chunk starting with: '{chunk_start}...'",
-        file=sys.stderr,
+    logger.debug(
+        "Looking for source block for chunk starting with: '%s...'", chunk_start
     )
 
     def substring_match(block: dict) -> bool:
@@ -371,9 +359,10 @@ def _find_source_block(
             None,
         )
         if match:
-            print(
-                f"DEBUG: Found matching source block on page {match['source'].get('page', None)} ({label})",
-                file=sys.stderr,
+            logger.debug(
+                "Found matching source block on page %s (%s)",
+                match["source"].get("page", None),
+                label,
             )
             return match
 
@@ -385,17 +374,18 @@ def _find_source_block(
         if matches:
             idx = block_starts.index(matches[0])
             block = ensure_source(original_blocks[idx])
-            print(
-                f"DEBUG: Fallback: difflib matched block {idx} on page {block['source'].get('page', None)}",
-                file=sys.stderr,
+            logger.debug(
+                "Fallback: difflib matched block %s on page %s",
+                idx,
+                block["source"].get("page", None),
             )
             return block
     except Exception as e:
-        print(f"DEBUG: difflib fallback failed: {e}", file=sys.stderr)
+        logger.debug("difflib fallback failed: %s", e)
 
     block = ensure_source(original_blocks[0])
-    print(
-        f"WARNING: No matching source block found for chunk starting with: '{chunk_start}...'. Mapping to first block.",
-        file=sys.stderr,
+    logger.warning(
+        "No matching source block found for chunk starting with: '%s...'. Mapping to first block.",
+        chunk_start,
     )
     return block


### PR DESCRIPTION
## Summary
- replace print statements with logger.debug/logger.warning in utils
- refactor _truncate_chunk to use functional break search via `next`

## Testing
- `black pdf_chunker/utils.py`
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` (fails: missing stubs and type issues)
- `bash scripts/validate_chunks.sh` (fails: file not found)
- `pytest tests/` (fails: ModuleNotFoundError for pdf_chunker)
- `bash tests/run_all_tests.sh` (fails: some tests reported issues)


------
https://chatgpt.com/codex/tasks/task_e_68912e8309b48325be021ee457f3c395