### PR TITLE
Fix double newline before author attribution

### DIFF
--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -148,6 +148,10 @@ def _should_merge_blocks(
         f"Merge check: Text endings - curr: '{curr_text[-10:]}', next: '{next_text[:10]}'"
     )
 
+    if next_text.startswith("—"):
+        logger.debug("Merge decision: AUTHOR_ATTRIBUTION")
+        return True, "author_attribution"
+
     # Check for quote-related splitting issues
     curr_has_quote = '"' in curr_text or "'" in curr_text
     next_has_quote = '"' in next_text or "'" in next_text
@@ -422,6 +426,8 @@ def merge_continuation_blocks(blocks: List[Dict[str, Any]]) -> List[Dict[str, An
                     merged_text = current_text + " " + next_text
                 elif merge_reason == "indented_continuation":
                     merged_text = current_text + "\n" + next_text
+                elif merge_reason == "author_attribution":
+                    merged_text = current_text + " " + next_text
                 else:
                     merged_text = current_text + " " + next_text
 

--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -196,14 +196,21 @@ def merge_spurious_paragraph_breaks(text: str) -> str:
     parts = [p for p in PARAGRAPH_BREAK.split(text) if p.strip()]
     merged: List[str] = []
     for part in parts:
-        if merged and not any(_is_probable_heading(seg) for seg in (merged[-1], part)):
+        if merged:
             prev = merged[-1]
-            if _has_unbalanced_quotes(prev) and not _has_unbalanced_quotes(prev + part):
-                merged[-1] = f"{prev.rstrip()} {part.lstrip()}"
+            author_line = part.lstrip()
+            if author_line.startswith("—"):
+                merged[-1] = f"{prev.rstrip()} {author_line}"
                 continue
-            if len(prev) < 60 or not prev.rstrip().endswith((".", "?", "!")):
-                merged[-1] = f"{prev.rstrip()} {part.lstrip()}"
-                continue
+            if not any(_is_probable_heading(seg) for seg in (prev, part)):
+                if _has_unbalanced_quotes(prev) and not _has_unbalanced_quotes(
+                    prev + part
+                ):
+                    merged[-1] = f"{prev.rstrip()} {part.lstrip()}"
+                    continue
+                if len(prev) < 60 or not prev.rstrip().endswith((".", "?", "!")):
+                    merged[-1] = f"{prev.rstrip()} {part.lstrip()}"
+                    continue
         merged.append(part)
     return "\n\n".join(merged)
 

--- a/tests/newline_cleanup_test.py
+++ b/tests/newline_cleanup_test.py
@@ -49,6 +49,17 @@ class TestNewlineCleanup(unittest.TestCase):
         expected = '" President Draws Planning Moral: Recalls Army Days to Show Value of Preparedness in Time of Crisis,"'
         self.assertEqual(clean_text(text), expected)
 
+    def test_merge_quote_with_author_line(self):
+        text = (
+            "What recommends commerce to me is its enterprise and bravery.\n\n"
+            "—Author Name, Book Name"
+        )
+        expected = (
+            "What recommends commerce to me is its enterprise and bravery. "
+            "—Author Name, Book Name"
+        )
+        self.assertEqual(clean_text(text), expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- merge author attribution lines into preceding quotes during PDF block merging
- collapse em-dash author lines during paragraph cleanup
- cover quote+author scenario in newline cleanup tests

## Testing
- `python -m flake8 pdf_chunker/`
- `python -m mypy pdf_chunker/ --ignore-missing-imports` *(fails: Cannot assign to a type, missing stubs, and other typing errors)*
- `PYTHONPATH=. bash tests/run_all_tests.sh` *(fails: EPUB spine exclusion and page exclusion verification issues)*
- `bash scripts/validate_chunks.sh /tmp/sample_quote_output.jsonl`
- `PYTHONPATH=. pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_68926be930c0832581c29e775cbbeda1