### PR TITLE
refactor: extract list detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ pdf_chunker/
 │   ├── epub_parsing.py            # EPUB extraction with spine exclusion support
 │   ├── pymupdf4llm_integration.py # Optional PyMuPDF4LLM enhancement
 │   ├── page_artifacts.py          # Header/footer detection helpers
+│   ├── list_detection.py          # Bullet and numbered list detection helpers
 │   ├── env_utils.py               # Environment flag helpers
 │   ├── text_processing.py         # Shared text manipulation utilities
 │   ├── splitter.py                # Semantic Pass: chunk splitting and boundaries

--- a/pdf_chunker/AGENTS.md
+++ b/pdf_chunker/AGENTS.md
@@ -23,6 +23,7 @@ Please, keep this file up-to-date with the latest code structure. If you notice 
 - `pymupdf4llm_integration.py`: Optional PyMuPDF4LLM extraction and cleanup.
 - `text_processing.py`: Additional text-repair helpers.
 - `source_matchers.py`: Matching strategies for locating original source blocks.
+- `list_detection.py`: Bullet and numbered list detection helpers.
 
 ## AI Agent Guidance
 - Respect strict separation of passes.

--- a/pdf_chunker/list_detection.py
+++ b/pdf_chunker/list_detection.py
@@ -1,0 +1,46 @@
+import re
+
+BULLET_CHARS = "*•◦▪‣·●◉○‧"
+BULLET_CHARS_ESC = re.escape(BULLET_CHARS)
+NUMBERED_RE = re.compile(r"\s*\d+[.)]")
+
+
+def starts_with_bullet(text: str) -> bool:
+    """Return True if ``text`` begins with a bullet character."""
+    return text.lstrip().startswith(tuple(BULLET_CHARS))
+
+
+def is_bullet_continuation(curr: str, nxt: str) -> bool:
+    """Return True when ``nxt`` continues a bullet item from ``curr``."""
+    return curr.rstrip().endswith(tuple(BULLET_CHARS)) and nxt[:1].islower()
+
+
+def is_bullet_list_pair(curr: str, nxt: str) -> bool:
+    """Return True when ``curr`` and ``nxt`` belong to the same bullet list."""
+    colon_bullet = re.search(rf":\s*[{BULLET_CHARS_ESC}]", curr)
+    has_bullet = starts_with_bullet(curr) or any(
+        starts_with_bullet(line) for line in curr.splitlines()
+    )
+    return starts_with_bullet(nxt) and (has_bullet or colon_bullet is not None)
+
+
+def starts_with_number(text: str) -> bool:
+    """Return True if ``text`` begins with a numbered list marker."""
+    return bool(NUMBERED_RE.match(text))
+
+
+def is_numbered_list_pair(curr: str, nxt: str) -> bool:
+    """Return True when ``curr`` and ``nxt`` belong to the same numbered list."""
+    has_number = starts_with_number(curr) or any(
+        starts_with_number(line) for line in curr.splitlines()
+    )
+    return starts_with_number(nxt) and has_number
+
+
+def is_numbered_continuation(curr: str, nxt: str) -> bool:
+    """Return True when ``nxt`` continues a numbered item from ``curr``."""
+    return (
+        starts_with_number(curr)
+        and not starts_with_number(nxt)
+        and not curr.rstrip().endswith((".", "!", "?"))
+    )


### PR DESCRIPTION
## Summary
- extract bullet and numbered list detection helpers into dedicated module
- reuse shared list detection in pdf_parsing to simplify block merge logic
- document new module in AGENTS guides

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: Need type annotation for "current_block_lines"; various missing stubs)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/` *(fails: Interrupted during collection in ai_enrichment_test.py)*
- `bash tests/run_all_tests.sh` *(reports test failures; see log)*

------
https://chatgpt.com/codex/tasks/task_e_68916041b7488325aee99cceafd67c36