### PR TITLE
refactor: extract source matchers

### DIFF
--- a/pdf_chunker/AGENTS.md
+++ b/pdf_chunker/AGENTS.md
@@ -22,6 +22,7 @@ Please, keep this file up-to-date with the latest code structure. If you notice 
 - `pdf_parsing.py`: High-level PDF parsing entry point.
 - `pymupdf4llm_integration.py`: Optional PyMuPDF4LLM extraction and cleanup.
 - `text_processing.py`: Additional text-repair helpers.
+- `source_matchers.py`: Matching strategies for locating original source blocks.
 
 ## AI Agent Guidance
 - Respect strict separation of passes.

--- a/pdf_chunker/source_matchers.py
+++ b/pdf_chunker/source_matchers.py
@@ -1,0 +1,69 @@
+# Source block matching predicate functions.
+# Each predicate returns True if ``block`` is considered a match for
+# ``chunk_start``. They are composed in ``MATCHERS`` which can be extended
+# for additional strategies.
+from __future__ import annotations
+
+from typing import Callable, List, Tuple
+
+Matcher = Callable[[str, dict, list[dict]], bool]
+
+
+def substring_match(chunk_start: str, block: dict, _blocks: list[dict]) -> bool:
+    return bool(chunk_start) and chunk_start in block.get("text", "")
+
+
+def start_match(chunk_start: str, block: dict, _blocks: list[dict]) -> bool:
+    block_text = block.get("text", "").strip()
+    if not block_text:
+        return False
+    block_start = block_text[: max(20, len(chunk_start))].replace("\n", " ").strip()
+    lower_chunk = chunk_start.lower()
+    lower_block = block_start.lower()
+    return lower_chunk.startswith(lower_block) or lower_block.startswith(lower_chunk)
+
+
+def fuzzy_match(chunk_start: str, block: dict, _blocks: list[dict]) -> bool:
+    import re
+
+    def normalize(s: str) -> str:
+        return re.sub(r"[\W_]+", "", s).lower()
+
+    block_start = block.get("text", "")[: max(20, len(chunk_start))]
+    return normalize(block_start).startswith(normalize(chunk_start)[:15])
+
+
+def overlap_match(chunk_start: str, block: dict, _blocks: list[dict]) -> bool:
+    block_text = block.get("text", "")
+    return any(chunk_start[:n] in block_text for n in range(30, 10, -5))
+
+
+def header_match(chunk_start: str, block: dict, blocks: list[dict]) -> bool:
+    return (
+        block is blocks[0]
+        and bool(chunk_start)
+        and (
+            chunk_start.isupper()
+            or chunk_start.startswith("CHAPTER")
+            or chunk_start.startswith("SECTION")
+        )
+    )
+
+
+MATCHERS: List[Tuple[str, Matcher]] = [
+    ("substring match", substring_match),
+    ("start match", start_match),
+    ("fuzzy match", fuzzy_match),
+    ("overlap match", overlap_match),
+    ("header/special formatting", header_match),
+]
+
+__all__ = [
+    "Matcher",
+    "MATCHERS",
+    "substring_match",
+    "start_match",
+    "fuzzy_match",
+    "overlap_match",
+    "header_match",
+]

--- a/tests/source_matchers_test.py
+++ b/tests/source_matchers_test.py
@@ -1,0 +1,23 @@
+from haystack.dataclasses import Document
+
+from pdf_chunker import utils
+from pdf_chunker import source_matchers as sm
+
+
+def test_substring_match():
+    block = {"text": "hello world"}
+    assert sm.substring_match("hello", block, [])
+    assert not sm.substring_match("bye", block, [])
+
+
+def test_find_source_block_uses_injected_matcher():
+    chunk = Document(content="greetings")
+    blocks = [{"text": "irrelevant", "source": {"filename": "f", "page": 1}}]
+
+    def always_match(chunk_start, block, blocks):
+        return True
+
+    result = utils._find_source_block(
+        chunk, {}, blocks, matchers=[("custom", always_match)]
+    )
+    assert result == blocks[0]


### PR DESCRIPTION
## Summary
- extract source-matching predicates into `source_matchers` module and expose registry
- refactor `_find_source_block` to consume matcher registry for flexible strategy composition
- cover matcher behaviors with new tests

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: Argument 1 to "maketrans"..., etc.)*
- `bash scripts/validate_chunks.sh`
- `pytest tests/` *(fails: ModuleNotFoundError: No module named 'pdf_chunker')*
- `bash tests/run_all_tests.sh` *(fails: ModuleNotFoundError: No module named 'pdf_chunker')*

------
https://chatgpt.com/codex/tasks/task_e_689145f2665c832591a377d1234bd082