### PR TITLE
style: configure Black and reformat codebase

### DIFF
--- a/pdf_chunker/epub_parsing.py
+++ b/pdf_chunker/epub_parsing.py
@@ -12,20 +12,24 @@ from .extraction_fallbacks import _detect_language
 
 def get_element_text_content(element) -> str:
     """Extract text from BeautifulSoup element without extra separators."""
-    return ' '.join(
-        ' '.join(child.stripped_strings) if hasattr(child, 'stripped_strings') else child
+    return " ".join(
+        (
+            " ".join(child.stripped_strings)
+            if hasattr(child, "stripped_strings")
+            else child
+        )
         for child in element.contents
     )
 
 
 def process_epub_item(item, filename):
-    soup = BeautifulSoup(item.get_content(), 'html.parser')
-    body = soup.find('body')
+    soup = BeautifulSoup(item.get_content(), "html.parser")
+    body = soup.find("body")
     if not body:
         return []
 
     blocks = []
-    for element in body.find_all(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']):
+    for element in body.find_all(["p", "h1", "h2", "h3", "h4", "h5", "h6"]):
         raw_text = get_element_text_content(element)
         block_text = clean_paragraph(raw_text)
         if not block_text:
@@ -33,26 +37,30 @@ def process_epub_item(item, filename):
 
         block_type = (
             "heading"
-            if element.name.startswith('h') or _detect_heading_fallback(block_text)
+            if element.name.startswith("h") or _detect_heading_fallback(block_text)
             else "paragraph"
         )
 
-        blocks.append({
-            "type": block_type,
-            "text": block_text,
-            "language": _detect_language(block_text),
-            "source": {"filename": filename, "location": item.get_name()}
-        })
+        blocks.append(
+            {
+                "type": block_type,
+                "text": block_text,
+                "language": _detect_language(block_text),
+                "source": {"filename": filename, "location": item.get_name()},
+            }
+        )
 
     return blocks
 
 
-def extract_text_blocks_from_epub(filepath: str, exclude_spines: str = None) -> list[dict]:
+def extract_text_blocks_from_epub(
+    filepath: str, exclude_spines: str = None
+) -> list[dict]:
     """
     Extracts structured text blocks from an EPUB file.
 
     Uses ebooklib.ITEM_DOCUMENT to enumerate document items.
-    
+
     Args:
         filepath: Path to the EPUB file
         exclude_spines: Spine ranges to exclude (e.g., "1,3,5-10,15-20")
@@ -62,16 +70,19 @@ def extract_text_blocks_from_epub(filepath: str, exclude_spines: str = None) -> 
 
     # Get spine items (ordered content documents)
     spine_items = list(book.get_items_of_type(ebooklib.ITEM_DOCUMENT))
-    
+
     print(f"EPUB has {len(spine_items)} spine items", file=sys.stderr)
-    
+
     # Parse and validate spine exclusions
     excluded_spines = set()
     if exclude_spines:
         try:
             from .page_utils import parse_page_ranges, validate_page_exclusions
+
             excluded_spines = parse_page_ranges(exclude_spines)
-            excluded_spines = validate_page_exclusions(excluded_spines, len(spine_items), filename)
+            excluded_spines = validate_page_exclusions(
+                excluded_spines, len(spine_items), filename
+            )
         except ValueError as e:
             print(f"Error parsing spine exclusions: {e}", file=sys.stderr)
             print("Continuing without spine exclusions", file=sys.stderr)
@@ -79,67 +90,76 @@ def extract_text_blocks_from_epub(filepath: str, exclude_spines: str = None) -> 
 
     # Process spine items with exclusion filtering
     all_blocks = []
-    for spine_index, item in enumerate(spine_items, 1):  # 1-based indexing like PDF pages
+    for spine_index, item in enumerate(
+        spine_items, 1
+    ):  # 1-based indexing like PDF pages
         if spine_index in excluded_spines:
-            print(f"Skipping excluded spine item {spine_index}: {item.get_name()}", file=sys.stderr)
+            print(
+                f"Skipping excluded spine item {spine_index}: {item.get_name()}",
+                file=sys.stderr,
+            )
             continue
-            
-        print(f"Processing spine item {spine_index}: {item.get_name()}", file=sys.stderr)
+
+        print(
+            f"Processing spine item {spine_index}: {item.get_name()}", file=sys.stderr
+        )
         blocks = process_epub_item(item, filename)
         all_blocks.extend(blocks)
-    
+
     return all_blocks
 
 
 def list_epub_spines(filepath: str) -> list[dict]:
     """
     Lists spine items from an EPUB file with their indices, filenames, and content previews.
-    
+
     Args:
         filepath: Path to the EPUB file
-        
+
     Returns:
         List of dictionaries containing spine information:
         [{"index": 1, "filename": "cover.xhtml", "content_preview": "Cover Page..."}, ...]
     """
     book = epub.read_epub(filepath)
     spine_items = list(book.get_items_of_type(ebooklib.ITEM_DOCUMENT))
-    
+
     def extract_content_preview(item) -> str:
         """Extract first 50-100 characters of text content from a spine item."""
         try:
-            soup = BeautifulSoup(item.get_content(), 'html.parser')
-            body = soup.find('body')
+            soup = BeautifulSoup(item.get_content(), "html.parser")
+            body = soup.find("body")
             if not body:
                 return "No readable content"
-            
+
             # Extract text from all elements, similar to process_epub_item
             text_parts = []
-            for element in body.find_all(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'span']):
+            for element in body.find_all(
+                ["p", "h1", "h2", "h3", "h4", "h5", "h6", "div", "span"]
+            ):
                 raw_text = get_element_text_content(element)
                 if raw_text and raw_text.strip():
                     text_parts.append(raw_text.strip())
-            
+
             if not text_parts:
                 return "No readable content"
-            
+
             # Join text parts and clean up
-            full_text = ' '.join(text_parts)
+            full_text = " ".join(text_parts)
             cleaned_text = clean_paragraph(full_text)
-            
+
             # Truncate to 80 characters with ellipsis
             if len(cleaned_text) > 80:
                 return cleaned_text[:77] + "..."
             return cleaned_text
-            
+
         except Exception:
             return "Content extraction failed"
-    
+
     return [
         {
-            "index": index, 
+            "index": index,
             "filename": item.get_name(),
-            "content_preview": extract_content_preview(item)
+            "content_preview": extract_content_preview(item),
         }
         for index, item in enumerate(spine_items, 1)
     ]

--- a/pdf_chunker/text_processing.py
+++ b/pdf_chunker/text_processing.py
@@ -3,6 +3,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 def normalize_quotes(text: str) -> str:
     """
     Normalize smart quotes to standard ASCII quotes and fix spacing around quotes.
@@ -16,10 +17,21 @@ def normalize_quotes(text: str) -> str:
         return text
 
     # 1. Map smart quotes to ASCII
-    text = text.translate(str.maketrans({
-        '“': '"', '”': '"', '„': '"', '«': '"', '»': '"',
-        '‘': "'", '’': "'", '‚': "'", '`': "'"
-    }))
+    text = text.translate(
+        str.maketrans(
+            {
+                "“": '"',
+                "”": '"',
+                "„": '"',
+                "«": '"',
+                "»": '"',
+                "‘": "'",
+                "’": "'",
+                "‚": "'",
+                "`": "'",
+            }
+        )
+    )
 
     # # 2. Add space before opening quote if missing (opening quote = quote followed by word char)
     # # Use positive lookbehind for any non-space (so both word and punctuation)
@@ -47,9 +59,8 @@ def normalize_quotes(text: str) -> str:
     # text = re.sub(r'(?<=\w)"(?=\w)', r'" ', text)
 
     # collapse any runs of multiple spaces
-    text = re.sub(r'\s{2,}', ' ', text)
+    text = re.sub(r"\s{2,}", " ", text)
     return text.strip()
-
 
 
 def _fix_case_transition_gluing(text: str) -> str:
@@ -61,17 +72,55 @@ def _fix_case_transition_gluing(text: str) -> str:
         return text
 
     # List of legitimate compounds to preserve
-    LEGIT_COMPOUNDS = {"JavaScript", "iPhone", "eBay", "YouTube", "GitHub", "OpenAI", "PowerPoint", "Photoshop", "iPad", "iOS", "macOS", "Airbnb", "PayPal", "LinkedIn", "WhatsApp", "Snapchat", "Dropbox", "Facebook", "Instagram", "Reddit", "Tumblr", "WordPress", "QuickTime", "YouGov", "BioNTech", "SpaceX", "DeepMind", "TensorFlow", "PyTorch", "NumPy", "SciPy", "Matplotlib", "Seaborn", "Pandas", "ScikitLearn", "LangChain"}
+    LEGIT_COMPOUNDS = {
+        "JavaScript",
+        "iPhone",
+        "eBay",
+        "YouTube",
+        "GitHub",
+        "OpenAI",
+        "PowerPoint",
+        "Photoshop",
+        "iPad",
+        "iOS",
+        "macOS",
+        "Airbnb",
+        "PayPal",
+        "LinkedIn",
+        "WhatsApp",
+        "Snapchat",
+        "Dropbox",
+        "Facebook",
+        "Instagram",
+        "Reddit",
+        "Tumblr",
+        "WordPress",
+        "QuickTime",
+        "YouGov",
+        "BioNTech",
+        "SpaceX",
+        "DeepMind",
+        "TensorFlow",
+        "PyTorch",
+        "NumPy",
+        "SciPy",
+        "Matplotlib",
+        "Seaborn",
+        "Pandas",
+        "ScikitLearn",
+        "LangChain",
+    }
 
     def split_camel(match):
         word = match.group(0)
         if word in LEGIT_COMPOUNDS:
             return word
-        return re.sub(r'([a-z])([A-Z])', r'\1 \2', word)
+        return re.sub(r"([a-z])([A-Z])", r"\1 \2", word)
 
-    pattern = re.compile(r'\b\w*[a-z][A-Z]\w*\b')
+    pattern = re.compile(r"\b\w*[a-z][A-Z]\w*\b")
     text = pattern.sub(split_camel, text)
     return text
+
 
 def _fix_page_boundary_gluing(text: str) -> str:
     """
@@ -79,6 +128,7 @@ def _fix_page_boundary_gluing(text: str) -> str:
     but preserve legitimate compound words.
     """
     return _fix_case_transition_gluing(text)
+
 
 def _fix_quote_boundary_gluing(text: str) -> str:
     """
@@ -91,10 +141,21 @@ def _fix_quote_boundary_gluing(text: str) -> str:
         return text
 
     # 1. Map smart quotes to ASCII
-    text = text.translate(str.maketrans({
-        '“': '"', '”': '"', '„': '"', '«': '"', '»': '"',
-        '‘': "'", '’': "'", '‚': "'", '`': "'"
-    }))
+    text = text.translate(
+        str.maketrans(
+            {
+                "“": '"',
+                "”": '"',
+                "„": '"',
+                "«": '"',
+                "»": '"',
+                "‘": "'",
+                "’": "'",
+                "‚": "'",
+                "`": "'",
+            }
+        )
+    )
 
     # # 2. Add space before opening quote if missing (opening quote = quote followed by word char)
     # text = re.sub(r'(?<!\s)(["\'])(?=\w)', r' \1', text)
@@ -121,7 +182,7 @@ def _fix_quote_boundary_gluing(text: str) -> str:
     # text = re.sub(r'(?<=\w)"(?=\w)', r'" ', text)
 
     # collapse any runs of multiple spaces
-    text = re.sub(r'\s{2,}', ' ', text)
+    text = re.sub(r"\s{2,}", " ", text)
     return text.strip()
 
 
@@ -138,6 +199,7 @@ def detect_and_fix_word_gluing(text: str) -> str:
     text = _fix_quote_boundary_gluing(text)
     return text
 
+
 def _repair_json_escaping_issues(text: str) -> str:
     """
     Remove problematic JSON escaping fragments, especially leading '",'.
@@ -153,11 +215,13 @@ def _detect_text_reordering(*args, **kwargs):
     """
     return False
 
+
 def _validate_chunk_integrity(chunks, original_text=None):
     """
     Stub for test compatibility. Returns chunks unchanged.
     """
     return chunks
+
 
 def _repair_json_escaping_issues(text):
     """
@@ -166,19 +230,23 @@ def _repair_json_escaping_issues(text):
     if not text:
         return text
     import re
+
     # Remove control characters
-    text = re.sub(r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]', '', text)
+    text = re.sub(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]", "", text)
     # Remove leading '",'
     # Remove leading '",' pattern specifically
     if text.startswith('",'):
         text = text[2:].lstrip()
     # Remove any other leading quote/comma patterns
-    text = re.sub(r'^["\s]*,\s*', '', text)
+    text = re.sub(r'^["\s]*,\s*', "", text)
     return text.strip()
+
 
 def _remove_control_characters(text):
     import re
-    return re.sub(r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]', '', text)
+
+    return re.sub(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]", "", text)
+
 
 def _fix_quote_splitting_issues(chunks):
     if not chunks or len(chunks) < 2:
@@ -192,55 +260,59 @@ def _fix_quote_splitting_issues(chunks):
     i = 0
     while i < len(chunks):
         # whenever you see the next chunk start with '",'
-        if i + 1 < len(chunks) and chunks[i+1].lstrip().startswith('",'):
-            merged.append(chunks[i] + chunks[i+1])
+        if i + 1 < len(chunks) and chunks[i + 1].lstrip().startswith('",'):
+            merged.append(chunks[i] + chunks[i + 1])
             i += 2
         else:
             merged.append(chunks[i])
             i += 1
     return merged
 
+
 # def _fix_quote_splitting_issues(chunks):
-    # """
-    # Merge chunks that were incorrectly split at quotes.
-    # Merge any two chunks where the first ends with a quote and the second starts with '",'
-    # (with or without whitespace), as in the test case.
-    # """
-    # if not chunks or len(chunks) < 2:
-        # return chunks
+# """
+# Merge chunks that were incorrectly split at quotes.
+# Merge any two chunks where the first ends with a quote and the second starts with '",'
+# (with or without whitespace), as in the test case.
+# """
+# if not chunks or len(chunks) < 2:
+# return chunks
 
-    # # Check if we have exactly 2 chunks and they match the splitting pattern
-    # if (len(chunks) == 2 and
-        # chunks[0].rstrip().endswith('"') and
-        # re.match(r'^\s*",', chunks[1])):
-        # merged_text = chunks[0] + chunks[1]
-        # return [merged_text]
+# # Check if we have exactly 2 chunks and they match the splitting pattern
+# if (len(chunks) == 2 and
+# chunks[0].rstrip().endswith('"') and
+# re.match(r'^\s*",', chunks[1])):
+# merged_text = chunks[0] + chunks[1]
+# return [merged_text]
 
-    # # General case: merge any such adjacent chunks
-    # merged = []
-    # i = 0
-    # while i < len(chunks):
-        # current = chunks[i]
-        # if (i + 1 < len(chunks) and
-            # current.rstrip().endswith('"') and
-            # re.match(r'^\s*",', chunks[i + 1])):
-            # merged_chunk = current + chunks[i + 1]
-            # merged.append(merged_chunk)
-            # i += 2
-        # else:
-            # merged.append(current)
-            # i += 1
-    # return merged
+# # General case: merge any such adjacent chunks
+# merged = []
+# i = 0
+# while i < len(chunks):
+# current = chunks[i]
+# if (i + 1 < len(chunks) and
+# current.rstrip().endswith('"') and
+# re.match(r'^\s*",', chunks[i + 1])):
+# merged_chunk = current + chunks[i + 1]
+# merged.append(merged_chunk)
+# i += 2
+# else:
+# merged.append(current)
+# i += 1
+# return merged
+
 
 def _validate_json_safety(text):
     """
     Stub for test compatibility. Returns (True, []) if text can be JSON serialized, else (False, [issue]).
     """
     import json
+
     try:
         json.dumps({"test": text})
         return True, []
     except Exception as e:
         return False, [str(e)]
+
 
 # ... existing code ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 88
+

--- a/scripts/benchmark_extraction.py
+++ b/scripts/benchmark_extraction.py
@@ -30,17 +30,18 @@ from pdf_chunker.pymupdf4llm_integration import (
     is_pymupdf4llm_available,
     extract_with_pymupdf4llm,
     assess_pymupdf4llm_quality,
-    PyMuPDF4LLMExtractionError
+    PyMuPDF4LLMExtractionError,
 )
 from pdf_chunker.extraction_fallbacks import (
     _assess_text_quality,
-    execute_fallback_extraction
+    execute_fallback_extraction,
 )
 
 
 @dataclass
 class ExtractionMetrics:
     """Metrics for a single extraction run"""
+
     method: str
     pdf_file: str
     success: bool
@@ -52,7 +53,7 @@ class ExtractionMetrics:
     avg_chunk_size: float
     quality_score: float
     error_message: Optional[str] = None
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
 
@@ -60,49 +61,47 @@ class ExtractionMetrics:
 @dataclass
 class BenchmarkResults:
     """Complete benchmark results for comparison"""
+
     hybrid_metrics: List[ExtractionMetrics]
     traditional_metrics: List[ExtractionMetrics]
     comparison_summary: Dict[str, Any]
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
-            'hybrid_metrics': [m.to_dict() for m in self.hybrid_metrics],
-            'traditional_metrics': [m.to_dict() for m in self.traditional_metrics],
-            'comparison_summary': self.comparison_summary
+            "hybrid_metrics": [m.to_dict() for m in self.hybrid_metrics],
+            "traditional_metrics": [m.to_dict() for m in self.traditional_metrics],
+            "comparison_summary": self.comparison_summary,
         }
 
 
 def measure_extraction_performance(
-    extraction_func,
-    pdf_file: str,
-    method_name: str,
-    **kwargs
+    extraction_func, pdf_file: str, method_name: str, **kwargs
 ) -> ExtractionMetrics:
     """
     Measure performance metrics for a single extraction method.
-    
+
     Args:
         extraction_func: Function to call for extraction
         pdf_file: Path to PDF file
         method_name: Name of the extraction method
         **kwargs: Additional arguments for extraction function
-        
+
     Returns:
         ExtractionMetrics with performance data
     """
     # Start memory tracking
     tracemalloc.start()
     start_time = time.time()
-    
+
     try:
         # Execute extraction
         result = extraction_func(pdf_file, **kwargs)
-        
+
         # Calculate metrics
         extraction_time = time.time() - start_time
         current, peak = tracemalloc.get_traced_memory()
         memory_peak_mb = peak / 1024 / 1024  # Convert to MB
-        
+
         # Analyze results
         if isinstance(result, list):
             # Traditional extraction returns list of blocks
@@ -112,18 +111,22 @@ def measure_extraction_performance(
             # Core process_document returns structured result
             chunks = result if isinstance(result, list) else []
             blocks = chunks
-        
+
         # Calculate text metrics
-        text_length = sum(len(block.get('text', '')) for block in blocks)
+        text_length = sum(len(block.get("text", "")) for block in blocks)
         chunk_count = len(chunks)
-        heading_count = sum(1 for block in blocks if block.get('is_heading', False) or block.get('type') == 'heading')
+        heading_count = sum(
+            1
+            for block in blocks
+            if block.get("is_heading", False) or block.get("type") == "heading"
+        )
         avg_chunk_size = text_length / chunk_count if chunk_count > 0 else 0
-        
+
         # Assess quality
-        combined_text = '\n'.join(block.get('text', '') for block in blocks)
+        combined_text = "\n".join(block.get("text", "") for block in blocks)
         quality_assessment = _assess_text_quality(combined_text)
-        quality_score = quality_assessment.get('quality_score', 0.0)
-        
+        quality_score = quality_assessment.get("quality_score", 0.0)
+
         return ExtractionMetrics(
             method=method_name,
             pdf_file=os.path.basename(pdf_file),
@@ -134,14 +137,14 @@ def measure_extraction_performance(
             chunk_count=chunk_count,
             heading_count=heading_count,
             avg_chunk_size=avg_chunk_size,
-            quality_score=quality_score
+            quality_score=quality_score,
         )
-        
+
     except Exception as e:
         extraction_time = time.time() - start_time
         current, peak = tracemalloc.get_traced_memory()
         memory_peak_mb = peak / 1024 / 1024
-        
+
         return ExtractionMetrics(
             method=method_name,
             pdf_file=os.path.basename(pdf_file),
@@ -153,9 +156,9 @@ def measure_extraction_performance(
             heading_count=0,
             avg_chunk_size=0,
             quality_score=0.0,
-            error_message=str(e)
+            error_message=str(e),
         )
-    
+
     finally:
         tracemalloc.stop()
 
@@ -163,56 +166,56 @@ def measure_extraction_performance(
 def extract_with_hybrid_approach(pdf_file: str, **kwargs) -> List[Dict[str, Any]]:
     """
     Extract using the hybrid PyMuPDF4LLM approach with fallback.
-    
+
     Args:
         pdf_file: Path to PDF file
         **kwargs: Additional arguments (chunk_size, overlap, etc.)
-        
+
     Returns:
         List of extracted chunks/blocks
     """
     # Use the core process_document function which implements the hybrid approach
     result = process_document(
         pdf_file,
-        chunk_size=kwargs.get('chunk_size', 8000),
-        overlap=kwargs.get('overlap', 200),
-        exclude_pages=kwargs.get('exclude_pages'),
+        chunk_size=kwargs.get("chunk_size", 8000),
+        overlap=kwargs.get("overlap", 200),
+        exclude_pages=kwargs.get("exclude_pages"),
         generate_metadata=True,
-        ai_enrichment=False  # Skip AI enrichment for performance testing
+        ai_enrichment=False,  # Skip AI enrichment for performance testing
     )
-    
+
     return result
 
 
 def extract_with_traditional_approach(pdf_file: str, **kwargs) -> List[Dict[str, Any]]:
     """
     Extract using only the traditional three-tier fallback approach.
-    
+
     Args:
         pdf_file: Path to PDF file
         **kwargs: Additional arguments (exclude_pages, etc.)
-        
+
     Returns:
         List of extracted blocks
     """
     # Force traditional extraction by bypassing PyMuPDF4LLM
     # We'll temporarily disable PyMuPDF4LLM for this test
     original_available = None
-    
+
     try:
         # Temporarily disable PyMuPDF4LLM to force traditional extraction
         import pdf_chunker.pymupdf4llm_integration as pymupdf4llm_module
+
         original_available = pymupdf4llm_module.PYMUPDF4LLM_AVAILABLE
         pymupdf4llm_module.PYMUPDF4LLM_AVAILABLE = False
-        
+
         # Use the PDF parsing function which will now use traditional methods
         blocks = extract_text_blocks_from_pdf(
-            pdf_file,
-            exclude_pages=kwargs.get('exclude_pages')
+            pdf_file, exclude_pages=kwargs.get("exclude_pages")
         )
-        
+
         return blocks
-        
+
     finally:
         # Restore original PyMuPDF4LLM availability
         if original_available is not None:
@@ -220,69 +223,60 @@ def extract_with_traditional_approach(pdf_file: str, **kwargs) -> List[Dict[str,
 
 
 def run_benchmark_iteration(
-    pdf_file: str,
-    iteration: int,
-    total_iterations: int,
-    **kwargs
+    pdf_file: str, iteration: int, total_iterations: int, **kwargs
 ) -> tuple[ExtractionMetrics, ExtractionMetrics]:
     """
     Run a single benchmark iteration comparing both methods.
-    
+
     Args:
         pdf_file: Path to PDF file
         iteration: Current iteration number
         total_iterations: Total number of iterations
         **kwargs: Additional arguments for extraction
-        
+
     Returns:
         Tuple of (hybrid_metrics, traditional_metrics)
     """
     print(f"  Iteration {iteration + 1}/{total_iterations}...")
-    
+
     # Test hybrid approach
     print(f"    Testing hybrid approach...")
     hybrid_metrics = measure_extraction_performance(
-        extract_with_hybrid_approach,
-        pdf_file,
-        "hybrid_pymupdf4llm",
-        **kwargs
+        extract_with_hybrid_approach, pdf_file, "hybrid_pymupdf4llm", **kwargs
     )
-    
+
     # Test traditional approach
     print(f"    Testing traditional approach...")
     traditional_metrics = measure_extraction_performance(
-        extract_with_traditional_approach,
-        pdf_file,
-        "traditional_fallback",
-        **kwargs
+        extract_with_traditional_approach, pdf_file, "traditional_fallback", **kwargs
     )
-    
+
     return hybrid_metrics, traditional_metrics
 
 
 def calculate_statistics(metrics_list: List[ExtractionMetrics]) -> Dict[str, Any]:
     """
     Calculate statistical summary for a list of metrics.
-    
+
     Args:
         metrics_list: List of ExtractionMetrics
-        
+
     Returns:
         Dictionary with statistical summary
     """
     if not metrics_list:
         return {}
-    
+
     successful_metrics = [m for m in metrics_list if m.success]
-    
+
     if not successful_metrics:
         return {
-            'success_rate': 0.0,
-            'total_runs': len(metrics_list),
-            'successful_runs': 0,
-            'failed_runs': len(metrics_list)
+            "success_rate": 0.0,
+            "total_runs": len(metrics_list),
+            "successful_runs": 0,
+            "failed_runs": len(metrics_list),
         }
-    
+
     # Extract numeric values for statistics
     extraction_times = [m.extraction_time for m in successful_metrics]
     memory_peaks = [m.memory_peak_mb for m in successful_metrics]
@@ -290,155 +284,170 @@ def calculate_statistics(metrics_list: List[ExtractionMetrics]) -> Dict[str, Any
     chunk_counts = [m.chunk_count for m in successful_metrics]
     heading_counts = [m.heading_count for m in successful_metrics]
     quality_scores = [m.quality_score for m in successful_metrics]
-    
+
     def safe_stats(values: List[float]) -> Dict[str, float]:
         """Calculate statistics safely handling edge cases"""
         if not values:
-            return {'mean': 0, 'median': 0, 'std_dev': 0, 'min': 0, 'max': 0}
-        
+            return {"mean": 0, "median": 0, "std_dev": 0, "min": 0, "max": 0}
+
         return {
-            'mean': statistics.mean(values),
-            'median': statistics.median(values),
-            'std_dev': statistics.stdev(values) if len(values) > 1 else 0,
-            'min': min(values),
-            'max': max(values)
+            "mean": statistics.mean(values),
+            "median": statistics.median(values),
+            "std_dev": statistics.stdev(values) if len(values) > 1 else 0,
+            "min": min(values),
+            "max": max(values),
         }
-    
+
     return {
-        'success_rate': len(successful_metrics) / len(metrics_list),
-        'total_runs': len(metrics_list),
-        'successful_runs': len(successful_metrics),
-        'failed_runs': len(metrics_list) - len(successful_metrics),
-        'extraction_time': safe_stats(extraction_times),
-        'memory_peak_mb': safe_stats(memory_peaks),
-        'text_length': safe_stats(text_lengths),
-        'chunk_count': safe_stats(chunk_counts),
-        'heading_count': safe_stats(heading_counts),
-        'quality_score': safe_stats(quality_scores)
+        "success_rate": len(successful_metrics) / len(metrics_list),
+        "total_runs": len(metrics_list),
+        "successful_runs": len(successful_metrics),
+        "failed_runs": len(metrics_list) - len(successful_metrics),
+        "extraction_time": safe_stats(extraction_times),
+        "memory_peak_mb": safe_stats(memory_peaks),
+        "text_length": safe_stats(text_lengths),
+        "chunk_count": safe_stats(chunk_counts),
+        "heading_count": safe_stats(heading_counts),
+        "quality_score": safe_stats(quality_scores),
     }
 
 
 def compare_methods(
-    hybrid_stats: Dict[str, Any],
-    traditional_stats: Dict[str, Any]
+    hybrid_stats: Dict[str, Any], traditional_stats: Dict[str, Any]
 ) -> Dict[str, Any]:
     """
     Compare performance between hybrid and traditional methods.
-    
+
     Args:
         hybrid_stats: Statistics for hybrid method
         traditional_stats: Statistics for traditional method
-        
+
     Returns:
         Comparison analysis
     """
     comparison = {
-        'performance_comparison': {},
-        'quality_comparison': {},
-        'reliability_comparison': {},
-        'recommendations': []
+        "performance_comparison": {},
+        "quality_comparison": {},
+        "reliability_comparison": {},
+        "recommendations": [],
     }
-    
+
     # Performance comparison
-    if (hybrid_stats.get('extraction_time', {}).get('mean', 0) > 0 and 
-        traditional_stats.get('extraction_time', {}).get('mean', 0) > 0):
-        
-        hybrid_time = hybrid_stats['extraction_time']['mean']
-        traditional_time = traditional_stats['extraction_time']['mean']
+    if (
+        hybrid_stats.get("extraction_time", {}).get("mean", 0) > 0
+        and traditional_stats.get("extraction_time", {}).get("mean", 0) > 0
+    ):
+
+        hybrid_time = hybrid_stats["extraction_time"]["mean"]
+        traditional_time = traditional_stats["extraction_time"]["mean"]
         speed_ratio = traditional_time / hybrid_time
-        
-        comparison['performance_comparison'] = {
-            'hybrid_avg_time': hybrid_time,
-            'traditional_avg_time': traditional_time,
-            'speed_ratio': speed_ratio,
-            'faster_method': 'hybrid' if speed_ratio > 1.0 else 'traditional',
-            'speed_improvement': abs(speed_ratio - 1.0) * 100
+
+        comparison["performance_comparison"] = {
+            "hybrid_avg_time": hybrid_time,
+            "traditional_avg_time": traditional_time,
+            "speed_ratio": speed_ratio,
+            "faster_method": "hybrid" if speed_ratio > 1.0 else "traditional",
+            "speed_improvement": abs(speed_ratio - 1.0) * 100,
         }
-        
+
         # Memory comparison
-        hybrid_memory = hybrid_stats.get('memory_peak_mb', {}).get('mean', 0)
-        traditional_memory = traditional_stats.get('memory_peak_mb', {}).get('mean', 0)
-        
+        hybrid_memory = hybrid_stats.get("memory_peak_mb", {}).get("mean", 0)
+        traditional_memory = traditional_stats.get("memory_peak_mb", {}).get("mean", 0)
+
         if hybrid_memory > 0 and traditional_memory > 0:
             memory_ratio = hybrid_memory / traditional_memory
-            comparison['performance_comparison']['memory_comparison'] = {
-                'hybrid_avg_memory_mb': hybrid_memory,
-                'traditional_avg_memory_mb': traditional_memory,
-                'memory_ratio': memory_ratio,
-                'lower_memory_method': 'hybrid' if memory_ratio < 1.0 else 'traditional'
+            comparison["performance_comparison"]["memory_comparison"] = {
+                "hybrid_avg_memory_mb": hybrid_memory,
+                "traditional_avg_memory_mb": traditional_memory,
+                "memory_ratio": memory_ratio,
+                "lower_memory_method": (
+                    "hybrid" if memory_ratio < 1.0 else "traditional"
+                ),
             }
-    
+
     # Quality comparison
-    hybrid_quality = hybrid_stats.get('quality_score', {}).get('mean', 0)
-    traditional_quality = traditional_stats.get('quality_score', {}).get('mean', 0)
-    
+    hybrid_quality = hybrid_stats.get("quality_score", {}).get("mean", 0)
+    traditional_quality = traditional_stats.get("quality_score", {}).get("mean", 0)
+
     if hybrid_quality > 0 or traditional_quality > 0:
-        comparison['quality_comparison'] = {
-            'hybrid_avg_quality': hybrid_quality,
-            'traditional_avg_quality': traditional_quality,
-            'quality_difference': hybrid_quality - traditional_quality,
-            'better_quality_method': 'hybrid' if hybrid_quality > traditional_quality else 'traditional'
+        comparison["quality_comparison"] = {
+            "hybrid_avg_quality": hybrid_quality,
+            "traditional_avg_quality": traditional_quality,
+            "quality_difference": hybrid_quality - traditional_quality,
+            "better_quality_method": (
+                "hybrid" if hybrid_quality > traditional_quality else "traditional"
+            ),
         }
-        
+
         # Heading detection comparison
-        hybrid_headings = hybrid_stats.get('heading_count', {}).get('mean', 0)
-        traditional_headings = traditional_stats.get('heading_count', {}).get('mean', 0)
-        
-        comparison['quality_comparison']['heading_detection'] = {
-            'hybrid_avg_headings': hybrid_headings,
-            'traditional_avg_headings': traditional_headings,
-            'heading_difference': hybrid_headings - traditional_headings,
-            'better_heading_detection': 'hybrid' if hybrid_headings > traditional_headings else 'traditional'
+        hybrid_headings = hybrid_stats.get("heading_count", {}).get("mean", 0)
+        traditional_headings = traditional_stats.get("heading_count", {}).get("mean", 0)
+
+        comparison["quality_comparison"]["heading_detection"] = {
+            "hybrid_avg_headings": hybrid_headings,
+            "traditional_avg_headings": traditional_headings,
+            "heading_difference": hybrid_headings - traditional_headings,
+            "better_heading_detection": (
+                "hybrid" if hybrid_headings > traditional_headings else "traditional"
+            ),
         }
-    
+
     # Reliability comparison
-    hybrid_success_rate = hybrid_stats.get('success_rate', 0)
-    traditional_success_rate = traditional_stats.get('success_rate', 0)
-    
-    comparison['reliability_comparison'] = {
-        'hybrid_success_rate': hybrid_success_rate,
-        'traditional_success_rate': traditional_success_rate,
-        'reliability_difference': hybrid_success_rate - traditional_success_rate,
-        'more_reliable_method': 'hybrid' if hybrid_success_rate > traditional_success_rate else 'traditional'
+    hybrid_success_rate = hybrid_stats.get("success_rate", 0)
+    traditional_success_rate = traditional_stats.get("success_rate", 0)
+
+    comparison["reliability_comparison"] = {
+        "hybrid_success_rate": hybrid_success_rate,
+        "traditional_success_rate": traditional_success_rate,
+        "reliability_difference": hybrid_success_rate - traditional_success_rate,
+        "more_reliable_method": (
+            "hybrid"
+            if hybrid_success_rate > traditional_success_rate
+            else "traditional"
+        ),
     }
-    
+
     # Generate recommendations
     recommendations = []
-    
+
     # Performance recommendations
-    perf_comp = comparison.get('performance_comparison', {})
-    if perf_comp.get('speed_improvement', 0) > 10:
-        faster = perf_comp.get('faster_method', 'unknown')
-        improvement = perf_comp.get('speed_improvement', 0)
+    perf_comp = comparison.get("performance_comparison", {})
+    if perf_comp.get("speed_improvement", 0) > 10:
+        faster = perf_comp.get("faster_method", "unknown")
+        improvement = perf_comp.get("speed_improvement", 0)
         recommendations.append(f"{faster.title()} method is {improvement:.1f}% faster")
-    
+
     # Quality recommendations
-    qual_comp = comparison.get('quality_comparison', {})
-    if abs(qual_comp.get('quality_difference', 0)) > 0.1:
-        better = qual_comp.get('better_quality_method', 'unknown')
-        diff = abs(qual_comp.get('quality_difference', 0))
-        recommendations.append(f"{better.title()} method has {diff:.2f} higher quality score")
-    
+    qual_comp = comparison.get("quality_comparison", {})
+    if abs(qual_comp.get("quality_difference", 0)) > 0.1:
+        better = qual_comp.get("better_quality_method", "unknown")
+        diff = abs(qual_comp.get("quality_difference", 0))
+        recommendations.append(
+            f"{better.title()} method has {diff:.2f} higher quality score"
+        )
+
     # Heading detection recommendations
-    heading_comp = qual_comp.get('heading_detection', {})
-    if abs(heading_comp.get('heading_difference', 0)) > 0.5:
-        better = heading_comp.get('better_heading_detection', 'unknown')
-        diff = abs(heading_comp.get('heading_difference', 0))
-        recommendations.append(f"{better.title()} method detects {diff:.1f} more headings on average")
-    
+    heading_comp = qual_comp.get("heading_detection", {})
+    if abs(heading_comp.get("heading_difference", 0)) > 0.5:
+        better = heading_comp.get("better_heading_detection", "unknown")
+        diff = abs(heading_comp.get("heading_difference", 0))
+        recommendations.append(
+            f"{better.title()} method detects {diff:.1f} more headings on average"
+        )
+
     # Reliability recommendations
-    rel_comp = comparison.get('reliability_comparison', {})
-    if abs(rel_comp.get('reliability_difference', 0)) > 0.05:
-        better = rel_comp.get('more_reliable_method', 'unknown')
-        diff = abs(rel_comp.get('reliability_difference', 0)) * 100
+    rel_comp = comparison.get("reliability_comparison", {})
+    if abs(rel_comp.get("reliability_difference", 0)) > 0.05:
+        better = rel_comp.get("more_reliable_method", "unknown")
+        diff = abs(rel_comp.get("reliability_difference", 0)) * 100
         recommendations.append(f"{better.title()} method is {diff:.1f}% more reliable")
-    
+
     # Overall recommendation
     if not recommendations:
         recommendations.append("Both methods perform similarly across all metrics")
-    
-    comparison['recommendations'] = recommendations
-    
+
+    comparison["recommendations"] = recommendations
+
     return comparison
 
 
@@ -447,99 +456,107 @@ def run_benchmark(
     iterations: int = 3,
     chunk_size: int = 8000,
     overlap: int = 200,
-    exclude_pages: Optional[str] = None
+    exclude_pages: Optional[str] = None,
 ) -> BenchmarkResults:
     """
     Run complete benchmark comparing hybrid vs traditional extraction.
-    
+
     Args:
         pdf_files: List of PDF files to test
         iterations: Number of iterations per file
         chunk_size: Chunk size for processing
         overlap: Overlap size for chunking
         exclude_pages: Pages to exclude from processing
-        
+
     Returns:
         Complete benchmark results
     """
-    print(f"Starting benchmark with {len(pdf_files)} PDF files, {iterations} iterations each")
+    print(
+        f"Starting benchmark with {len(pdf_files)} PDF files, {iterations} iterations each"
+    )
     print(f"PyMuPDF4LLM available: {is_pymupdf4llm_available()}")
-    
+
     all_hybrid_metrics = []
     all_traditional_metrics = []
-    
+
     extraction_kwargs = {
-        'chunk_size': chunk_size,
-        'overlap': overlap,
-        'exclude_pages': exclude_pages
+        "chunk_size": chunk_size,
+        "overlap": overlap,
+        "exclude_pages": exclude_pages,
     }
-    
+
     for i, pdf_file in enumerate(pdf_files):
-        print(f"\nProcessing file {i + 1}/{len(pdf_files)}: {os.path.basename(pdf_file)}")
-        
+        print(
+            f"\nProcessing file {i + 1}/{len(pdf_files)}: {os.path.basename(pdf_file)}"
+        )
+
         if not os.path.exists(pdf_file):
             print(f"  WARNING: File not found: {pdf_file}")
             continue
-        
+
         for iteration in range(iterations):
             hybrid_metrics, traditional_metrics = run_benchmark_iteration(
                 pdf_file, iteration, iterations, **extraction_kwargs
             )
-            
+
             all_hybrid_metrics.append(hybrid_metrics)
             all_traditional_metrics.append(traditional_metrics)
-            
+
             # Print iteration summary
-            print(f"    Hybrid: {hybrid_metrics.extraction_time:.2f}s, "
-                  f"{hybrid_metrics.text_length} chars, "
-                  f"{hybrid_metrics.chunk_count} chunks, "
-                  f"quality: {hybrid_metrics.quality_score:.2f}")
-            print(f"    Traditional: {traditional_metrics.extraction_time:.2f}s, "
-                  f"{traditional_metrics.text_length} chars, "
-                  f"{traditional_metrics.chunk_count} chunks, "
-                  f"quality: {traditional_metrics.quality_score:.2f}")
-    
+            print(
+                f"    Hybrid: {hybrid_metrics.extraction_time:.2f}s, "
+                f"{hybrid_metrics.text_length} chars, "
+                f"{hybrid_metrics.chunk_count} chunks, "
+                f"quality: {hybrid_metrics.quality_score:.2f}"
+            )
+            print(
+                f"    Traditional: {traditional_metrics.extraction_time:.2f}s, "
+                f"{traditional_metrics.text_length} chars, "
+                f"{traditional_metrics.chunk_count} chunks, "
+                f"quality: {traditional_metrics.quality_score:.2f}"
+            )
+
     # Calculate statistics
     print("\nCalculating statistics...")
     hybrid_stats = calculate_statistics(all_hybrid_metrics)
     traditional_stats = calculate_statistics(all_traditional_metrics)
-    
+
     # Compare methods
     comparison = compare_methods(hybrid_stats, traditional_stats)
-    
+
     # Create summary
     comparison_summary = {
-        'benchmark_config': {
-            'pdf_files': [os.path.basename(f) for f in pdf_files],
-            'iterations_per_file': iterations,
-            'total_iterations': len(all_hybrid_metrics),
-            'chunk_size': chunk_size,
-            'overlap': overlap,
-            'exclude_pages': exclude_pages,
-            'pymupdf4llm_available': is_pymupdf4llm_available()
+        "benchmark_config": {
+            "pdf_files": [os.path.basename(f) for f in pdf_files],
+            "iterations_per_file": iterations,
+            "total_iterations": len(all_hybrid_metrics),
+            "chunk_size": chunk_size,
+            "overlap": overlap,
+            "exclude_pages": exclude_pages,
+            "pymupdf4llm_available": is_pymupdf4llm_available(),
         },
-        'hybrid_statistics': hybrid_stats,
-        'traditional_statistics': traditional_stats,
-        'comparison_analysis': comparison
+        "hybrid_statistics": hybrid_stats,
+        "traditional_statistics": traditional_stats,
+        "comparison_analysis": comparison,
     }
-    
+
     return BenchmarkResults(
         hybrid_metrics=all_hybrid_metrics,
         traditional_metrics=all_traditional_metrics,
-        comparison_summary=comparison_summary
+        comparison_summary=comparison_summary,
     )
 
 
 def print_benchmark_summary(results: BenchmarkResults):
     """Print a human-readable summary of benchmark results"""
     summary = results.comparison_summary
-    config = summary['benchmark_config']
-    comparison = summary['comparison_analysis']
-    
-    print("\n" + "="*80)
+    config = summary["benchmark_config"]
+    comparison = summary["comparison_analysis"]
+
+    print("\n" + "=" * 80)
     print("PDF EXTRACTION PERFORMANCE BENCHMARK RESULTS")
-    print("="*80)
-    
+    print("=" * 80)
+
     print(f"\nBenchmark Configuration:")
     print(f"  Files tested: {', '.join(config['pdf_files'])}")
     print(f"  Iterations per file: {config['iterations_per_file']}")
@@ -547,52 +564,72 @@ def print_benchmark_summary(results: BenchmarkResults):
     print(f"  Chunk size: {config['chunk_size']}")
     print(f"  Overlap: {config['overlap']}")
     print(f"  PyMuPDF4LLM available: {config['pymupdf4llm_available']}")
-    
+
     # Performance comparison
-    perf = comparison.get('performance_comparison', {})
+    perf = comparison.get("performance_comparison", {})
     if perf:
         print(f"\nPerformance Comparison:")
         print(f"  Hybrid average time: {perf.get('hybrid_avg_time', 0):.2f}s")
         print(f"  Traditional average time: {perf.get('traditional_avg_time', 0):.2f}s")
         print(f"  Faster method: {perf.get('faster_method', 'unknown').title()}")
         print(f"  Speed improvement: {perf.get('speed_improvement', 0):.1f}%")
-        
-        mem_comp = perf.get('memory_comparison', {})
+
+        mem_comp = perf.get("memory_comparison", {})
         if mem_comp:
-            print(f"  Hybrid average memory: {mem_comp.get('hybrid_avg_memory_mb', 0):.1f} MB")
-            print(f"  Traditional average memory: {mem_comp.get('traditional_avg_memory_mb', 0):.1f} MB")
-            print(f"  Lower memory method: {mem_comp.get('lower_memory_method', 'unknown').title()}")
-    
+            print(
+                f"  Hybrid average memory: {mem_comp.get('hybrid_avg_memory_mb', 0):.1f} MB"
+            )
+            print(
+                f"  Traditional average memory: {mem_comp.get('traditional_avg_memory_mb', 0):.1f} MB"
+            )
+            print(
+                f"  Lower memory method: {mem_comp.get('lower_memory_method', 'unknown').title()}"
+            )
+
     # Quality comparison
-    qual = comparison.get('quality_comparison', {})
+    qual = comparison.get("quality_comparison", {})
     if qual:
         print(f"\nQuality Comparison:")
         print(f"  Hybrid average quality: {qual.get('hybrid_avg_quality', 0):.2f}")
-        print(f"  Traditional average quality: {qual.get('traditional_avg_quality', 0):.2f}")
-        print(f"  Better quality method: {qual.get('better_quality_method', 'unknown').title()}")
-        
-        heading = qual.get('heading_detection', {})
+        print(
+            f"  Traditional average quality: {qual.get('traditional_avg_quality', 0):.2f}"
+        )
+        print(
+            f"  Better quality method: {qual.get('better_quality_method', 'unknown').title()}"
+        )
+
+        heading = qual.get("heading_detection", {})
         if heading:
-            print(f"  Hybrid average headings: {heading.get('hybrid_avg_headings', 0):.1f}")
-            print(f"  Traditional average headings: {heading.get('traditional_avg_headings', 0):.1f}")
-            print(f"  Better heading detection: {heading.get('better_heading_detection', 'unknown').title()}")
-    
+            print(
+                f"  Hybrid average headings: {heading.get('hybrid_avg_headings', 0):.1f}"
+            )
+            print(
+                f"  Traditional average headings: {heading.get('traditional_avg_headings', 0):.1f}"
+            )
+            print(
+                f"  Better heading detection: {heading.get('better_heading_detection', 'unknown').title()}"
+            )
+
     # Reliability comparison
-    rel = comparison.get('reliability_comparison', {})
+    rel = comparison.get("reliability_comparison", {})
     if rel:
         print(f"\nReliability Comparison:")
         print(f"  Hybrid success rate: {rel.get('hybrid_success_rate', 0):.1%}")
-        print(f"  Traditional success rate: {rel.get('traditional_success_rate', 0):.1%}")
-        print(f"  More reliable method: {rel.get('more_reliable_method', 'unknown').title()}")
-    
+        print(
+            f"  Traditional success rate: {rel.get('traditional_success_rate', 0):.1%}"
+        )
+        print(
+            f"  More reliable method: {rel.get('more_reliable_method', 'unknown').title()}"
+        )
+
     # Recommendations
-    recommendations = comparison.get('recommendations', [])
+    recommendations = comparison.get("recommendations", [])
     if recommendations:
         print(f"\nRecommendations:")
         for i, rec in enumerate(recommendations, 1):
             print(f"  {i}. {rec}")
-    
-    print("\n" + "="*80)
+
+    print("\n" + "=" * 80)
 
 
 def main():
@@ -600,46 +637,39 @@ def main():
     parser = argparse.ArgumentParser(
         description="Benchmark PDF extraction performance: hybrid vs traditional methods"
     )
+    parser.add_argument("pdf_files", nargs="+", help="PDF files to benchmark")
     parser.add_argument(
-        'pdf_files',
-        nargs='+',
-        help='PDF files to benchmark'
+        "--output",
+        "-o",
+        default="benchmark_report.json",
+        help="Output file for detailed results (default: benchmark_report.json)",
     )
     parser.add_argument(
-        '--output', '-o',
-        default='benchmark_report.json',
-        help='Output file for detailed results (default: benchmark_report.json)'
-    )
-    parser.add_argument(
-        '--iterations', '-i',
+        "--iterations",
+        "-i",
         type=int,
         default=3,
-        help='Number of iterations per file (default: 3)'
+        help="Number of iterations per file (default: 3)",
     )
     parser.add_argument(
-        '--chunk-size',
+        "--chunk-size",
         type=int,
         default=8000,
-        help='Chunk size for processing (default: 8000)'
+        help="Chunk size for processing (default: 8000)",
     )
     parser.add_argument(
-        '--overlap',
+        "--overlap",
         type=int,
         default=200,
-        help='Overlap size for chunking (default: 200)'
+        help="Overlap size for chunking (default: 200)",
     )
+    parser.add_argument("--exclude-pages", help='Pages to exclude (e.g., "1,3,5-10")')
     parser.add_argument(
-        '--exclude-pages',
-        help='Pages to exclude (e.g., "1,3,5-10")'
+        "--quiet", "-q", action="store_true", help="Suppress detailed output"
     )
-    parser.add_argument(
-        '--quiet', '-q',
-        action='store_true',
-        help='Suppress detailed output'
-    )
-    
+
     args = parser.parse_args()
-    
+
     # Validate PDF files
     valid_files = []
     for pdf_file in args.pdf_files:
@@ -647,11 +677,11 @@ def main():
             valid_files.append(pdf_file)
         else:
             print(f"WARNING: File not found: {pdf_file}")
-    
+
     if not valid_files:
         print("ERROR: No valid PDF files found")
         sys.exit(1)
-    
+
     # Run benchmark
     try:
         results = run_benchmark(
@@ -659,31 +689,35 @@ def main():
             iterations=args.iterations,
             chunk_size=args.chunk_size,
             overlap=args.overlap,
-            exclude_pages=args.exclude_pages
+            exclude_pages=args.exclude_pages,
         )
-        
+
         # Save detailed results
-        with open(args.output, 'w') as f:
+        with open(args.output, "w") as f:
             json.dump(results.to_dict(), f, indent=2)
-        
+
         if not args.quiet:
             print_benchmark_summary(results)
-        
+
         print(f"\nDetailed results saved to: {args.output}")
-        
+
         # Exit with appropriate code based on results
-        hybrid_success = results.comparison_summary['hybrid_statistics'].get('success_rate', 0)
-        traditional_success = results.comparison_summary['traditional_statistics'].get('success_rate', 0)
-        
+        hybrid_success = results.comparison_summary["hybrid_statistics"].get(
+            "success_rate", 0
+        )
+        traditional_success = results.comparison_summary["traditional_statistics"].get(
+            "success_rate", 0
+        )
+
         if hybrid_success < 0.8 or traditional_success < 0.8:
             print("WARNING: Low success rate detected in benchmark results")
             sys.exit(1)
-        
+
     except Exception as e:
         print(f"ERROR: Benchmark failed: {e}")
         traceback.print_exc()
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/compare_text_quality.py
+++ b/scripts/compare_text_quality.py
@@ -2,9 +2,9 @@
 """
 Text Quality Comparison Script for PDF Extraction Methods
 
-This script compares the text quality of JSONL outputs from the hybrid PyMuPDF4LLM 
-extraction approach against the traditional three-tier fallback system. It focuses 
-on text integrity metrics like sentence boundaries, word joining, whitespace handling, 
+This script compares the text quality of JSONL outputs from the hybrid PyMuPDF4LLM
+extraction approach against the traditional three-tier fallback system. It focuses
+on text integrity metrics like sentence boundaries, word joining, whitespace handling,
 ligature translation, and detection of misplaced headers/footers.
 
 Usage:
@@ -33,6 +33,7 @@ from pdf_chunker.text_cleaning import clean_text, clean_paragraph
 @dataclass
 class TextQualityMetrics:
     """Metrics for text quality assessment"""
+
     method: str
     pdf_file: str
     total_chunks: int
@@ -46,7 +47,7 @@ class TextQualityMetrics:
     overall_quality_score: float
     issues_detected: List[str]
     sample_issues: List[Dict[str, str]]
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
 
@@ -54,27 +55,28 @@ class TextQualityMetrics:
 @dataclass
 class QualityComparison:
     """Complete quality comparison results"""
+
     hybrid_metrics: TextQualityMetrics
     traditional_metrics: TextQualityMetrics
     comparison_analysis: Dict[str, Any]
     detailed_examples: List[Dict[str, Any]]
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
-            'hybrid_metrics': self.hybrid_metrics.to_dict(),
-            'traditional_metrics': self.traditional_metrics.to_dict(),
-            'comparison_analysis': self.comparison_analysis,
-            'detailed_examples': self.detailed_examples
+            "hybrid_metrics": self.hybrid_metrics.to_dict(),
+            "traditional_metrics": self.traditional_metrics.to_dict(),
+            "comparison_analysis": self.comparison_analysis,
+            "detailed_examples": self.detailed_examples,
         }
 
 
 def extract_with_hybrid_method(pdf_file: str) -> List[Dict[str, Any]]:
     """
     Extract text using the hybrid PyMuPDF4LLM approach.
-    
+
     Args:
         pdf_file: Path to PDF file
-        
+
     Returns:
         List of chunks with text and metadata
     """
@@ -84,7 +86,7 @@ def extract_with_hybrid_method(pdf_file: str) -> List[Dict[str, Any]]:
             chunk_size=8000,
             overlap=200,
             generate_metadata=True,
-            ai_enrichment=False  # Skip AI enrichment for quality testing
+            ai_enrichment=False,  # Skip AI enrichment for quality testing
         )
         return result
     except Exception as e:
@@ -95,119 +97,120 @@ def extract_with_hybrid_method(pdf_file: str) -> List[Dict[str, Any]]:
 def extract_with_traditional_method(pdf_file: str) -> List[Dict[str, Any]]:
     """
     Extract text using only the traditional three-tier fallback approach.
-    
+
     Args:
         pdf_file: Path to PDF file
-        
+
     Returns:
         List of chunks with text and metadata
     """
     try:
         # Temporarily disable PyMuPDF4LLM to force traditional extraction
         import pdf_chunker.pymupdf4llm_integration as pymupdf4llm_module
+
         original_available = pymupdf4llm_module.PYMUPDF4LLM_AVAILABLE
         pymupdf4llm_module.PYMUPDF4LLM_AVAILABLE = False
-        
+
         # Extract blocks using traditional methods
         blocks = extract_text_blocks_from_pdf(pdf_file)
-        
+
         # Convert blocks to chunk format for comparison
         chunks = []
         for i, block in enumerate(blocks):
             chunk = {
-                'text': block.get('text', ''),
-                'metadata': {
-                    'chunk_id': f'traditional_{i}',
-                    'page': block.get('source', {}).get('page', 1),
-                    'language': block.get('language', 'unknown'),
-                    'type': block.get('type', 'paragraph'),
-                    'extraction_method': 'traditional'
-                }
+                "text": block.get("text", ""),
+                "metadata": {
+                    "chunk_id": f"traditional_{i}",
+                    "page": block.get("source", {}).get("page", 1),
+                    "language": block.get("language", "unknown"),
+                    "type": block.get("type", "paragraph"),
+                    "extraction_method": "traditional",
+                },
             }
             chunks.append(chunk)
-        
+
         return chunks
-        
+
     except Exception as e:
         print(f"ERROR: Traditional extraction failed for {pdf_file}: {e}")
         return []
     finally:
         # Restore original PyMuPDF4LLM availability
-        if 'original_available' in locals():
+        if "original_available" in locals():
             pymupdf4llm_module.PYMUPDF4LLM_AVAILABLE = original_available
 
 
 def assess_sentence_integrity(text: str) -> Tuple[float, List[str]]:
     """
     Assess sentence integrity by detecting broken sentences and improper boundaries.
-    
+
     Args:
         text: Text to analyze
-        
+
     Returns:
         Tuple of (score, issues_list) where score is 0-1
     """
     issues = []
-    
+
     # Split into sentences using basic punctuation
-    sentences = re.split(r'[.!?]+', text)
+    sentences = re.split(r"[.!?]+", text)
     sentences = [s.strip() for s in sentences if s.strip()]
-    
+
     if not sentences:
         return 0.0, ["No sentences detected"]
-    
+
     broken_sentences = 0
     total_sentences = len(sentences)
-    
+
     for sentence in sentences:
         # Check for sentences that are too short (likely broken)
         if len(sentence.split()) < 3:
             broken_sentences += 1
             issues.append(f"Very short sentence: '{sentence[:50]}...'")
-        
+
         # Check for sentences starting with lowercase (likely continuation)
         if sentence and sentence[0].islower():
             broken_sentences += 1
             issues.append(f"Sentence starts with lowercase: '{sentence[:50]}...'")
-        
+
         # Check for sentences ending mid-word (hyphenation issues)
-        if sentence.endswith('-'):
+        if sentence.endswith("-"):
             broken_sentences += 1
             issues.append(f"Sentence ends with hyphen: '{sentence[-20:]}'")
-    
+
     # Calculate score (higher is better)
     score = max(0.0, 1.0 - (broken_sentences / total_sentences))
-    
+
     return score, issues[:5]  # Limit to 5 examples
 
 
 def assess_word_joining(text: str) -> Tuple[float, List[str]]:
     """
     Assess word joining quality by detecting improperly joined or split words.
-    
+
     Args:
         text: Text to analyze
-        
+
     Returns:
         Tuple of (score, issues_list) where score is 0-1
     """
     issues = []
-    
+
     # Common patterns indicating word joining problems
     patterns = [
-        (r'\b[a-z]+[A-Z][a-z]+\b', "CamelCase words (likely joined)"),
-        (r'\b\w{1,2}\s+\w{1,2}\s+\w{1,2}\b', "Excessive single/double letter words"),
-        (r'\b[a-z]+-\s*\n\s*[a-z]+\b', "Hyphenated words across lines"),
-        (r'\b\w+\s+\w+(?=\w)', "Missing spaces between words"),
-        (r'\b[a-z]+[0-9]+[a-z]+\b', "Words with embedded numbers")
+        (r"\b[a-z]+[A-Z][a-z]+\b", "CamelCase words (likely joined)"),
+        (r"\b\w{1,2}\s+\w{1,2}\s+\w{1,2}\b", "Excessive single/double letter words"),
+        (r"\b[a-z]+-\s*\n\s*[a-z]+\b", "Hyphenated words across lines"),
+        (r"\b\w+\s+\w+(?=\w)", "Missing spaces between words"),
+        (r"\b[a-z]+[0-9]+[a-z]+\b", "Words with embedded numbers"),
     ]
-    
+
     total_words = len(text.split())
     if total_words == 0:
         return 0.0, ["No words detected"]
-    
+
     problem_count = 0
-    
+
     for pattern, description in patterns:
         matches = re.findall(pattern, text, re.IGNORECASE)
         if matches:
@@ -215,189 +218,211 @@ def assess_word_joining(text: str) -> Tuple[float, List[str]]:
             # Add sample issues
             for match in matches[:3]:  # Limit to 3 examples per pattern
                 issues.append(f"{description}: '{match}'")
-    
+
     # Calculate score (higher is better)
     score = max(0.0, 1.0 - (problem_count / total_words))
-    
+
     return score, issues[:10]  # Limit to 10 examples
 
 
 def assess_whitespace_quality(text: str) -> Tuple[float, List[str]]:
     """
     Assess whitespace handling quality by detecting excessive or missing whitespace.
-    
+
     Args:
         text: Text to analyze
-        
+
     Returns:
         Tuple of (score, issues_list) where score is 0-1
     """
     issues = []
-    
+
     # Check for excessive newlines
-    excessive_newlines = len(re.findall(r'\n{3,}', text))
+    excessive_newlines = len(re.findall(r"\n{3,}", text))
     if excessive_newlines > 0:
-        issues.append(f"Found {excessive_newlines} instances of 3+ consecutive newlines")
-    
+        issues.append(
+            f"Found {excessive_newlines} instances of 3+ consecutive newlines"
+        )
+
     # Check for missing spaces after punctuation
-    missing_spaces = len(re.findall(r'[.!?][a-zA-Z]', text))
+    missing_spaces = len(re.findall(r"[.!?][a-zA-Z]", text))
     if missing_spaces > 0:
-        issues.append(f"Found {missing_spaces} instances of missing spaces after punctuation")
-    
+        issues.append(
+            f"Found {missing_spaces} instances of missing spaces after punctuation"
+        )
+
     # Check for excessive spaces
-    excessive_spaces = len(re.findall(r' {3,}', text))
+    excessive_spaces = len(re.findall(r" {3,}", text))
     if excessive_spaces > 0:
         issues.append(f"Found {excessive_spaces} instances of 3+ consecutive spaces")
-    
+
     # Check for tabs mixed with spaces (inconsistent indentation)
-    mixed_whitespace = '\t' in text and '  ' in text
+    mixed_whitespace = "\t" in text and "  " in text
     if mixed_whitespace:
         issues.append("Mixed tabs and spaces detected")
-    
+
     # Check for trailing whitespace on lines
-    lines = text.split('\n')
-    trailing_whitespace = sum(1 for line in lines if line.endswith(' ') or line.endswith('\t'))
+    lines = text.split("\n")
+    trailing_whitespace = sum(
+        1 for line in lines if line.endswith(" ") or line.endswith("\t")
+    )
     if trailing_whitespace > len(lines) * 0.1:  # More than 10% of lines
         issues.append(f"Excessive trailing whitespace on {trailing_whitespace} lines")
-    
+
     # Calculate score based on issues found
-    total_issues = excessive_newlines + missing_spaces + excessive_spaces + trailing_whitespace
+    total_issues = (
+        excessive_newlines + missing_spaces + excessive_spaces + trailing_whitespace
+    )
     if mixed_whitespace:
         total_issues += 1
-    
+
     # Normalize by text length
     text_length = len(text)
     if text_length == 0:
         return 0.0, ["No text to analyze"]
-    
+
     issue_density = total_issues / (text_length / 1000)  # Issues per 1000 characters
     score = max(0.0, 1.0 - min(issue_density, 1.0))
-    
+
     return score, issues[:8]  # Limit to 8 examples
 
 
 def assess_ligature_translation(text: str) -> Tuple[float, List[str]]:
     """
     Assess ligature translation quality by detecting untranslated ligatures.
-    
+
     Args:
         text: Text to analyze
-        
+
     Returns:
         Tuple of (score, issues_list) where score is 0-1
     """
     issues = []
-    
+
     # Common ligatures that should be translated
     ligatures = {
-        'ﬁ': 'fi',
-        'ﬂ': 'fl',
-        'ﬀ': 'ff',
-        'ﬃ': 'ffi',
-        'ﬄ': 'ffl',
-        'ﬆ': 'st',
-        'ﬅ': 'ft',
-        '﬈': 'ft',
-        'ﬗ': 'et',
-        'ﬞ': 'at'
+        "ﬁ": "fi",
+        "ﬂ": "fl",
+        "ﬀ": "ff",
+        "ﬃ": "ffi",
+        "ﬄ": "ffl",
+        "ﬆ": "st",
+        "ﬅ": "ft",
+        "﬈": "ft",
+        "ﬗ": "et",
+        "ﬞ": "at",
     }
-    
+
     total_chars = len(text)
     if total_chars == 0:
         return 0.0, ["No text to analyze"]
-    
+
     untranslated_count = 0
-    
+
     for ligature, replacement in ligatures.items():
         count = text.count(ligature)
         if count > 0:
             untranslated_count += count
-            issues.append(f"Untranslated ligature '{ligature}' found {count} times (should be '{replacement}')")
-    
+            issues.append(
+                f"Untranslated ligature '{ligature}' found {count} times (should be '{replacement}')"
+            )
+
     # Also check for other Unicode ligature characters
-    unicode_ligatures = re.findall(r'[\uFB00-\uFB4F]', text)
+    unicode_ligatures = re.findall(r"[\uFB00-\uFB4F]", text)
     if unicode_ligatures:
         unique_ligatures = set(unicode_ligatures)
         untranslated_count += len(unicode_ligatures)
         issues.append(f"Other Unicode ligatures found: {list(unique_ligatures)}")
-    
+
     # Calculate score (higher is better)
     ligature_density = untranslated_count / total_chars
-    score = max(0.0, 1.0 - min(ligature_density * 1000, 1.0))  # Scale by 1000 for reasonable scoring
-    
+    score = max(
+        0.0, 1.0 - min(ligature_density * 1000, 1.0)
+    )  # Scale by 1000 for reasonable scoring
+
     return score, issues[:5]  # Limit to 5 examples
 
 
 def assess_header_footer_contamination(text: str) -> Tuple[float, List[str]]:
     """
     Assess header/footer contamination by detecting repeated patterns and page artifacts.
-    
+
     Args:
         text: Text to analyze
-        
+
     Returns:
         Tuple of (score, issues_list) where score is 0-1
     """
     issues = []
-    
-    lines = text.split('\n')
+
+    lines = text.split("\n")
     if len(lines) < 3:
         return 1.0, []  # Too short to have header/footer issues
-    
+
     # Check for repeated short lines (likely headers/footers)
     line_counts = {}
     for line in lines:
         stripped = line.strip()
-        if stripped and len(stripped) < 50:  # Short lines more likely to be headers/footers
+        if (
+            stripped and len(stripped) < 50
+        ):  # Short lines more likely to be headers/footers
             line_counts[stripped] = line_counts.get(stripped, 0) + 1
-    
+
     repeated_lines = [(line, count) for line, count in line_counts.items() if count > 1]
     contamination_score = 0
-    
+
     for line, count in repeated_lines:
         if count > 2:  # Repeated more than twice
             contamination_score += count
-            issues.append(f"Repeated line '{line}' appears {count} times (likely header/footer)")
-    
+            issues.append(
+                f"Repeated line '{line}' appears {count} times (likely header/footer)"
+            )
+
     # Check for page numbers in text
-    page_numbers = re.findall(r'\b(?:page\s+)?\d+\b', text, re.IGNORECASE)
-    isolated_numbers = [num for num in page_numbers if re.match(r'^\d+$', num.strip())]
+    page_numbers = re.findall(r"\b(?:page\s+)?\d+\b", text, re.IGNORECASE)
+    isolated_numbers = [num for num in page_numbers if re.match(r"^\d+$", num.strip())]
     if len(isolated_numbers) > 3:
         contamination_score += len(isolated_numbers)
-        issues.append(f"Found {len(isolated_numbers)} isolated numbers (possible page numbers)")
-    
+        issues.append(
+            f"Found {len(isolated_numbers)} isolated numbers (possible page numbers)"
+        )
+
     # Check for common header/footer patterns
     header_footer_patterns = [
-        r'\b(?:chapter|section)\s+\d+\b',
-        r'\b\d{1,2}/\d{1,2}/\d{2,4}\b',  # Dates
-        r'\b\d{1,2}:\d{2}\s*(?:AM|PM)?\b',  # Times
-        r'\b(?:copyright|©)\b',
-        r'\b(?:confidential|draft|preliminary)\b'
+        r"\b(?:chapter|section)\s+\d+\b",
+        r"\b\d{1,2}/\d{1,2}/\d{2,4}\b",  # Dates
+        r"\b\d{1,2}:\d{2}\s*(?:AM|PM)?\b",  # Times
+        r"\b(?:copyright|©)\b",
+        r"\b(?:confidential|draft|preliminary)\b",
     ]
-    
+
     for pattern in header_footer_patterns:
         matches = re.findall(pattern, text, re.IGNORECASE)
         if matches:
             contamination_score += len(matches)
-            issues.append(f"Header/footer pattern found: {matches[:3]}")  # Show first 3 matches
-    
+            issues.append(
+                f"Header/footer pattern found: {matches[:3]}"
+            )  # Show first 3 matches
+
     # Calculate score (higher is better, lower contamination)
     total_lines = len(lines)
     contamination_ratio = contamination_score / total_lines
     score = max(0.0, 1.0 - min(contamination_ratio, 1.0))
-    
+
     return score, issues[:8]  # Limit to 8 examples
 
 
-def analyze_text_quality(chunks: List[Dict[str, Any]], method_name: str, pdf_file: str) -> TextQualityMetrics:
+def analyze_text_quality(
+    chunks: List[Dict[str, Any]], method_name: str, pdf_file: str
+) -> TextQualityMetrics:
     """
     Analyze text quality for a list of chunks.
-    
+
     Args:
         chunks: List of text chunks with metadata
         method_name: Name of extraction method
         pdf_file: PDF file name
-        
+
     Returns:
         TextQualityMetrics with quality assessment
     """
@@ -415,41 +440,49 @@ def analyze_text_quality(chunks: List[Dict[str, Any]], method_name: str, pdf_fil
             header_footer_contamination_score=0.0,
             overall_quality_score=0.0,
             issues_detected=["No chunks extracted"],
-            sample_issues=[]
+            sample_issues=[],
         )
-    
+
     # Combine all text for analysis
-    all_text = '\n'.join(chunk.get('text', '') for chunk in chunks)
+    all_text = "\n".join(chunk.get("text", "") for chunk in chunks)
     total_text_length = len(all_text)
     avg_chunk_length = total_text_length / len(chunks) if chunks else 0
-    
+
     # Assess different quality dimensions
     sentence_score, sentence_issues = assess_sentence_integrity(all_text)
     word_score, word_issues = assess_word_joining(all_text)
     whitespace_score, whitespace_issues = assess_whitespace_quality(all_text)
     ligature_score, ligature_issues = assess_ligature_translation(all_text)
-    contamination_score, contamination_issues = assess_header_footer_contamination(all_text)
-    
+    contamination_score, contamination_issues = assess_header_footer_contamination(
+        all_text
+    )
+
     # Calculate overall quality score (weighted average)
     weights = {
-        'sentence': 0.3,
-        'word': 0.25,
-        'whitespace': 0.2,
-        'ligature': 0.15,
-        'contamination': 0.1
+        "sentence": 0.3,
+        "word": 0.25,
+        "whitespace": 0.2,
+        "ligature": 0.15,
+        "contamination": 0.1,
     }
-    
+
     overall_score = (
-        sentence_score * weights['sentence'] +
-        word_score * weights['word'] +
-        whitespace_score * weights['whitespace'] +
-        ligature_score * weights['ligature'] +
-        contamination_score * weights['contamination']
+        sentence_score * weights["sentence"]
+        + word_score * weights["word"]
+        + whitespace_score * weights["whitespace"]
+        + ligature_score * weights["ligature"]
+        + contamination_score * weights["contamination"]
     )
-    
+
     # Collect all issues
-    all_issues = sentence_issues + word_issues + whitespace_issues + ligature_issues + contamination_issues
-    
+    all_issues = (
+        sentence_issues
+        + word_issues
+        + whitespace_issues
+        + ligature_issues
+        + contamination_issues
+    )
+
     # Create sample issues with categories
     sample_issues = []
     issue_categories = [
@@ -457,17 +490,23 @@ def analyze_text_quality(chunks: List[Dict[str, Any]], method_name: str, pdf_fil
         ("Word Joining", word_issues),
         ("Whitespace Quality", whitespace_issues),
         ("Ligature Translation", ligature_issues),
-        ("Header/Footer Contamination", contamination_issues)
+        ("Header/Footer Contamination", contamination_issues),
     ]
-    
+
     for category, issues in issue_categories:
         for issue in issues[:2]:  # Limit to 2 examples per category
-            sample_issues.append({
-                'category': category,
-                'issue': issue,
-                'severity': 'high' if category in ['Sentence Integrity', 'Word Joining'] else 'medium'
-            })
-    
+            sample_issues.append(
+                {
+                    "category": category,
+                    "issue": issue,
+                    "severity": (
+                        "high"
+                        if category in ["Sentence Integrity", "Word Joining"]
+                        else "medium"
+                    ),
+                }
+            )
+
     return TextQualityMetrics(
         method=method_name,
         pdf_file=pdf_file,
@@ -481,249 +520,284 @@ def analyze_text_quality(chunks: List[Dict[str, Any]], method_name: str, pdf_fil
         header_footer_contamination_score=contamination_score,
         overall_quality_score=overall_score,
         issues_detected=all_issues[:15],  # Limit to 15 total issues
-        sample_issues=sample_issues[:10]  # Limit to 10 sample issues
+        sample_issues=sample_issues[:10],  # Limit to 10 sample issues
     )
 
 
 def compare_text_quality(
-    hybrid_metrics: TextQualityMetrics,
-    traditional_metrics: TextQualityMetrics
+    hybrid_metrics: TextQualityMetrics, traditional_metrics: TextQualityMetrics
 ) -> Dict[str, Any]:
     """
     Compare text quality between hybrid and traditional methods.
-    
+
     Args:
         hybrid_metrics: Quality metrics for hybrid method
         traditional_metrics: Quality metrics for traditional method
-        
+
     Returns:
         Comparison analysis
     """
     comparison = {
-        'overall_comparison': {},
-        'dimension_comparison': {},
-        'recommendations': [],
-        'quality_summary': {}
+        "overall_comparison": {},
+        "dimension_comparison": {},
+        "recommendations": [],
+        "quality_summary": {},
     }
-    
+
     # Overall comparison
     hybrid_overall = hybrid_metrics.overall_quality_score
     traditional_overall = traditional_metrics.overall_quality_score
-    
-    comparison['overall_comparison'] = {
-        'hybrid_score': hybrid_overall,
-        'traditional_score': traditional_overall,
-        'difference': hybrid_overall - traditional_overall,
-        'better_method': 'hybrid' if hybrid_overall > traditional_overall else 'traditional',
-        'improvement_percentage': abs(hybrid_overall - traditional_overall) * 100
+
+    comparison["overall_comparison"] = {
+        "hybrid_score": hybrid_overall,
+        "traditional_score": traditional_overall,
+        "difference": hybrid_overall - traditional_overall,
+        "better_method": (
+            "hybrid" if hybrid_overall > traditional_overall else "traditional"
+        ),
+        "improvement_percentage": abs(hybrid_overall - traditional_overall) * 100,
     }
-    
+
     # Dimension-by-dimension comparison
     dimensions = [
-        ('sentence_integrity', 'Sentence Integrity'),
-        ('word_joining', 'Word Joining'),
-        ('whitespace_quality', 'Whitespace Quality'),
-        ('ligature_translation', 'Ligature Translation'),
-        ('header_footer_contamination', 'Header/Footer Contamination')
+        ("sentence_integrity", "Sentence Integrity"),
+        ("word_joining", "Word Joining"),
+        ("whitespace_quality", "Whitespace Quality"),
+        ("ligature_translation", "Ligature Translation"),
+        ("header_footer_contamination", "Header/Footer Contamination"),
     ]
-    
+
     dimension_results = {}
     for dim_key, dim_name in dimensions:
-        hybrid_score = getattr(hybrid_metrics, f'{dim_key}_score')
-        traditional_score = getattr(traditional_metrics, f'{dim_key}_score')
-        
+        hybrid_score = getattr(hybrid_metrics, f"{dim_key}_score")
+        traditional_score = getattr(traditional_metrics, f"{dim_key}_score")
+
         dimension_results[dim_key] = {
-            'name': dim_name,
-            'hybrid_score': hybrid_score,
-            'traditional_score': traditional_score,
-            'difference': hybrid_score - traditional_score,
-            'better_method': 'hybrid' if hybrid_score > traditional_score else 'traditional'
+            "name": dim_name,
+            "hybrid_score": hybrid_score,
+            "traditional_score": traditional_score,
+            "difference": hybrid_score - traditional_score,
+            "better_method": (
+                "hybrid" if hybrid_score > traditional_score else "traditional"
+            ),
         }
-    
-    comparison['dimension_comparison'] = dimension_results
-    
+
+    comparison["dimension_comparison"] = dimension_results
+
     # Generate recommendations
     recommendations = []
-    
+
     # Overall recommendation
     if hybrid_overall > traditional_overall + 0.05:  # 5% threshold
-        recommendations.append(f"Hybrid method shows {(hybrid_overall - traditional_overall) * 100:.1f}% better overall text quality")
+        recommendations.append(
+            f"Hybrid method shows {(hybrid_overall - traditional_overall) * 100:.1f}% better overall text quality"
+        )
     elif traditional_overall > hybrid_overall + 0.05:
-        recommendations.append(f"Traditional method shows {(traditional_overall - hybrid_overall) * 100:.1f}% better overall text quality")
+        recommendations.append(
+            f"Traditional method shows {(traditional_overall - hybrid_overall) * 100:.1f}% better overall text quality"
+        )
     else:
         recommendations.append("Both methods show similar overall text quality")
-    
+
     # Dimension-specific recommendations
     for dim_key, dim_data in dimension_results.items():
-        if abs(dim_data['difference']) > 0.1:  # 10% threshold
-            better = dim_data['better_method']
-            improvement = abs(dim_data['difference']) * 100
-            recommendations.append(f"{better.title()} method is {improvement:.1f}% better at {dim_data['name'].lower()}")
-    
+        if abs(dim_data["difference"]) > 0.1:  # 10% threshold
+            better = dim_data["better_method"]
+            improvement = abs(dim_data["difference"]) * 100
+            recommendations.append(
+                f"{better.title()} method is {improvement:.1f}% better at {dim_data['name'].lower()}"
+            )
+
     # Issue-based recommendations
     hybrid_issue_count = len(hybrid_metrics.issues_detected)
     traditional_issue_count = len(traditional_metrics.issues_detected)
-    
+
     if hybrid_issue_count < traditional_issue_count:
-        recommendations.append(f"Hybrid method has {traditional_issue_count - hybrid_issue_count} fewer quality issues")
+        recommendations.append(
+            f"Hybrid method has {traditional_issue_count - hybrid_issue_count} fewer quality issues"
+        )
     elif traditional_issue_count < hybrid_issue_count:
-        recommendations.append(f"Traditional method has {hybrid_issue_count - traditional_issue_count} fewer quality issues")
-    
-    comparison['recommendations'] = recommendations
-    
+        recommendations.append(
+            f"Traditional method has {hybrid_issue_count - traditional_issue_count} fewer quality issues"
+        )
+
+    comparison["recommendations"] = recommendations
+
     # Quality summary
-    comparison['quality_summary'] = {
-        'hybrid_chunks': hybrid_metrics.total_chunks,
-        'traditional_chunks': traditional_metrics.total_chunks,
-        'hybrid_text_length': hybrid_metrics.total_text_length,
-        'traditional_text_length': traditional_metrics.total_text_length,
-        'hybrid_avg_chunk_length': hybrid_metrics.avg_chunk_length,
-        'traditional_avg_chunk_length': traditional_metrics.avg_chunk_length,
-        'hybrid_issue_count': len(hybrid_metrics.issues_detected),
-        'traditional_issue_count': len(traditional_metrics.issues_detected)
+    comparison["quality_summary"] = {
+        "hybrid_chunks": hybrid_metrics.total_chunks,
+        "traditional_chunks": traditional_metrics.total_chunks,
+        "hybrid_text_length": hybrid_metrics.total_text_length,
+        "traditional_text_length": traditional_metrics.total_text_length,
+        "hybrid_avg_chunk_length": hybrid_metrics.avg_chunk_length,
+        "traditional_avg_chunk_length": traditional_metrics.avg_chunk_length,
+        "hybrid_issue_count": len(hybrid_metrics.issues_detected),
+        "traditional_issue_count": len(traditional_metrics.issues_detected),
     }
-    
+
     return comparison
 
 
 def generate_detailed_examples(
     hybrid_chunks: List[Dict[str, Any]],
     traditional_chunks: List[Dict[str, Any]],
-    pdf_file: str
+    pdf_file: str,
 ) -> List[Dict[str, Any]]:
     """
     Generate detailed examples showing text quality differences.
-    
+
     Args:
         hybrid_chunks: Chunks from hybrid method
         traditional_chunks: Chunks from traditional method
         pdf_file: PDF file name
-        
+
     Returns:
         List of detailed comparison examples
     """
     examples = []
-    
+
     # Compare first few chunks for detailed analysis
     max_examples = min(3, len(hybrid_chunks), len(traditional_chunks))
-    
+
     for i in range(max_examples):
-        hybrid_text = hybrid_chunks[i].get('text', '')
-        traditional_text = traditional_chunks[i].get('text', '')
-        
+        hybrid_text = hybrid_chunks[i].get("text", "")
+        traditional_text = traditional_chunks[i].get("text", "")
+
         # Analyze differences
         example = {
-            'chunk_index': i,
-            'pdf_file': pdf_file,
-            'hybrid_text_preview': hybrid_text[:200] + '...' if len(hybrid_text) > 200 else hybrid_text,
-            'traditional_text_preview': traditional_text[:200] + '...' if len(traditional_text) > 200 else traditional_text,
-            'length_comparison': {
-                'hybrid_length': len(hybrid_text),
-                'traditional_length': len(traditional_text),
-                'difference': len(hybrid_text) - len(traditional_text)
+            "chunk_index": i,
+            "pdf_file": pdf_file,
+            "hybrid_text_preview": (
+                hybrid_text[:200] + "..." if len(hybrid_text) > 200 else hybrid_text
+            ),
+            "traditional_text_preview": (
+                traditional_text[:200] + "..."
+                if len(traditional_text) > 200
+                else traditional_text
+            ),
+            "length_comparison": {
+                "hybrid_length": len(hybrid_text),
+                "traditional_length": len(traditional_text),
+                "difference": len(hybrid_text) - len(traditional_text),
             },
-            'quality_differences': []
+            "quality_differences": [],
         }
-        
+
         # Check for specific quality differences
-        
+
         # Sentence count comparison
-        hybrid_sentences = len(re.split(r'[.!?]+', hybrid_text))
-        traditional_sentences = len(re.split(r'[.!?]+', traditional_text))
+        hybrid_sentences = len(re.split(r"[.!?]+", hybrid_text))
+        traditional_sentences = len(re.split(r"[.!?]+", traditional_text))
         if abs(hybrid_sentences - traditional_sentences) > 1:
-            example['quality_differences'].append({
-                'type': 'sentence_count',
-                'hybrid_value': hybrid_sentences,
-                'traditional_value': traditional_sentences,
-                'description': f"Sentence count differs: hybrid={hybrid_sentences}, traditional={traditional_sentences}"
-            })
-        
+            example["quality_differences"].append(
+                {
+                    "type": "sentence_count",
+                    "hybrid_value": hybrid_sentences,
+                    "traditional_value": traditional_sentences,
+                    "description": f"Sentence count differs: hybrid={hybrid_sentences}, traditional={traditional_sentences}",
+                }
+            )
+
         # Word count comparison
         hybrid_words = len(hybrid_text.split())
         traditional_words = len(traditional_text.split())
         if abs(hybrid_words - traditional_words) > 5:
-            example['quality_differences'].append({
-                'type': 'word_count',
-                'hybrid_value': hybrid_words,
-                'traditional_value': traditional_words,
-                'description': f"Word count differs: hybrid={hybrid_words}, traditional={traditional_words}"
-            })
-        
+            example["quality_differences"].append(
+                {
+                    "type": "word_count",
+                    "hybrid_value": hybrid_words,
+                    "traditional_value": traditional_words,
+                    "description": f"Word count differs: hybrid={hybrid_words}, traditional={traditional_words}",
+                }
+            )
+
         # Newline count comparison
-        hybrid_newlines = hybrid_text.count('\n')
-        traditional_newlines = traditional_text.count('\n')
+        hybrid_newlines = hybrid_text.count("\n")
+        traditional_newlines = traditional_text.count("\n")
         if abs(hybrid_newlines - traditional_newlines) > 2:
-            example['quality_differences'].append({
-                'type': 'newline_count',
-                'hybrid_value': hybrid_newlines,
-                'traditional_value': traditional_newlines,
-                'description': f"Newline count differs: hybrid={hybrid_newlines}, traditional={traditional_newlines}"
-            })
-        
+            example["quality_differences"].append(
+                {
+                    "type": "newline_count",
+                    "hybrid_value": hybrid_newlines,
+                    "traditional_value": traditional_newlines,
+                    "description": f"Newline count differs: hybrid={hybrid_newlines}, traditional={traditional_newlines}",
+                }
+            )
+
         examples.append(example)
-    
+
     return examples
 
 
 def run_text_quality_comparison(pdf_files: List[str]) -> List[QualityComparison]:
     """
     Run complete text quality comparison for multiple PDF files.
-    
+
     Args:
         pdf_files: List of PDF files to analyze
-        
+
     Returns:
         List of quality comparison results
     """
     results = []
-    
+
     for pdf_file in pdf_files:
         print(f"Analyzing text quality for: {os.path.basename(pdf_file)}")
-        
+
         if not os.path.exists(pdf_file):
             print(f"  WARNING: File not found: {pdf_file}")
             continue
-        
+
         # Extract with both methods
         print("  Extracting with hybrid method...")
         hybrid_chunks = extract_with_hybrid_method(pdf_file)
-        
+
         print("  Extracting with traditional method...")
         traditional_chunks = extract_with_traditional_method(pdf_file)
-        
+
         if not hybrid_chunks and not traditional_chunks:
             print(f"  WARNING: Both extraction methods failed for {pdf_file}")
             continue
-        
+
         # Analyze text quality
         print("  Analyzing hybrid text quality...")
-        hybrid_metrics = analyze_text_quality(hybrid_chunks, "hybrid_pymupdf4llm", os.path.basename(pdf_file))
-        
+        hybrid_metrics = analyze_text_quality(
+            hybrid_chunks, "hybrid_pymupdf4llm", os.path.basename(pdf_file)
+        )
+
         print("  Analyzing traditional text quality...")
-        traditional_metrics = analyze_text_quality(traditional_chunks, "traditional_fallback", os.path.basename(pdf_file))
-        
+        traditional_metrics = analyze_text_quality(
+            traditional_chunks, "traditional_fallback", os.path.basename(pdf_file)
+        )
+
         # Compare methods
         print("  Comparing text quality...")
         comparison_analysis = compare_text_quality(hybrid_metrics, traditional_metrics)
-        
+
         # Generate detailed examples
-        detailed_examples = generate_detailed_examples(hybrid_chunks, traditional_chunks, os.path.basename(pdf_file))
-        
+        detailed_examples = generate_detailed_examples(
+            hybrid_chunks, traditional_chunks, os.path.basename(pdf_file)
+        )
+
         # Create comparison result
         result = QualityComparison(
             hybrid_metrics=hybrid_metrics,
             traditional_metrics=traditional_metrics,
             comparison_analysis=comparison_analysis,
-            detailed_examples=detailed_examples
+            detailed_examples=detailed_examples,
         )
-        
+
         results.append(result)
-        
+
         # Print summary
         print(f"  Hybrid overall quality: {hybrid_metrics.overall_quality_score:.2f}")
-        print(f"  Traditional overall quality: {traditional_metrics.overall_quality_score:.2f}")
-        print(f"  Better method: {comparison_analysis['overall_comparison']['better_method']}")
-    
+        print(
+            f"  Traditional overall quality: {traditional_metrics.overall_quality_score:.2f}"
+        )
+        print(
+            f"  Better method: {comparison_analysis['overall_comparison']['better_method']}"
+        )
+
     return results
 
 
@@ -732,74 +806,94 @@ def print_quality_summary(results: List[QualityComparison]):
     if not results:
         print("No results to display")
         return
-    
-    print("\n" + "="*80)
+
+    print("\n" + "=" * 80)
     print("TEXT QUALITY COMPARISON RESULTS")
-    print("="*80)
-    
+    print("=" * 80)
+
     for i, result in enumerate(results):
         hybrid = result.hybrid_metrics
         traditional = result.traditional_metrics
         comparison = result.comparison_analysis
-        
+
         print(f"\nFile {i+1}: {hybrid.pdf_file}")
         print("-" * 40)
-        
+
         # Overall scores
         print(f"Overall Quality Scores:")
         print(f"  Hybrid (PyMuPDF4LLM): {hybrid.overall_quality_score:.3f}")
         print(f"  Traditional:          {traditional.overall_quality_score:.3f}")
-        print(f"  Better method:        {comparison['overall_comparison']['better_method'].title()}")
-        print(f"  Improvement:          {comparison['overall_comparison']['improvement_percentage']:.1f}%")
-        
+        print(
+            f"  Better method:        {comparison['overall_comparison']['better_method'].title()}"
+        )
+        print(
+            f"  Improvement:          {comparison['overall_comparison']['improvement_percentage']:.1f}%"
+        )
+
         # Dimension scores
         print(f"\nDimension Scores:")
-        dimensions = comparison['dimension_comparison']
+        dimensions = comparison["dimension_comparison"]
         for dim_key, dim_data in dimensions.items():
             print(f"  {dim_data['name']}:")
-            print(f"    Hybrid: {dim_data['hybrid_score']:.3f}, Traditional: {dim_data['traditional_score']:.3f}")
+            print(
+                f"    Hybrid: {dim_data['hybrid_score']:.3f}, Traditional: {dim_data['traditional_score']:.3f}"
+            )
             print(f"    Better: {dim_data['better_method'].title()}")
-        
+
         # Content statistics
         print(f"\nContent Statistics:")
-        summary = comparison['quality_summary']
-        print(f"  Chunks:     Hybrid={summary['hybrid_chunks']}, Traditional={summary['traditional_chunks']}")
-        print(f"  Text length: Hybrid={summary['hybrid_text_length']}, Traditional={summary['traditional_text_length']}")
-        print(f"  Avg chunk:  Hybrid={summary['hybrid_avg_chunk_length']:.0f}, Traditional={summary['traditional_avg_chunk_length']:.0f}")
-        print(f"  Issues:     Hybrid={summary['hybrid_issue_count']}, Traditional={summary['traditional_issue_count']}")
-        
+        summary = comparison["quality_summary"]
+        print(
+            f"  Chunks:     Hybrid={summary['hybrid_chunks']}, Traditional={summary['traditional_chunks']}"
+        )
+        print(
+            f"  Text length: Hybrid={summary['hybrid_text_length']}, Traditional={summary['traditional_text_length']}"
+        )
+        print(
+            f"  Avg chunk:  Hybrid={summary['hybrid_avg_chunk_length']:.0f}, Traditional={summary['traditional_avg_chunk_length']:.0f}"
+        )
+        print(
+            f"  Issues:     Hybrid={summary['hybrid_issue_count']}, Traditional={summary['traditional_issue_count']}"
+        )
+
         # Key recommendations
-        recommendations = comparison['recommendations']
+        recommendations = comparison["recommendations"]
         if recommendations:
             print(f"\nKey Findings:")
             for j, rec in enumerate(recommendations[:3], 1):  # Show top 3
                 print(f"  {j}. {rec}")
-    
+
     # Overall summary across all files
     if len(results) > 1:
-        print(f"\n" + "="*80)
+        print(f"\n" + "=" * 80)
         print("OVERALL SUMMARY")
-        print("="*80)
-        
+        print("=" * 80)
+
         hybrid_scores = [r.hybrid_metrics.overall_quality_score for r in results]
-        traditional_scores = [r.traditional_metrics.overall_quality_score for r in results]
-        
+        traditional_scores = [
+            r.traditional_metrics.overall_quality_score for r in results
+        ]
+
         avg_hybrid = statistics.mean(hybrid_scores)
         avg_traditional = statistics.mean(traditional_scores)
-        
+
         print(f"Average Quality Scores:")
         print(f"  Hybrid:     {avg_hybrid:.3f}")
         print(f"  Traditional: {avg_traditional:.3f}")
         print(f"  Difference: {avg_hybrid - avg_traditional:+.3f}")
-        
-        hybrid_wins = sum(1 for r in results if r.comparison_analysis['overall_comparison']['better_method'] == 'hybrid')
+
+        hybrid_wins = sum(
+            1
+            for r in results
+            if r.comparison_analysis["overall_comparison"]["better_method"] == "hybrid"
+        )
         traditional_wins = len(results) - hybrid_wins
-        
+
         print(f"\nMethod Performance:")
         print(f"  Hybrid wins:     {hybrid_wins}/{len(results)} files")
         print(f"  Traditional wins: {traditional_wins}/{len(results)} files")
-    
-    print("\n" + "="*80)
+
+    print("\n" + "=" * 80)
 
 
 def main():
@@ -808,28 +902,25 @@ def main():
         description="Compare text quality between hybrid PyMuPDF4LLM and traditional PDF extraction methods"
     )
     parser.add_argument(
-        'pdf_files',
-        nargs='+',
-        help='PDF files to analyze for text quality'
+        "pdf_files", nargs="+", help="PDF files to analyze for text quality"
     )
     parser.add_argument(
-        '--output', '-o',
-        default='text_quality_comparison.json',
-        help='Output file for detailed results (default: text_quality_comparison.json)'
+        "--output",
+        "-o",
+        default="text_quality_comparison.json",
+        help="Output file for detailed results (default: text_quality_comparison.json)",
     )
     parser.add_argument(
-        '--detailed',
-        action='store_true',
-        help='Include detailed text examples in output'
+        "--detailed",
+        action="store_true",
+        help="Include detailed text examples in output",
     )
     parser.add_argument(
-        '--quiet', '-q',
-        action='store_true',
-        help='Suppress detailed output'
+        "--quiet", "-q", action="store_true", help="Suppress detailed output"
     )
-    
+
     args = parser.parse_args()
-    
+
     # Validate PDF files
     valid_files = []
     for pdf_file in args.pdf_files:
@@ -837,64 +928,82 @@ def main():
             valid_files.append(pdf_file)
         else:
             print(f"WARNING: File not found: {pdf_file}")
-    
+
     if not valid_files:
         print("ERROR: No valid PDF files found")
         sys.exit(1)
-    
+
     # Run text quality comparison
     try:
         results = run_text_quality_comparison(valid_files)
-        
+
         if not results:
             print("ERROR: No comparison results generated")
             sys.exit(1)
-        
+
         # Prepare output data
         output_data = {
-            'comparison_date': '2025-07-20T15:47:07Z',
-            'files_analyzed': [os.path.basename(f) for f in valid_files],
-            'total_comparisons': len(results),
-            'results': [result.to_dict() for result in results]
+            "comparison_date": "2025-07-20T15:47:07Z",
+            "files_analyzed": [os.path.basename(f) for f in valid_files],
+            "total_comparisons": len(results),
+            "results": [result.to_dict() for result in results],
         }
-        
+
         # Add summary statistics
         if results:
             hybrid_scores = [r.hybrid_metrics.overall_quality_score for r in results]
-            traditional_scores = [r.traditional_metrics.overall_quality_score for r in results]
-            
-            output_data['summary_statistics'] = {
-                'average_hybrid_quality': statistics.mean(hybrid_scores),
-                'average_traditional_quality': statistics.mean(traditional_scores),
-                'hybrid_wins': sum(1 for r in results if r.comparison_analysis['overall_comparison']['better_method'] == 'hybrid'),
-                'traditional_wins': sum(1 for r in results if r.comparison_analysis['overall_comparison']['better_method'] == 'traditional'),
-                'quality_improvement': statistics.mean(hybrid_scores) - statistics.mean(traditional_scores)
+            traditional_scores = [
+                r.traditional_metrics.overall_quality_score for r in results
+            ]
+
+            output_data["summary_statistics"] = {
+                "average_hybrid_quality": statistics.mean(hybrid_scores),
+                "average_traditional_quality": statistics.mean(traditional_scores),
+                "hybrid_wins": sum(
+                    1
+                    for r in results
+                    if r.comparison_analysis["overall_comparison"]["better_method"]
+                    == "hybrid"
+                ),
+                "traditional_wins": sum(
+                    1
+                    for r in results
+                    if r.comparison_analysis["overall_comparison"]["better_method"]
+                    == "traditional"
+                ),
+                "quality_improvement": statistics.mean(hybrid_scores)
+                - statistics.mean(traditional_scores),
             }
-        
+
         # Save detailed results
-        with open(args.output, 'w') as f:
+        with open(args.output, "w") as f:
             json.dump(output_data, f, indent=2)
-        
+
         if not args.quiet:
             print_quality_summary(results)
-        
+
         print(f"\nDetailed results saved to: {args.output}")
-        
+
         # Exit with appropriate code based on results
         if results:
-            avg_hybrid = statistics.mean([r.hybrid_metrics.overall_quality_score for r in results])
-            avg_traditional = statistics.mean([r.traditional_metrics.overall_quality_score for r in results])
-            
+            avg_hybrid = statistics.mean(
+                [r.hybrid_metrics.overall_quality_score for r in results]
+            )
+            avg_traditional = statistics.mean(
+                [r.traditional_metrics.overall_quality_score for r in results]
+            )
+
             if avg_hybrid < 0.5 or avg_traditional < 0.5:
                 print("WARNING: Low text quality scores detected")
                 sys.exit(1)
-        
+
     except Exception as e:
         print(f"ERROR: Text quality comparison failed: {e}")
         import traceback
+
         traceback.print_exc()
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/detect_duplicates.py
+++ b/scripts/detect_duplicates.py
@@ -21,14 +21,14 @@ def load_chunks(jsonl_file: str) -> List[Dict]:
     """Load chunks from JSONL file."""
     chunks = []
     try:
-        with open(jsonl_file, 'r', encoding='utf-8') as f:
+        with open(jsonl_file, "r", encoding="utf-8") as f:
             for line_num, line in enumerate(f, 1):
                 line = line.strip()
                 if not line:
                     continue
                 try:
                     chunk = json.loads(line)
-                    chunk['_line_number'] = line_num
+                    chunk["_line_number"] = line_num
                     chunks.append(chunk)
                 except json.JSONDecodeError as e:
                     print(f"Warning: Invalid JSON on line {line_num}: {e}")
@@ -39,7 +39,7 @@ def load_chunks(jsonl_file: str) -> List[Dict]:
     except Exception as e:
         print(f"Error reading file '{jsonl_file}': {e}")
         sys.exit(1)
-    
+
     return chunks
 
 
@@ -47,121 +47,150 @@ def create_sliding_windows(text: str, window_size: int = 50) -> List[str]:
     """Create sliding windows of text for overlap detection."""
     if len(text) < window_size:
         return [text.strip()]
-    
+
     windows = []
     words = text.split()
-    
+
     for i in range(len(words) - window_size + 1):
-        window = ' '.join(words[i:i + window_size])
+        window = " ".join(words[i : i + window_size])
         windows.append(window.strip())
-    
+
     return windows
 
 
-def detect_duplications(chunks: List[Dict], window_size: int = 50, min_overlap: int = 20) -> List[Dict]:
+def detect_duplications(
+    chunks: List[Dict], window_size: int = 50, min_overlap: int = 20
+) -> List[Dict]:
     """
     Detect content duplications between chunks using sliding window approach.
-    
+
     Args:
         chunks: List of chunk dictionaries
         window_size: Size of sliding window in words
         min_overlap: Minimum overlap size in words to report as duplication
-    
+
     Returns:
         List of duplication reports
     """
     duplications = []
     window_to_chunks = defaultdict(list)
-    
+
     # Create sliding windows for each chunk
     for i, chunk in enumerate(chunks):
-        text = chunk.get('text', '')
+        text = chunk.get("text", "")
         if not text.strip():
             continue
-            
+
         windows = create_sliding_windows(text, window_size)
-        
+
         for window_idx, window in enumerate(windows):
             if len(window.split()) >= min_overlap:
-                window_to_chunks[window].append({
-                    'chunk_index': i,
-                    'chunk_line': chunk.get('_line_number', i + 1),
-                    'window_index': window_idx,
-                    'text_preview': window[:100] + '...' if len(window) > 100 else window
-                })
-    
+                window_to_chunks[window].append(
+                    {
+                        "chunk_index": i,
+                        "chunk_line": chunk.get("_line_number", i + 1),
+                        "window_index": window_idx,
+                        "text_preview": (
+                            window[:100] + "..." if len(window) > 100 else window
+                        ),
+                    }
+                )
+
     # Find duplicated windows
     for window, chunk_list in window_to_chunks.items():
         if len(chunk_list) > 1:
             # Multiple chunks contain this window - potential duplication
             duplication = {
-                'duplicated_text': window[:200] + '...' if len(window) > 200 else window,
-                'word_count': len(window.split()),
-                'occurrences': []
+                "duplicated_text": (
+                    window[:200] + "..." if len(window) > 200 else window
+                ),
+                "word_count": len(window.split()),
+                "occurrences": [],
             }
-            
+
             for occurrence in chunk_list:
-                chunk = chunks[occurrence['chunk_index']]
-                duplication['occurrences'].append({
-                    'chunk_line': occurrence['chunk_line'],
-                    'chunk_index': occurrence['chunk_index'],
-                    'window_position': occurrence['window_index'],
-                    'chunk_id': chunk.get('metadata', {}).get('chunk_id', f"chunk_{occurrence['chunk_index']}"),
-                    'chunk_preview': chunk.get('text', '')[:100] + '...' if len(chunk.get('text', '')) > 100 else chunk.get('text', '')
-                })
-            
+                chunk = chunks[occurrence["chunk_index"]]
+                duplication["occurrences"].append(
+                    {
+                        "chunk_line": occurrence["chunk_line"],
+                        "chunk_index": occurrence["chunk_index"],
+                        "window_position": occurrence["window_index"],
+                        "chunk_id": chunk.get("metadata", {}).get(
+                            "chunk_id", f"chunk_{occurrence['chunk_index']}"
+                        ),
+                        "chunk_preview": (
+                            chunk.get("text", "")[:100] + "..."
+                            if len(chunk.get("text", "")) > 100
+                            else chunk.get("text", "")
+                        ),
+                    }
+                )
+
             duplications.append(duplication)
-    
+
     # Sort by word count (largest duplications first)
-    duplications.sort(key=lambda x: x['word_count'], reverse=True)
-    
+    duplications.sort(key=lambda x: x["word_count"], reverse=True)
+
     return duplications
 
 
 def analyze_chunk_boundaries(chunks: List[Dict]) -> Dict:
     """Analyze potential boundary issues between consecutive chunks."""
     boundary_issues = []
-    
+
     for i in range(len(chunks) - 1):
         current_chunk = chunks[i]
         next_chunk = chunks[i + 1]
-        
-        current_text = current_chunk.get('text', '').strip()
-        next_text = next_chunk.get('text', '').strip()
-        
+
+        current_text = current_chunk.get("text", "").strip()
+        next_text = next_chunk.get("text", "").strip()
+
         if not current_text or not next_text:
             continue
-        
+
         # Check if next chunk starts with end of current chunk
         current_words = current_text.split()
         next_words = next_text.split()
-        
+
         # Look for overlap at boundaries
         max_check = min(20, len(current_words), len(next_words))
-        
-        for overlap_size in range(max_check, 4, -1):  # Check from large to small overlaps
-            current_end = ' '.join(current_words[-overlap_size:])
-            next_start = ' '.join(next_words[:overlap_size])
-            
+
+        for overlap_size in range(
+            max_check, 4, -1
+        ):  # Check from large to small overlaps
+            current_end = " ".join(current_words[-overlap_size:])
+            next_start = " ".join(next_words[:overlap_size])
+
             if current_end.lower() == next_start.lower():
-                boundary_issues.append({
-                    'chunk1_line': current_chunk.get('_line_number', i + 1),
-                    'chunk2_line': next_chunk.get('_line_number', i + 2),
-                    'chunk1_id': current_chunk.get('metadata', {}).get('chunk_id', f"chunk_{i}"),
-                    'chunk2_id': next_chunk.get('metadata', {}).get('chunk_id', f"chunk_{i+1}"),
-                    'overlap_words': overlap_size,
-                    'overlapping_text': current_end,
-                    'issue_type': 'boundary_overlap'
-                })
+                boundary_issues.append(
+                    {
+                        "chunk1_line": current_chunk.get("_line_number", i + 1),
+                        "chunk2_line": next_chunk.get("_line_number", i + 2),
+                        "chunk1_id": current_chunk.get("metadata", {}).get(
+                            "chunk_id", f"chunk_{i}"
+                        ),
+                        "chunk2_id": next_chunk.get("metadata", {}).get(
+                            "chunk_id", f"chunk_{i+1}"
+                        ),
+                        "overlap_words": overlap_size,
+                        "overlapping_text": current_end,
+                        "issue_type": "boundary_overlap",
+                    }
+                )
                 break
-    
+
     return {
-        'boundary_overlaps': boundary_issues,
-        'total_boundary_issues': len(boundary_issues)
+        "boundary_overlaps": boundary_issues,
+        "total_boundary_issues": len(boundary_issues),
     }
 
 
-def generate_report(chunks: List[Dict], duplications: List[Dict], boundary_analysis: Dict, jsonl_file: str):
+def generate_report(
+    chunks: List[Dict],
+    duplications: List[Dict],
+    boundary_analysis: Dict,
+    jsonl_file: str,
+):
     """Generate and print the duplication detection report."""
     print(f"\n{'='*80}")
     print(f"DUPLICATION DETECTION REPORT")
@@ -170,45 +199,49 @@ def generate_report(chunks: List[Dict], duplications: List[Dict], boundary_analy
     print(f"Total chunks analyzed: {len(chunks)}")
     print(f"Total duplications found: {len(duplications)}")
     print(f"Boundary overlap issues: {boundary_analysis['total_boundary_issues']}")
-    
+
     if duplications:
         print(f"\n{'='*60}")
         print("CONTENT DUPLICATIONS")
         print(f"{'='*60}")
-        
+
         for i, dup in enumerate(duplications[:10], 1):  # Show top 10
             print(f"\n--- Duplication #{i} ---")
             print(f"Duplicated text ({dup['word_count']} words):")
             print(f"  \"{dup['duplicated_text']}\"")
             print(f"Found in {len(dup['occurrences'])} chunks:")
-            
-            for occ in dup['occurrences']:
+
+            for occ in dup["occurrences"]:
                 print(f"  • Line {occ['chunk_line']}: {occ['chunk_id']}")
                 print(f"    Position: window {occ['window_position']}")
                 print(f"    Preview: \"{occ['chunk_preview']}\"")
-        
+
         if len(duplications) > 10:
             print(f"\n... and {len(duplications) - 10} more duplications")
-    
-    if boundary_analysis['boundary_overlaps']:
+
+    if boundary_analysis["boundary_overlaps"]:
         print(f"\n{'='*60}")
         print("BOUNDARY OVERLAP ISSUES")
         print(f"{'='*60}")
-        
-        for issue in boundary_analysis['boundary_overlaps'][:5]:  # Show top 5
+
+        for issue in boundary_analysis["boundary_overlaps"][:5]:  # Show top 5
             print(f"\nOverlap between chunks:")
             print(f"  Chunk 1 (Line {issue['chunk1_line']}): {issue['chunk1_id']}")
             print(f"  Chunk 2 (Line {issue['chunk2_line']}): {issue['chunk2_id']}")
-            print(f"  Overlapping text ({issue['overlap_words']} words): \"{issue['overlapping_text']}\"")
-        
-        if len(boundary_analysis['boundary_overlaps']) > 5:
-            print(f"\n... and {len(boundary_analysis['boundary_overlaps']) - 5} more boundary issues")
-    
-    if not duplications and not boundary_analysis['boundary_overlaps']:
+            print(
+                f"  Overlapping text ({issue['overlap_words']} words): \"{issue['overlapping_text']}\""
+            )
+
+        if len(boundary_analysis["boundary_overlaps"]) > 5:
+            print(
+                f"\n... and {len(boundary_analysis['boundary_overlaps']) - 5} more boundary issues"
+            )
+
+    if not duplications and not boundary_analysis["boundary_overlaps"]:
         print(f"\n✅ No content duplications or boundary issues detected!")
     else:
         print(f"\n⚠️  Issues detected. Review chunking algorithm for improvements.")
-    
+
     print(f"\n{'='*80}")
 
 
@@ -217,24 +250,24 @@ def main():
         print("Usage: python scripts/detect_duplicates.py <jsonl_file>")
         print("Example: python scripts/detect_duplicates.py output_chunks_pdf.jsonl")
         sys.exit(1)
-    
+
     jsonl_file = sys.argv[1]
-    
+
     print(f"Loading chunks from {jsonl_file}...")
     chunks = load_chunks(jsonl_file)
-    
+
     if not chunks:
         print("No valid chunks found in file.")
         sys.exit(1)
-    
+
     print(f"Analyzing {len(chunks)} chunks for duplications...")
-    
+
     # Detect content duplications
     duplications = detect_duplications(chunks, window_size=50, min_overlap=10)
-    
+
     # Analyze boundary issues
     boundary_analysis = analyze_chunk_boundaries(chunks)
-    
+
     # Generate report
     generate_report(chunks, duplications, boundary_analysis, jsonl_file)
 

--- a/scripts/diagnose_hyphens.py
+++ b/scripts/diagnose_hyphens.py
@@ -10,6 +10,7 @@ import json
 import sys
 from collections import Counter
 
+
 def diagnose(path):
     counts = Counter()
     with open(path, encoding="utf-8") as f:
@@ -28,9 +29,9 @@ def diagnose(path):
     for ch, cnt in counts.most_common():
         print(f"U+{ord(ch):04X}  {ch!r}    {cnt}")
 
+
 if __name__ == "__main__":
     if len(sys.argv) != 2:
         print("Usage: python diagnose_hyphens.py yourfile.jsonl")
         sys.exit(1)
     diagnose(sys.argv[1])
-

--- a/scripts/fix_newlines.py
+++ b/scripts/fix_newlines.py
@@ -23,6 +23,7 @@ import sys
 # Make sure you have `aspell` installed (`dnf install aspell`).
 SPELLER_CMD = ["aspell", "list"]
 
+
 def is_real_word(word: str) -> bool:
     """Return True if `word` is recognized by aspell."""
     # aspell list prints unknown words—so if our word does NOT show up,
@@ -31,10 +32,12 @@ def is_real_word(word: str) -> bool:
         SPELLER_CMD, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True
     )
     out, _ = p.communicate(word + "\n")
-    return (out.strip() == "")
+    return out.strip() == ""
+
 
 # Regex to find letter‐only fragments separated by double‐newline.
 PAT = re.compile(r"([A-Za-z]+)\n\n([a-z][A-Za-z]+)")
+
 
 def repl(match: re.Match) -> str:
     head, tail = match.group(1), match.group(2)
@@ -47,16 +50,17 @@ def repl(match: re.Match) -> str:
         # e.g. "find an\n\naudience" -> "find an audience"
         return head + " " + tail
 
+
 def fix_stream(in_stream, out_stream):
     text = in_stream.read()
     # Perform a global substitution
     cleaned = PAT.sub(repl, text)
     out_stream.write(cleaned)
 
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
-        with open(sys.argv[1], 'r', encoding='utf-8') as f_in:
+        with open(sys.argv[1], "r", encoding="utf-8") as f_in:
             fix_stream(f_in, sys.stdout)
     else:
         fix_stream(sys.stdin, sys.stdout)
-

--- a/scripts/fix_newlines_jsonl.py
+++ b/scripts/fix_newlines_jsonl.py
@@ -6,11 +6,11 @@ Reads JSONL from stdin (or a file), fixes spurious \n\n inside words or clauses,
 and writes cleaned JSONL to stdout.
 
 Algorithm:
-  1. **Merge true word-splits**  
-     Pattern: letter+  \n\n  lowercase-letter+  
-     → try head+tail; if spell-checker says it’s a real word, glue;  
+  1. **Merge true word-splits**
+     Pattern: letter+  \n\n  lowercase-letter+
+     → try head+tail; if spell-checker says it’s a real word, glue;
        else fall back to head + “ ” + tail.
-  2. **Collapse clause-splits**  
+  2. **Collapse clause-splits**
      Any \n\n followed by lowercase or ‘(’ → replace \n\n with a space.
   3. Leave all other \n\n (e.g. before uppercase, quotes, headings) intact.
 """
@@ -20,33 +20,41 @@ from functools import partial, reduce
 
 SPELLER_CMD = ["aspell", "list"]
 
+
 def is_real_word(w: str) -> bool:
     """Return True if aspell knows this word."""
-    p = subprocess.Popen(SPELLER_CMD, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+    p = subprocess.Popen(
+        SPELLER_CMD, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True
+    )
     out, _ = p.communicate(w + "\n")
     return out.strip() == ""
 
+
 # Phase 1: merge hyphen-style or pure letter splits
 _merge_re = re.compile(r"([A-Za-z]+)\n\n([a-z][A-Za-z]+)")
+
 
 def merge_splits(text: str) -> str:
     def repl(m):
         head, tail = m.group(1), m.group(2)
         candidate = head + tail
         return candidate if is_real_word(candidate) else head + " " + tail
+
     return _merge_re.sub(repl, text)
+
 
 # Phase 2: collapse spurious clause splits (lowercase or parentheses)
 _collapse_re = re.compile(r"\n\n(?=[a-z(])")
 
+
 def collapse_clause_breaks(text: str) -> str:
     return _collapse_re.sub(" ", text)
 
+
 # Full pipeline
 def fix_text(text: str) -> str:
-    return reduce(lambda acc, fn: fn(acc),
-                  (merge_splits, collapse_clause_breaks),
-                  text)
+    return reduce(lambda acc, fn: fn(acc), (merge_splits, collapse_clause_breaks), text)
+
 
 def process_stream(inp, outp):
     for line in inp:
@@ -64,6 +72,7 @@ def process_stream(inp, outp):
             obj["text"] = fix_text(txt)
 
         outp.write(json.dumps(obj, ensure_ascii=False) + "\n")
+
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:

--- a/scripts/generate_test_epub.py
+++ b/scripts/generate_test_epub.py
@@ -12,30 +12,33 @@ import sys
 import zipfile
 from pathlib import Path
 
+
 def create_test_epub():
     """Create a test EPUB file manually"""
     # Create test_data directory if it doesn't exist
     test_data_dir = Path(__file__).parent.parent / "test_data"
     test_data_dir.mkdir(exist_ok=True)
-    
+
     epub_path = test_data_dir / "sample_test.epub"
-    
+
     # EPUB is essentially a ZIP file with specific structure
-    with zipfile.ZipFile(epub_path, 'w', zipfile.ZIP_DEFLATED) as epub:
+    with zipfile.ZipFile(epub_path, "w", zipfile.ZIP_DEFLATED) as epub:
         # mimetype file (must be first and uncompressed)
-        epub.writestr('mimetype', 'application/epub+zip', compress_type=zipfile.ZIP_STORED)
-        
+        epub.writestr(
+            "mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED
+        )
+
         # META-INF/container.xml
-        container_xml = '''<?xml version="1.0" encoding="UTF-8"?>
+        container_xml = """<?xml version="1.0" encoding="UTF-8"?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
     <rootfiles>
         <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
     </rootfiles>
-</container>'''
-        epub.writestr('META-INF/container.xml', container_xml)
-        
+</container>"""
+        epub.writestr("META-INF/container.xml", container_xml)
+
         # OEBPS/content.opf (package file)
-        content_opf = '''<?xml version="1.0" encoding="UTF-8"?>
+        content_opf = """<?xml version="1.0" encoding="UTF-8"?>
 <package version="3.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="uid">
     <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
         <dc:identifier id="uid">test-epub-001</dc:identifier>
@@ -56,11 +59,11 @@ def create_test_epub():
         <itemref idref="chapter2"/>
         <itemref idref="chapter3"/>
     </spine>
-</package>'''
-        epub.writestr('OEBPS/content.opf', content_opf)
-        
+</package>"""
+        epub.writestr("OEBPS/content.opf", content_opf)
+
         # OEBPS/nav.xhtml (navigation document)
-        nav_xhtml = '''<?xml version="1.0" encoding="UTF-8"?>
+        nav_xhtml = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
 <head>
@@ -76,11 +79,11 @@ def create_test_epub():
         </ol>
     </nav>
 </body>
-</html>'''
-        epub.writestr('OEBPS/nav.xhtml', nav_xhtml)
-        
+</html>"""
+        epub.writestr("OEBPS/nav.xhtml", nav_xhtml)
+
         # OEBPS/chapter1.xhtml
-        chapter1_xhtml = '''<?xml version="1.0" encoding="UTF-8"?>
+        chapter1_xhtml = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -100,11 +103,11 @@ def create_test_epub():
     
     <p>This content should be processed by the EPUB chunking system to extract meaningful text blocks and validate the extraction pipeline.</p>
 </body>
-</html>'''
-        epub.writestr('OEBPS/chapter1.xhtml', chapter1_xhtml)
-        
+</html>"""
+        epub.writestr("OEBPS/chapter1.xhtml", chapter1_xhtml)
+
         # OEBPS/chapter2.xhtml
-        chapter2_xhtml = '''<?xml version="1.0" encoding="UTF-8"?>
+        chapter2_xhtml = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -129,11 +132,11 @@ def create_test_epub():
     
     <p>Another paragraph with some technical terms like <em>PyMuPDF4LLM</em> and <strong>text processing algorithms</strong> to test specialized handling.</p>
 </body>
-</html>'''
-        epub.writestr('OEBPS/chapter2.xhtml', chapter2_xhtml)
-        
+</html>"""
+        epub.writestr("OEBPS/chapter2.xhtml", chapter2_xhtml)
+
         # OEBPS/chapter3.xhtml
-        chapter3_xhtml = '''<?xml version="1.0" encoding="UTF-8"?>
+        chapter3_xhtml = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -160,11 +163,12 @@ def create_test_epub():
     
     <p>End of test document.</p>
 </body>
-</html>'''
-        epub.writestr('OEBPS/chapter3.xhtml', chapter3_xhtml)
-    
+</html>"""
+        epub.writestr("OEBPS/chapter3.xhtml", chapter3_xhtml)
+
     print(f"Created test EPUB: {epub_path}")
     return str(epub_path)
+
 
 if __name__ == "__main__":
     create_test_epub()

--- a/scripts/generate_test_pdf.py
+++ b/scripts/generate_test_pdf.py
@@ -11,17 +11,20 @@ import os
 import sys
 from pathlib import Path
 
+
 def create_test_pdf():
     """Create a test PDF file using reportlab"""
     try:
         # Debug import path and environment
         import sys
+
         print(f"Python executable: {sys.executable}")
         print(f"Python path: {sys.path[:3]}...")  # Show first 3 entries
-        
+
         from reportlab.pdfgen import canvas
         from reportlab.lib.pagesizes import letter
         from reportlab.lib.units import inch
+
         print("reportlab imported successfully")
     except ImportError as e:
         print(f"reportlab import failed: {e}")
@@ -32,96 +35,156 @@ def create_test_pdf():
         print(f"Unexpected error importing reportlab: {e}")
         print("Creating placeholder PDF info file instead...")
         return create_pdf_placeholder()
-    
+
     # Create test_data directory if it doesn't exist
     test_data_dir = Path(__file__).parent.parent / "test_data"
     test_data_dir.mkdir(exist_ok=True)
-    
+
     pdf_path = test_data_dir / "sample_test.pdf"
-    
+
     # Create PDF
     c = canvas.Canvas(str(pdf_path), pagesize=letter)
     width, height = letter
-    
+
     # Page 1 - Title and introduction
     c.setFont("Helvetica-Bold", 16)
-    c.drawString(1*inch, height - 1*inch, "Test Document for PDF Processing")
-    
+    c.drawString(1 * inch, height - 1 * inch, "Test Document for PDF Processing")
+
     c.setFont("Helvetica", 12)
-    c.drawString(1*inch, height - 1.5*inch, "This is a test document created for validating PDF processing functionality.")
-    c.drawString(1*inch, height - 2*inch, "It contains multiple pages with different types of content to test:")
-    
-    c.drawString(1.5*inch, height - 2.5*inch, "• Text extraction capabilities")
-    c.drawString(1.5*inch, height - 2.8*inch, "• Multi-page processing")
-    c.drawString(1.5*inch, height - 3.1*inch, "• Various text formatting")
-    c.drawString(1.5*inch, height - 3.4*inch, "• Paragraph and line breaks")
-    
+    c.drawString(
+        1 * inch,
+        height - 1.5 * inch,
+        "This is a test document created for validating PDF processing functionality.",
+    )
+    c.drawString(
+        1 * inch,
+        height - 2 * inch,
+        "It contains multiple pages with different types of content to test:",
+    )
+
+    c.drawString(1.5 * inch, height - 2.5 * inch, "• Text extraction capabilities")
+    c.drawString(1.5 * inch, height - 2.8 * inch, "• Multi-page processing")
+    c.drawString(1.5 * inch, height - 3.1 * inch, "• Various text formatting")
+    c.drawString(1.5 * inch, height - 3.4 * inch, "• Paragraph and line breaks")
+
     c.setFont("Helvetica", 10)
-    c.drawString(1*inch, height - 4*inch, "This document should be processed by the PDF chunking system to extract")
-    c.drawString(1*inch, height - 4.2*inch, "meaningful text blocks and validate the extraction pipeline.")
-    
+    c.drawString(
+        1 * inch,
+        height - 4 * inch,
+        "This document should be processed by the PDF chunking system to extract",
+    )
+    c.drawString(
+        1 * inch,
+        height - 4.2 * inch,
+        "meaningful text blocks and validate the extraction pipeline.",
+    )
+
     # Page 2 - Sample content with dialogue
     c.showPage()
     c.setFont("Helvetica-Bold", 14)
-    c.drawString(1*inch, height - 1*inch, "Chapter 1: Sample Content")
-    
+    c.drawString(1 * inch, height - 1 * inch, "Chapter 1: Sample Content")
+
     c.setFont("Helvetica", 11)
-    c.drawString(1*inch, height - 1.5*inch, "This page contains sample text that mimics real document content.")
-    c.drawString(1*inch, height - 1.8*inch, "It includes paragraphs, dialogue, and various text patterns.")
-    
-    c.drawString(1*inch, height - 2.3*inch, "\"Hello, this is a sample dialogue,\" said the first speaker.")
-    c.drawString(1*inch, height - 2.6*inch, "\"Yes, this helps test dialogue detection,\" replied the second.")
-    
-    c.drawString(1*inch, height - 3.1*inch, "Regular paragraph text continues here. This text should be")
-    c.drawString(1*inch, height - 3.4*inch, "processed as a normal paragraph block, separate from the")
-    c.drawString(1*inch, height - 3.7*inch, "dialogue above.")
-    
-    c.drawString(1*inch, height - 4.2*inch, "Another paragraph with some technical terms like PyMuPDF4LLM")
-    c.drawString(1*inch, height - 4.5*inch, "and text processing algorithms to test specialized handling.")
-    
+    c.drawString(
+        1 * inch,
+        height - 1.5 * inch,
+        "This page contains sample text that mimics real document content.",
+    )
+    c.drawString(
+        1 * inch,
+        height - 1.8 * inch,
+        "It includes paragraphs, dialogue, and various text patterns.",
+    )
+
+    c.drawString(
+        1 * inch,
+        height - 2.3 * inch,
+        '"Hello, this is a sample dialogue," said the first speaker.',
+    )
+    c.drawString(
+        1 * inch,
+        height - 2.6 * inch,
+        '"Yes, this helps test dialogue detection," replied the second.',
+    )
+
+    c.drawString(
+        1 * inch,
+        height - 3.1 * inch,
+        "Regular paragraph text continues here. This text should be",
+    )
+    c.drawString(
+        1 * inch,
+        height - 3.4 * inch,
+        "processed as a normal paragraph block, separate from the",
+    )
+    c.drawString(1 * inch, height - 3.7 * inch, "dialogue above.")
+
+    c.drawString(
+        1 * inch,
+        height - 4.2 * inch,
+        "Another paragraph with some technical terms like PyMuPDF4LLM",
+    )
+    c.drawString(
+        1 * inch,
+        height - 4.5 * inch,
+        "and text processing algorithms to test specialized handling.",
+    )
+
     # Page 3 - Lists and structured content
     c.showPage()
     c.setFont("Helvetica-Bold", 14)
-    c.drawString(1*inch, height - 1*inch, "Chapter 2: Structured Content")
-    
+    c.drawString(1 * inch, height - 1 * inch, "Chapter 2: Structured Content")
+
     c.setFont("Helvetica", 11)
-    c.drawString(1*inch, height - 1.5*inch, "This page tests structured content processing:")
-    
-    c.drawString(1*inch, height - 2*inch, "1. First numbered item")
-    c.drawString(1*inch, height - 2.3*inch, "2. Second numbered item")
-    c.drawString(1*inch, height - 2.6*inch, "3. Third numbered item")
-    
-    c.drawString(1*inch, height - 3.1*inch, "Bullet points:")
-    c.drawString(1.2*inch, height - 3.4*inch, "• First bullet point")
-    c.drawString(1.2*inch, height - 3.7*inch, "• Second bullet point")
-    c.drawString(1.2*inch, height - 4*inch, "• Third bullet point")
-    
-    c.drawString(1*inch, height - 4.5*inch, "This content tests the system's ability to handle different")
-    c.drawString(1*inch, height - 4.8*inch, "text structures and formatting patterns.")
-    
+    c.drawString(
+        1 * inch, height - 1.5 * inch, "This page tests structured content processing:"
+    )
+
+    c.drawString(1 * inch, height - 2 * inch, "1. First numbered item")
+    c.drawString(1 * inch, height - 2.3 * inch, "2. Second numbered item")
+    c.drawString(1 * inch, height - 2.6 * inch, "3. Third numbered item")
+
+    c.drawString(1 * inch, height - 3.1 * inch, "Bullet points:")
+    c.drawString(1.2 * inch, height - 3.4 * inch, "• First bullet point")
+    c.drawString(1.2 * inch, height - 3.7 * inch, "• Second bullet point")
+    c.drawString(1.2 * inch, height - 4 * inch, "• Third bullet point")
+
+    c.drawString(
+        1 * inch,
+        height - 4.5 * inch,
+        "This content tests the system's ability to handle different",
+    )
+    c.drawString(
+        1 * inch, height - 4.8 * inch, "text structures and formatting patterns."
+    )
+
     c.save()
     print(f"Created test PDF: {pdf_path}")
     return str(pdf_path)
+
 
 def create_pdf_placeholder():
     """Create a placeholder info file when reportlab is not available"""
     test_data_dir = Path(__file__).parent.parent / "test_data"
     test_data_dir.mkdir(exist_ok=True)
-    
+
     info_path = test_data_dir / "sample_test_pdf_info.txt"
-    
-    with open(info_path, 'w') as f:
+
+    with open(info_path, "w") as f:
         f.write("TEST PDF PLACEHOLDER\n")
         f.write("===================\n\n")
         f.write("This file serves as a placeholder for sample_test.pdf\n")
-        f.write("The actual PDF could not be created because reportlab is not available.\n\n")
+        f.write(
+            "The actual PDF could not be created because reportlab is not available.\n\n"
+        )
         f.write("To create the test PDF, install reportlab:\n")
         f.write("pip install reportlab\n\n")
         f.write("Then run this script again:\n")
         f.write("python scripts/generate_test_pdf.py\n")
-    
+
     print(f"Created PDF placeholder info: {info_path}")
     return str(info_path)
+
 
 if __name__ == "__main__":
     create_test_pdf()

--- a/scripts/llm_correction.py
+++ b/scripts/llm_correction.py
@@ -7,10 +7,11 @@ load_dotenv()
 MODEL = "gpt-3.5-turbo"
 litellm.api_key = os.getenv("OPENAI_API_KEY")
 
+
 def correct_word(word, snippet):
     prompt = (
         f"The following snippet contains the possibly erroneous word '{word}':\n\n"
-        f"\"{snippet}\"\n\n"
+        f'"{snippet}"\n\n'
         "If the word results from words glued together accidentally, correct it. "
         "Otherwise, return the original word unchanged.\n\n"
         "Reply ONLY with the corrected or original word."
@@ -20,7 +21,6 @@ def correct_word(word, snippet):
         model=MODEL,
         messages=[{"role": "user", "content": prompt}],
         temperature=0.0,
-        max_tokens=100
+        max_tokens=100,
     )
     return response.choices[0].message.content.strip()
-

--- a/scripts/test_page_boundaries.py
+++ b/scripts/test_page_boundaries.py
@@ -26,46 +26,49 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from pdf_chunker.pdf_parsing import extract_text_blocks_from_pdf
 from pdf_chunker.text_cleaning import clean_text, clean_text_traditional
-from pdf_chunker.pymupdf4llm_integration import is_pymupdf4llm_available, clean_text_with_pymupdf4llm
+from pdf_chunker.pymupdf4llm_integration import (
+    is_pymupdf4llm_available,
+    clean_text_with_pymupdf4llm,
+)
 
 
 def extract_with_traditional_approach(pdf_path: str) -> List[Dict[str, Any]]:
     """Extract text using traditional approach only."""
     # Temporarily disable PyMuPDF4LLM for traditional extraction
-    os.environ['PDF_CHUNKER_USE_PYMUPDF4LLM'] = 'false'
+    os.environ["PDF_CHUNKER_USE_PYMUPDF4LLM"] = "false"
     try:
         blocks = extract_text_blocks_from_pdf(pdf_path)
         return blocks
     finally:
         # Restore environment
-        if 'PDF_CHUNKER_USE_PYMUPDF4LLM' in os.environ:
-            del os.environ['PDF_CHUNKER_USE_PYMUPDF4LLM']
+        if "PDF_CHUNKER_USE_PYMUPDF4LLM" in os.environ:
+            del os.environ["PDF_CHUNKER_USE_PYMUPDF4LLM"]
 
 
 def extract_with_pymupdf4llm_approach(pdf_path: str) -> List[Dict[str, Any]]:
     """Extract text using PyMuPDF4LLM enhanced approach."""
     # Enable PyMuPDF4LLM for enhanced extraction
-    os.environ['PDF_CHUNKER_USE_PYMUPDF4LLM'] = 'true'
+    os.environ["PDF_CHUNKER_USE_PYMUPDF4LLM"] = "true"
     try:
         blocks = extract_text_blocks_from_pdf(pdf_path)
         return blocks
     finally:
         # Restore environment
-        if 'PDF_CHUNKER_USE_PYMUPDF4LLM' in os.environ:
-            del os.environ['PDF_CHUNKER_USE_PYMUPDF4LLM']
+        if "PDF_CHUNKER_USE_PYMUPDF4LLM" in os.environ:
+            del os.environ["PDF_CHUNKER_USE_PYMUPDF4LLM"]
 
 
 def analyze_sentence_boundaries(text: str) -> Dict[str, Any]:
     """Analyze sentence boundary quality in extracted text."""
-    sentences = re.split(r'[.!?]+', text)
+    sentences = re.split(r"[.!?]+", text)
     sentences = [s.strip() for s in sentences if s.strip()]
-    
+
     # Look for incomplete sentences (very short fragments)
     short_fragments = [s for s in sentences if len(s.split()) <= 4]
-    
+
     # Look for sentences that start with lowercase (potential continuation issues)
     lowercase_starts = [s for s in sentences if s and s[0].islower()]
-    
+
     # Look for abrupt endings (sentences ending mid-word or with unusual patterns)
     abrupt_endings = []
     for sentence in sentences:
@@ -74,74 +77,74 @@ def analyze_sentence_boundaries(text: str) -> Dict[str, Any]:
             words = sentence.split()
             if words and len(words[-1]) <= 2 and not words[-1].isdigit():
                 abrupt_endings.append(sentence)
-    
+
     return {
-        'total_sentences': len(sentences),
-        'short_fragments': len(short_fragments),
-        'lowercase_starts': len(lowercase_starts),
-        'abrupt_endings': len(abrupt_endings),
-        'short_fragment_examples': short_fragments[:3],
-        'lowercase_start_examples': lowercase_starts[:3],
-        'abrupt_ending_examples': abrupt_endings[:3]
+        "total_sentences": len(sentences),
+        "short_fragments": len(short_fragments),
+        "lowercase_starts": len(lowercase_starts),
+        "abrupt_endings": len(abrupt_endings),
+        "short_fragment_examples": short_fragments[:3],
+        "lowercase_start_examples": lowercase_starts[:3],
+        "abrupt_ending_examples": abrupt_endings[:3],
     }
 
 
 def detect_page_artifacts(blocks: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Detect headers, footers, and page artifacts in extracted blocks."""
     artifacts = {
-        'page_numbers': [],
-        'headers': [],
-        'footers': [],
-        'footnotes': [],
-        'other_artifacts': []
+        "page_numbers": [],
+        "headers": [],
+        "footers": [],
+        "footnotes": [],
+        "other_artifacts": [],
     }
-    
+
     for i, block in enumerate(blocks):
-        text = block.get('text', '').strip()
-        page = block.get('source', {}).get('page', 0)
-        
+        text = block.get("text", "").strip()
+        page = block.get("source", {}).get("page", 0)
+
         if not text:
             continue
-        
+
         # Page numbers (standalone digits)
-        if re.match(r'^\d+$', text):
-            artifacts['page_numbers'].append({
-                'block_index': i,
-                'page': page,
-                'text': text
-            })
+        if re.match(r"^\d+$", text):
+            artifacts["page_numbers"].append(
+                {"block_index": i, "page": page, "text": text}
+            )
             continue
-        
+
         # Headers (common patterns at top of pages)
-        if re.match(r'^(chapter\s+\d+|page\s+\d+|table\s+of\s+contents)', text.lower()):
-            artifacts['headers'].append({
-                'block_index': i,
-                'page': page,
-                'text': text[:50] + '...' if len(text) > 50 else text
-            })
+        if re.match(r"^(chapter\s+\d+|page\s+\d+|table\s+of\s+contents)", text.lower()):
+            artifacts["headers"].append(
+                {
+                    "block_index": i,
+                    "page": page,
+                    "text": text[:50] + "..." if len(text) > 50 else text,
+                }
+            )
             continue
-        
+
         # Footnotes (text starting with numbers or footnote markers)
-        if re.match(r'^\d+\s+[a-z]', text.lower()) or 'footnote' in text.lower():
-            artifacts['footnotes'].append({
-                'block_index': i,
-                'page': page,
-                'text': text[:50] + '...' if len(text) > 50 else text
-            })
+        if re.match(r"^\d+\s+[a-z]", text.lower()) or "footnote" in text.lower():
+            artifacts["footnotes"].append(
+                {
+                    "block_index": i,
+                    "page": page,
+                    "text": text[:50] + "..." if len(text) > 50 else text,
+                }
+            )
             continue
-        
+
         # Other potential artifacts (very short text with specific patterns)
         if len(text.split()) <= 3 and (
-            any(char.isdigit() for char in text) or
-            text.isupper() or
-            re.match(r'^[A-Z\s]+$', text)
+            any(char.isdigit() for char in text)
+            or text.isupper()
+            or re.match(r"^[A-Z\s]+$", text)
         ):
-            artifacts['other_artifacts'].append({
-                'block_index': i,
-                'page': page,
-                'text': text
-            })
-    
+            artifacts["other_artifacts"].append(
+                {"block_index": i, "page": page, "text": text}
+            )
+
     return artifacts
 
 
@@ -149,140 +152,173 @@ def analyze_text_flow_quality(blocks: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Analyze the quality of text flow across page boundaries."""
     flow_issues = []
     page_transitions = []
-    
+
     for i in range(len(blocks) - 1):
         curr_block = blocks[i]
         next_block = blocks[i + 1]
-        
-        curr_text = curr_block.get('text', '').strip()
-        next_text = next_block.get('text', '').strip()
-        
-        curr_page = curr_block.get('source', {}).get('page', 0)
-        next_page = next_block.get('source', {}).get('page', 0)
-        
+
+        curr_text = curr_block.get("text", "").strip()
+        next_text = next_block.get("text", "").strip()
+
+        curr_page = curr_block.get("source", {}).get("page", 0)
+        next_page = next_block.get("source", {}).get("page", 0)
+
         # Check for page transitions
         if curr_page != next_page:
-            page_transitions.append({
-                'from_page': curr_page,
-                'to_page': next_page,
-                'curr_text_end': curr_text[-50:] if curr_text else '',
-                'next_text_start': next_text[:50] if next_text else '',
-                'block_indices': [i, i + 1]
-            })
-            
+            page_transitions.append(
+                {
+                    "from_page": curr_page,
+                    "to_page": next_page,
+                    "curr_text_end": curr_text[-50:] if curr_text else "",
+                    "next_text_start": next_text[:50] if next_text else "",
+                    "block_indices": [i, i + 1],
+                }
+            )
+
             # Check for potential flow issues at page boundaries
             if curr_text and next_text:
                 # Sentence cut off (no punctuation at end, lowercase start)
-                if (not curr_text.endswith(('.', '!', '?', ':', ';')) and 
-                    next_text and next_text[0].islower()):
-                    flow_issues.append({
-                        'type': 'sentence_cut_off',
-                        'from_page': curr_page,
-                        'to_page': next_page,
-                        'description': f"Sentence appears cut off between pages {curr_page}-{next_page}",
-                        'curr_text_end': curr_text[-30:],
-                        'next_text_start': next_text[:30]
-                    })
-                
+                if (
+                    not curr_text.endswith((".", "!", "?", ":", ";"))
+                    and next_text
+                    and next_text[0].islower()
+                ):
+                    flow_issues.append(
+                        {
+                            "type": "sentence_cut_off",
+                            "from_page": curr_page,
+                            "to_page": next_page,
+                            "description": f"Sentence appears cut off between pages {curr_page}-{next_page}",
+                            "curr_text_end": curr_text[-30:],
+                            "next_text_start": next_text[:30],
+                        }
+                    )
+
                 # Word split (ends with partial word, starts with continuation)
                 curr_words = curr_text.split()
                 next_words = next_text.split()
-                if (curr_words and next_words and 
-                    len(curr_words[-1]) < 4 and 
-                    next_words[0][0].islower()):
-                    flow_issues.append({
-                        'type': 'word_split',
-                        'from_page': curr_page,
-                        'to_page': next_page,
-                        'description': f"Word appears split between pages {curr_page}-{next_page}",
-                        'split_word': f"{curr_words[-1]}|{next_words[0]}"
-                    })
-    
+                if (
+                    curr_words
+                    and next_words
+                    and len(curr_words[-1]) < 4
+                    and next_words[0][0].islower()
+                ):
+                    flow_issues.append(
+                        {
+                            "type": "word_split",
+                            "from_page": curr_page,
+                            "to_page": next_page,
+                            "description": f"Word appears split between pages {curr_page}-{next_page}",
+                            "split_word": f"{curr_words[-1]}|{next_words[0]}",
+                        }
+                    )
+
     return {
-        'page_transitions': page_transitions,
-        'flow_issues': flow_issues,
-        'total_transitions': len(page_transitions),
-        'total_flow_issues': len(flow_issues)
+        "page_transitions": page_transitions,
+        "flow_issues": flow_issues,
+        "total_transitions": len(page_transitions),
+        "total_flow_issues": len(flow_issues),
     }
 
 
-def compare_text_quality(traditional_blocks: List[Dict[str, Any]], 
-                        pymupdf4llm_blocks: List[Dict[str, Any]]) -> Dict[str, Any]:
+def compare_text_quality(
+    traditional_blocks: List[Dict[str, Any]], pymupdf4llm_blocks: List[Dict[str, Any]]
+) -> Dict[str, Any]:
     """Compare text quality between traditional and PyMuPDF4LLM approaches."""
-    
+
     # Combine text from all blocks
-    traditional_text = '\n\n'.join(block.get('text', '') for block in traditional_blocks)
-    pymupdf4llm_text = '\n\n'.join(block.get('text', '') for block in pymupdf4llm_blocks)
-    
+    traditional_text = "\n\n".join(
+        block.get("text", "") for block in traditional_blocks
+    )
+    pymupdf4llm_text = "\n\n".join(
+        block.get("text", "") for block in pymupdf4llm_blocks
+    )
+
     # Analyze sentence boundaries
     traditional_sentences = analyze_sentence_boundaries(traditional_text)
     pymupdf4llm_sentences = analyze_sentence_boundaries(pymupdf4llm_text)
-    
+
     # Detect page artifacts
     traditional_artifacts = detect_page_artifacts(traditional_blocks)
     pymupdf4llm_artifacts = detect_page_artifacts(pymupdf4llm_blocks)
-    
+
     # Analyze text flow quality
     traditional_flow = analyze_text_flow_quality(traditional_blocks)
     pymupdf4llm_flow = analyze_text_flow_quality(pymupdf4llm_blocks)
-    
+
     # Calculate quality scores
     def calculate_quality_score(sentences, artifacts, flow):
         score = 1.0
-        
+
         # Penalize for sentence issues
-        if sentences['total_sentences'] > 0:
-            fragment_ratio = sentences['short_fragments'] / sentences['total_sentences']
-            lowercase_ratio = sentences['lowercase_starts'] / sentences['total_sentences']
-            abrupt_ratio = sentences['abrupt_endings'] / sentences['total_sentences']
-            
+        if sentences["total_sentences"] > 0:
+            fragment_ratio = sentences["short_fragments"] / sentences["total_sentences"]
+            lowercase_ratio = (
+                sentences["lowercase_starts"] / sentences["total_sentences"]
+            )
+            abrupt_ratio = sentences["abrupt_endings"] / sentences["total_sentences"]
+
             score -= fragment_ratio * 0.3
             score -= lowercase_ratio * 0.2
             score -= abrupt_ratio * 0.2
-        
+
         # Penalize for artifacts
-        total_artifacts = (len(artifacts['page_numbers']) + len(artifacts['headers']) + 
-                          len(artifacts['footers']) + len(artifacts['other_artifacts']))
+        total_artifacts = (
+            len(artifacts["page_numbers"])
+            + len(artifacts["headers"])
+            + len(artifacts["footers"])
+            + len(artifacts["other_artifacts"])
+        )
         if total_artifacts > 0:
             score -= min(total_artifacts * 0.05, 0.3)
-        
+
         # Penalize for flow issues
-        if flow['total_transitions'] > 0:
-            flow_issue_ratio = flow['total_flow_issues'] / flow['total_transitions']
+        if flow["total_transitions"] > 0:
+            flow_issue_ratio = flow["total_flow_issues"] / flow["total_transitions"]
             score -= flow_issue_ratio * 0.4
-        
+
         return max(score, 0.0)
-    
-    traditional_score = calculate_quality_score(traditional_sentences, traditional_artifacts, traditional_flow)
-    pymupdf4llm_score = calculate_quality_score(pymupdf4llm_sentences, pymupdf4llm_artifacts, pymupdf4llm_flow)
-    
+
+    traditional_score = calculate_quality_score(
+        traditional_sentences, traditional_artifacts, traditional_flow
+    )
+    pymupdf4llm_score = calculate_quality_score(
+        pymupdf4llm_sentences, pymupdf4llm_artifacts, pymupdf4llm_flow
+    )
+
     return {
-        'traditional': {
-            'quality_score': traditional_score,
-            'total_blocks': len(traditional_blocks),
-            'total_characters': len(traditional_text),
-            'sentences': traditional_sentences,
-            'artifacts': traditional_artifacts,
-            'flow': traditional_flow
+        "traditional": {
+            "quality_score": traditional_score,
+            "total_blocks": len(traditional_blocks),
+            "total_characters": len(traditional_text),
+            "sentences": traditional_sentences,
+            "artifacts": traditional_artifacts,
+            "flow": traditional_flow,
         },
-        'pymupdf4llm': {
-            'quality_score': pymupdf4llm_score,
-            'total_blocks': len(pymupdf4llm_blocks),
-            'total_characters': len(pymupdf4llm_text),
-            'sentences': pymupdf4llm_sentences,
-            'artifacts': pymupdf4llm_artifacts,
-            'flow': pymupdf4llm_flow
+        "pymupdf4llm": {
+            "quality_score": pymupdf4llm_score,
+            "total_blocks": len(pymupdf4llm_blocks),
+            "total_characters": len(pymupdf4llm_text),
+            "sentences": pymupdf4llm_sentences,
+            "artifacts": pymupdf4llm_artifacts,
+            "flow": pymupdf4llm_flow,
         },
-        'comparison': {
-            'quality_improvement': pymupdf4llm_score - traditional_score,
-            'block_count_change': len(pymupdf4llm_blocks) - len(traditional_blocks),
-            'character_count_change': len(pymupdf4llm_text) - len(traditional_text),
-            'better_approach': 'PyMuPDF4LLM' if pymupdf4llm_score > traditional_score else 'Traditional'
-        }
+        "comparison": {
+            "quality_improvement": pymupdf4llm_score - traditional_score,
+            "block_count_change": len(pymupdf4llm_blocks) - len(traditional_blocks),
+            "character_count_change": len(pymupdf4llm_text) - len(traditional_text),
+            "better_approach": (
+                "PyMuPDF4LLM"
+                if pymupdf4llm_score > traditional_score
+                else "Traditional"
+            ),
+        },
     }
 
 
-def generate_comparison_report(comparison_results: Dict[str, Any], pdf_path: str) -> str:
+def generate_comparison_report(
+    comparison_results: Dict[str, Any], pdf_path: str
+) -> str:
     """Generate a detailed comparison report."""
     report = []
     report.append("=" * 80)
@@ -291,12 +327,12 @@ def generate_comparison_report(comparison_results: Dict[str, Any], pdf_path: str
     report.append(f"PDF File: {pdf_path}")
     report.append(f"PyMuPDF4LLM Available: {is_pymupdf4llm_available()}")
     report.append("")
-    
+
     # Overall quality comparison
-    trad = comparison_results['traditional']
-    pymu = comparison_results['pymupdf4llm']
-    comp = comparison_results['comparison']
-    
+    trad = comparison_results["traditional"]
+    pymu = comparison_results["pymupdf4llm"]
+    comp = comparison_results["comparison"]
+
     report.append("OVERALL QUALITY SCORES")
     report.append("-" * 40)
     report.append(f"Traditional Approach:  {trad['quality_score']:.3f}")
@@ -304,7 +340,7 @@ def generate_comparison_report(comparison_results: Dict[str, Any], pdf_path: str
     report.append(f"Quality Improvement:   {comp['quality_improvement']:+.3f}")
     report.append(f"Better Approach:       {comp['better_approach']}")
     report.append("")
-    
+
     # Block and character counts
     report.append("EXTRACTION STATISTICS")
     report.append("-" * 40)
@@ -316,44 +352,70 @@ def generate_comparison_report(comparison_results: Dict[str, Any], pdf_path: str
     report.append(f"PyMuPDF4LLM Characters: {pymu['total_characters']}")
     report.append(f"Character Count Change: {comp['character_count_change']:+d}")
     report.append("")
-    
+
     # Sentence analysis
     report.append("SENTENCE BOUNDARY ANALYSIS")
     report.append("-" * 40)
     report.append(f"                        Traditional  PyMuPDF4LLM")
-    report.append(f"Total Sentences:        {trad['sentences']['total_sentences']:>11d}  {pymu['sentences']['total_sentences']:>11d}")
-    report.append(f"Short Fragments:        {trad['sentences']['short_fragments']:>11d}  {pymu['sentences']['short_fragments']:>11d}")
-    report.append(f"Lowercase Starts:       {trad['sentences']['lowercase_starts']:>11d}  {pymu['sentences']['lowercase_starts']:>11d}")
-    report.append(f"Abrupt Endings:         {trad['sentences']['abrupt_endings']:>11d}  {pymu['sentences']['abrupt_endings']:>11d}")
+    report.append(
+        f"Total Sentences:        {trad['sentences']['total_sentences']:>11d}  {pymu['sentences']['total_sentences']:>11d}"
+    )
+    report.append(
+        f"Short Fragments:        {trad['sentences']['short_fragments']:>11d}  {pymu['sentences']['short_fragments']:>11d}"
+    )
+    report.append(
+        f"Lowercase Starts:       {trad['sentences']['lowercase_starts']:>11d}  {pymu['sentences']['lowercase_starts']:>11d}"
+    )
+    report.append(
+        f"Abrupt Endings:         {trad['sentences']['abrupt_endings']:>11d}  {pymu['sentences']['abrupt_endings']:>11d}"
+    )
     report.append("")
-    
+
     # Page artifacts
     report.append("PAGE ARTIFACT DETECTION")
     report.append("-" * 40)
     report.append(f"                        Traditional  PyMuPDF4LLM")
-    report.append(f"Page Numbers:           {len(trad['artifacts']['page_numbers']):>11d}  {len(pymu['artifacts']['page_numbers']):>11d}")
-    report.append(f"Headers:                {len(trad['artifacts']['headers']):>11d}  {len(pymu['artifacts']['headers']):>11d}")
-    report.append(f"Footers:                {len(trad['artifacts']['footers']):>11d}  {len(pymu['artifacts']['footers']):>11d}")
-    report.append(f"Footnotes:              {len(trad['artifacts']['footnotes']):>11d}  {len(pymu['artifacts']['footnotes']):>11d}")
-    report.append(f"Other Artifacts:        {len(trad['artifacts']['other_artifacts']):>11d}  {len(pymu['artifacts']['other_artifacts']):>11d}")
+    report.append(
+        f"Page Numbers:           {len(trad['artifacts']['page_numbers']):>11d}  {len(pymu['artifacts']['page_numbers']):>11d}"
+    )
+    report.append(
+        f"Headers:                {len(trad['artifacts']['headers']):>11d}  {len(pymu['artifacts']['headers']):>11d}"
+    )
+    report.append(
+        f"Footers:                {len(trad['artifacts']['footers']):>11d}  {len(pymu['artifacts']['footers']):>11d}"
+    )
+    report.append(
+        f"Footnotes:              {len(trad['artifacts']['footnotes']):>11d}  {len(pymu['artifacts']['footnotes']):>11d}"
+    )
+    report.append(
+        f"Other Artifacts:        {len(trad['artifacts']['other_artifacts']):>11d}  {len(pymu['artifacts']['other_artifacts']):>11d}"
+    )
     report.append("")
-    
+
     # Text flow analysis
     report.append("TEXT FLOW ANALYSIS")
     report.append("-" * 40)
     report.append(f"                        Traditional  PyMuPDF4LLM")
-    report.append(f"Page Transitions:       {trad['flow']['total_transitions']:>11d}  {pymu['flow']['total_transitions']:>11d}")
-    report.append(f"Flow Issues:            {trad['flow']['total_flow_issues']:>11d}  {pymu['flow']['total_flow_issues']:>11d}")
+    report.append(
+        f"Page Transitions:       {trad['flow']['total_transitions']:>11d}  {pymu['flow']['total_transitions']:>11d}"
+    )
+    report.append(
+        f"Flow Issues:            {trad['flow']['total_flow_issues']:>11d}  {pymu['flow']['total_flow_issues']:>11d}"
+    )
 
     # Print Flow Issue Ratio for both columns in a single line
-    if trad['flow']['total_transitions'] > 0:
-        trad_flow_ratio = trad['flow']['total_flow_issues'] / trad['flow']['total_transitions']
+    if trad["flow"]["total_transitions"] > 0:
+        trad_flow_ratio = (
+            trad["flow"]["total_flow_issues"] / trad["flow"]["total_transitions"]
+        )
         trad_ratio_str = f"{trad_flow_ratio:>11.3f}"
     else:
         trad_ratio_str = f"{'N/A':>11s}"
 
-    if pymu['flow']['total_transitions'] > 0:
-        pymu_flow_ratio = pymu['flow']['total_flow_issues'] / pymu['flow']['total_transitions']
+    if pymu["flow"]["total_transitions"] > 0:
+        pymu_flow_ratio = (
+            pymu["flow"]["total_flow_issues"] / pymu["flow"]["total_transitions"]
+        )
         pymu_ratio_str = f"{pymu_flow_ratio:>11.3f}"
     else:
         pymu_ratio_str = f"{'N/A':>11s}"
@@ -363,94 +425,99 @@ def generate_comparison_report(comparison_results: Dict[str, Any], pdf_path: str
     report.append("")
 
     # Examples of issues
-    if trad['flow']['flow_issues'] or pymu['flow']['flow_issues']:
+    if trad["flow"]["flow_issues"] or pymu["flow"]["flow_issues"]:
         report.append("FLOW ISSUE EXAMPLES")
         report.append("-" * 40)
-        
-        if trad['flow']['flow_issues']:
+
+        if trad["flow"]["flow_issues"]:
             report.append("Traditional Approach Issues:")
-            for issue in trad['flow']['flow_issues'][:3]:
+            for issue in trad["flow"]["flow_issues"][:3]:
                 report.append(f"  {issue['type']}: {issue['description']}")
-                if 'curr_text_end' in issue:
+                if "curr_text_end" in issue:
                     report.append(f"    End: ...{issue['curr_text_end']}")
                     report.append(f"    Start: {issue['next_text_start']}...")
             report.append("")
-        
-        if pymu['flow']['flow_issues']:
+
+        if pymu["flow"]["flow_issues"]:
             report.append("PyMuPDF4LLM Approach Issues:")
-            for issue in pymu['flow']['flow_issues'][:3]:
+            for issue in pymu["flow"]["flow_issues"][:3]:
                 report.append(f"  {issue['type']}: {issue['description']}")
-                if 'curr_text_end' in issue:
+                if "curr_text_end" in issue:
                     report.append(f"    End: ...{issue['curr_text_end']}")
                     report.append(f"    Start: {issue['next_text_start']}...")
             report.append("")
-    
+
     # Recommendations
     report.append("RECOMMENDATIONS")
     report.append("-" * 40)
-    
-    if comp['quality_improvement'] > 0.1:
+
+    if comp["quality_improvement"] > 0.1:
         report.append("✓ PyMuPDF4LLM approach shows significant improvement")
         report.append("  Recommendation: Enable PyMuPDF4LLM for this document type")
-    elif comp['quality_improvement'] > 0.05:
+    elif comp["quality_improvement"] > 0.05:
         report.append("✓ PyMuPDF4LLM approach shows moderate improvement")
         report.append("  Recommendation: Consider enabling PyMuPDF4LLM")
-    elif comp['quality_improvement'] > -0.05:
+    elif comp["quality_improvement"] > -0.05:
         report.append("≈ Both approaches perform similarly")
         report.append("  Recommendation: Use traditional approach for consistency")
     else:
         report.append("✗ PyMuPDF4LLM approach shows degradation")
         report.append("  Recommendation: Use traditional approach")
-    
+
     report.append("")
     report.append("=" * 80)
-    
-    return '\n'.join(report)
+
+    return "\n".join(report)
 
 
 def main():
     if len(sys.argv) != 2:
         print("Usage: python scripts/test_page_boundaries.py <pdf_file>")
         sys.exit(1)
-    
+
     pdf_path = sys.argv[1]
-    
+
     if not os.path.exists(pdf_path):
         print(f"Error: PDF file '{pdf_path}' not found")
         sys.exit(1)
-    
+
     print(f"Testing page boundary handling for: {pdf_path}")
     print(f"PyMuPDF4LLM available: {is_pymupdf4llm_available()}")
     print()
-    
+
     # Extract with both approaches
     print("Extracting with traditional approach...")
     traditional_blocks = extract_with_traditional_approach(pdf_path)
-    
+
     print("Extracting with PyMuPDF4LLM approach...")
     pymupdf4llm_blocks = extract_with_pymupdf4llm_approach(pdf_path)
-    
+
     # Compare results
     print("Analyzing and comparing results...")
     comparison_results = compare_text_quality(traditional_blocks, pymupdf4llm_blocks)
-    
+
     # Generate report
     report = generate_comparison_report(comparison_results, pdf_path)
     print(report)
-    
+
     # Save detailed results to JSON
     output_file = f"page_boundary_comparison_{Path(pdf_path).stem}.json"
-    with open(output_file, 'w') as f:
-        json.dump({
-            'pdf_path': pdf_path,
-            'pymupdf4llm_available': is_pymupdf4llm_available(),
-            'comparison_results': comparison_results,
-            'traditional_blocks': traditional_blocks,
-            'pymupdf4llm_blocks': pymupdf4llm_blocks
-        }, f, indent=2, default=str)
-    
+    with open(output_file, "w") as f:
+        json.dump(
+            {
+                "pdf_path": pdf_path,
+                "pymupdf4llm_available": is_pymupdf4llm_available(),
+                "comparison_results": comparison_results,
+                "traditional_blocks": traditional_blocks,
+                "pymupdf4llm_blocks": pymupdf4llm_blocks,
+            },
+            f,
+            indent=2,
+            default=str,
+        )
+
     print(f"\nDetailed results saved to: {output_file}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/validate_chunk_quality.py
+++ b/scripts/validate_chunk_quality.py
@@ -34,11 +34,11 @@ from pdf_chunker.core import process_document
 
 # Centralized chunk threshold constants (matching splitter.py)
 VALIDATION_THRESHOLDS = {
-    'very_short': 9,      # Very short chunks (≤5 words) - quality concern
-    'short': 12,          # Short chunks (≤10 words) - potential quality issue
-    'minimal': 15,        # Minimal chunks (≤15 words) - acceptable but monitored
-    'dialogue_response': 6,  # Short dialogue responses (≤6 words)
-    'fragment': 4         # Very short fragments (≤4 words) - critical issue
+    "very_short": 9,  # Very short chunks (≤5 words) - quality concern
+    "short": 12,  # Short chunks (≤10 words) - potential quality issue
+    "minimal": 15,  # Minimal chunks (≤15 words) - acceptable but monitored
+    "dialogue_response": 6,  # Short dialogue responses (≤6 words)
+    "fragment": 4,  # Very short fragments (≤4 words) - critical issue
 }
 
 
@@ -46,7 +46,7 @@ def load_jsonl(filepath: str) -> List[Dict[str, Any]]:
     """Load chunks from a JSONL file."""
     chunks = []
     try:
-        with open(filepath, 'r', encoding='utf-8') as f:
+        with open(filepath, "r", encoding="utf-8") as f:
             for line_num, line in enumerate(f, 1):
                 line = line.strip()
                 if not line:
@@ -55,7 +55,10 @@ def load_jsonl(filepath: str) -> List[Dict[str, Any]]:
                     chunk = json.loads(line)
                     chunks.append(chunk)
                 except json.JSONDecodeError as e:
-                    print(f"Warning: Invalid JSON on line {line_num}: {e}", file=sys.stderr)
+                    print(
+                        f"Warning: Invalid JSON on line {line_num}: {e}",
+                        file=sys.stderr,
+                    )
                     continue
     except FileNotFoundError:
         print(f"Error: File '{filepath}' not found", file=sys.stderr)
@@ -71,17 +74,17 @@ def analyze_chunk_sizes(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Analyze chunk size distribution and statistics."""
     if not chunks:
         return {
-            'total_chunks': 0,
-            'word_counts': [],
-            'char_counts': [],
-            'statistics': {}
+            "total_chunks": 0,
+            "word_counts": [],
+            "char_counts": [],
+            "statistics": {},
         }
 
     word_counts = []
     char_counts = []
 
     for chunk in chunks:
-        text = chunk.get('text', '')
+        text = chunk.get("text", "")
         if text:
             words = len(text.split())
             chars = len(text)
@@ -90,74 +93,73 @@ def analyze_chunk_sizes(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
 
     if not word_counts:
         return {
-            'total_chunks': len(chunks),
-            'word_counts': [],
-            'char_counts': [],
-            'statistics': {}
+            "total_chunks": len(chunks),
+            "word_counts": [],
+            "char_counts": [],
+            "statistics": {},
         }
 
     # Calculate statistics
     word_stats = {
-        'mean': statistics.mean(word_counts),
-        'median': statistics.median(word_counts),
-        'mode': statistics.mode(word_counts) if word_counts else 0,
-        'min': min(word_counts),
-        'max': max(word_counts),
-        'std_dev': statistics.stdev(word_counts) if len(word_counts) > 1 else 0
+        "mean": statistics.mean(word_counts),
+        "median": statistics.median(word_counts),
+        "mode": statistics.mode(word_counts) if word_counts else 0,
+        "min": min(word_counts),
+        "max": max(word_counts),
+        "std_dev": statistics.stdev(word_counts) if len(word_counts) > 1 else 0,
     }
 
     char_stats = {
-        'mean': statistics.mean(char_counts),
-        'median': statistics.median(char_counts),
-        'min': min(char_counts),
-        'max': max(char_counts),
-        'std_dev': statistics.stdev(char_counts) if len(char_counts) > 1 else 0
+        "mean": statistics.mean(char_counts),
+        "median": statistics.median(char_counts),
+        "min": min(char_counts),
+        "max": max(char_counts),
+        "std_dev": statistics.stdev(char_counts) if len(char_counts) > 1 else 0,
     }
 
     return {
-        'total_chunks': len(chunks),
-        'word_counts': word_counts,
-        'char_counts': char_counts,
-        'statistics': {
-            'words': word_stats,
-            'characters': char_stats
-        }
+        "total_chunks": len(chunks),
+        "word_counts": word_counts,
+        "char_counts": char_counts,
+        "statistics": {"words": word_stats, "characters": char_stats},
     }
 
 
-def detect_short_chunks(chunks: List[Dict[str, Any]], thresholds: Dict[str, int] = None) -> Dict[str, Any]:
+def detect_short_chunks(
+    chunks: List[Dict[str, Any]], thresholds: Dict[str, int] = None
+) -> Dict[str, Any]:
     """Detect and categorize short chunks using centralized thresholds."""
     if thresholds is None:
         thresholds = VALIDATION_THRESHOLDS
 
     categorized_chunks = {
-        'very_short': [],  # ≤ 5 words
-        'short': [],       # 6-10 words
-        'minimal': [],     # 11-15 words
-        'normal': []       # > 15 words
+        "very_short": [],  # ≤ 5 words
+        "short": [],  # 6-10 words
+        "minimal": [],  # 11-15 words
+        "normal": [],  # > 15 words
     }
 
-
     for i, chunk in enumerate(chunks):
-        text = chunk.get('text', '')
+        text = chunk.get("text", "")
         word_count = len(text.split()) if text else 0
 
         chunk_info = {
-            'index': i,
-            'word_count': word_count,
-            'char_count': len(text),
-            'text_preview': text[:100].replace('\n', ' ') + ('...' if len(text) > 100 else ''),
-            'full_text': text
+            "index": i,
+            "word_count": word_count,
+            "char_count": len(text),
+            "text_preview": text[:100].replace("\n", " ")
+            + ("..." if len(text) > 100 else ""),
+            "full_text": text,
         }
 
-        if word_count <= thresholds['very_short']:
-            categorized_chunks['very_short'].append(chunk_info)
-        elif word_count <= thresholds['short']:
-            categorized_chunks['short'].append(chunk_info)
-        elif word_count <= thresholds['minimal']:
-            categorized_chunks['minimal'].append(chunk_info)
+        if word_count <= thresholds["very_short"]:
+            categorized_chunks["very_short"].append(chunk_info)
+        elif word_count <= thresholds["short"]:
+            categorized_chunks["short"].append(chunk_info)
+        elif word_count <= thresholds["minimal"]:
+            categorized_chunks["minimal"].append(chunk_info)
         else:
-            categorized_chunks['normal'].append(chunk_info)
+            categorized_chunks["normal"].append(chunk_info)
 
     return categorized_chunks
 
@@ -165,31 +167,51 @@ def detect_short_chunks(chunks: List[Dict[str, Any]], thresholds: Dict[str, int]
 def detect_dialogue_patterns(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Detect dialogue and conversational patterns in chunks using centralized thresholds."""
     dialogue_patterns = {
-        'quoted_speech': [],
-        'dialogue_attribution': [],
-        'conversational_responses': [],
-        'potential_fragments': []
+        "quoted_speech": [],
+        "dialogue_attribution": [],
+        "conversational_responses": [],
+        "potential_fragments": [],
     }
 
     # Patterns for detecting dialogue
     quote_pattern = r'"[^"]*"'
     attribution_words = [
-        'said', 'replied', 'asked', 'answered', 'continued', 'added', 'noted',
-        'observed', 'remarked', 'stated', 'declared', 'exclaimed', 'whispered',
-        'shouted', 'muttered', 'explained', 'insisted', 'argued', 'suggested',
-        'wondered', 'thought', 'concluded', 'responded', 'commented'
+        "said",
+        "replied",
+        "asked",
+        "answered",
+        "continued",
+        "added",
+        "noted",
+        "observed",
+        "remarked",
+        "stated",
+        "declared",
+        "exclaimed",
+        "whispered",
+        "shouted",
+        "muttered",
+        "explained",
+        "insisted",
+        "argued",
+        "suggested",
+        "wondered",
+        "thought",
+        "concluded",
+        "responded",
+        "commented",
     ]
 
     def _analyze_chunk_info(i: int, text: str, word_count: int) -> Dict[str, Any]:
         """Helper function to create standardized chunk info."""
         return {
-            'index': i,
-            'word_count': word_count,
-            'text_preview': text[:100].replace('\n', ' ')
+            "index": i,
+            "word_count": word_count,
+            "text_preview": text[:100].replace("\n", " "),
         }
 
     for i, chunk in enumerate(chunks):
-        text = chunk.get('text', '')
+        text = chunk.get("text", "")
         if not text:
             continue
 
@@ -200,50 +222,60 @@ def detect_dialogue_patterns(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
         quotes = re.findall(quote_pattern, text)
         if quotes:
             chunk_info = _analyze_chunk_info(i, text, word_count)
-            chunk_info.update({
-                'quote_count': len(quotes),
-                'quotes': quotes[:3]
-            })
-            dialogue_patterns['quoted_speech'].append(chunk_info)
+            chunk_info.update({"quote_count": len(quotes), "quotes": quotes[:3]})
+            dialogue_patterns["quoted_speech"].append(chunk_info)
 
         # Check for dialogue attribution using centralized thresholds
         attribution_found = any(word in text_lower for word in attribution_words)
-        if attribution_found and word_count <= VALIDATION_THRESHOLDS['short']:
+        if attribution_found and word_count <= VALIDATION_THRESHOLDS["short"]:
             chunk_info = _analyze_chunk_info(i, text, word_count)
-            chunk_info['attribution_words'] = [word for word in attribution_words if word in text_lower]
-            dialogue_patterns['dialogue_attribution'].append(chunk_info)
+            chunk_info["attribution_words"] = [
+                word for word in attribution_words if word in text_lower
+            ]
+            dialogue_patterns["dialogue_attribution"].append(chunk_info)
 
         # Check for conversational responses using centralized thresholds
-        if VALIDATION_THRESHOLDS['very_short'] <= word_count <= VALIDATION_THRESHOLDS['dialogue_response']:
+        if (
+            VALIDATION_THRESHOLDS["very_short"]
+            <= word_count
+            <= VALIDATION_THRESHOLDS["dialogue_response"]
+        ):
             response_indicators = [
-                text.strip().endswith('?'),
-                text.strip().startswith(('Yes', 'No', 'Well', 'Oh', 'Ah', 'Indeed', 'Certainly')),
-                any(word in text_lower for word in ['indeed', 'certainly', 'perhaps', 'maybe', 'probably'])
+                text.strip().endswith("?"),
+                text.strip().startswith(
+                    ("Yes", "No", "Well", "Oh", "Ah", "Indeed", "Certainly")
+                ),
+                any(
+                    word in text_lower
+                    for word in ["indeed", "certainly", "perhaps", "maybe", "probably"]
+                ),
             ]
             if any(response_indicators):
                 chunk_info = _analyze_chunk_info(i, text, word_count)
-                chunk_info['indicators'] = [
-                    ind for ind, present in zip(
-                        ['question', 'starter', 'qualifier'], response_indicators
-                    ) if present
+                chunk_info["indicators"] = [
+                    ind
+                    for ind, present in zip(
+                        ["question", "starter", "qualifier"], response_indicators
+                    )
+                    if present
                 ]
-                dialogue_patterns['conversational_responses'].append(chunk_info)
+                dialogue_patterns["conversational_responses"].append(chunk_info)
 
         # Check for potential fragments using centralized thresholds
-        if word_count <= VALIDATION_THRESHOLDS['very_short']:
+        if word_count <= VALIDATION_THRESHOLDS["very_short"]:
             is_complete_sentence = (
-                text.strip().endswith(('.', '!', '?')) and
-                text.strip()[0].isupper() and
-                word_count >= VALIDATION_THRESHOLDS['fragment']
+                text.strip().endswith((".", "!", "?"))
+                and text.strip()[0].isupper()
+                and word_count >= VALIDATION_THRESHOLDS["fragment"]
             )
             if not is_complete_sentence:
                 chunk_info = _analyze_chunk_info(i, text, word_count)
-                chunk_info['issues'] = {
-                    'no_end_punctuation': not text.strip().endswith(('.', '!', '?')),
-                    'no_capitalization': not text.strip()[0].isupper(),
-                    'too_short': word_count < VALIDATION_THRESHOLDS['fragment']
+                chunk_info["issues"] = {
+                    "no_end_punctuation": not text.strip().endswith((".", "!", "?")),
+                    "no_capitalization": not text.strip()[0].isupper(),
+                    "too_short": word_count < VALIDATION_THRESHOLDS["fragment"],
                 }
-                dialogue_patterns['potential_fragments'].append(chunk_info)
+                dialogue_patterns["potential_fragments"].append(chunk_info)
 
     return dialogue_patterns
 
@@ -251,10 +283,10 @@ def detect_dialogue_patterns(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
 def analyze_chunk_flow(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Analyze text flow and continuity between chunks."""
     flow_analysis = {
-        'abrupt_transitions': [],
-        'potential_splits': [],
-        'continuation_issues': [],
-        'flow_score': 0.0
+        "abrupt_transitions": [],
+        "potential_splits": [],
+        "continuation_issues": [],
+        "flow_score": 0.0,
     }
 
     if len(chunks) < 2:
@@ -267,97 +299,111 @@ def analyze_chunk_flow(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
         current_chunk = chunks[i]
         next_chunk = chunks[i + 1]
 
-        current_text = current_chunk.get('text', '').strip()
-        next_text = next_chunk.get('text', '').strip()
+        current_text = current_chunk.get("text", "").strip()
+        next_text = next_chunk.get("text", "").strip()
 
         if not current_text or not next_text:
             continue
 
         # Check for abrupt transitions
-        current_ends_incomplete = not current_text.endswith(('.', '!', '?', ':', ';'))
+        current_ends_incomplete = not current_text.endswith((".", "!", "?", ":", ";"))
         next_starts_lowercase = next_text and next_text[0].islower()
 
         if current_ends_incomplete and next_starts_lowercase:
-            flow_analysis['abrupt_transitions'].append({
-                'current_index': i,
-                'next_index': i + 1,
-                'current_end': current_text[-30:],
-                'next_start': next_text[:30],
-                'issue': 'incomplete_sentence_split'
-            })
+            flow_analysis["abrupt_transitions"].append(
+                {
+                    "current_index": i,
+                    "next_index": i + 1,
+                    "current_end": current_text[-30:],
+                    "next_start": next_text[:30],
+                    "issue": "incomplete_sentence_split",
+                }
+            )
             issues_count += 1
 
         # Check for potential word splits
         current_words = current_text.split()
         next_words = next_text.split()
 
-        if (current_words and next_words and
-            len(current_words[-1]) < 4 and
-            len(next_words[0]) < 8 and
-            next_words[0][0].islower()):
+        if (
+            current_words
+            and next_words
+            and len(current_words[-1]) < 4
+            and len(next_words[0]) < 8
+            and next_words[0][0].islower()
+        ):
 
-            flow_analysis['potential_splits'].append({
-                'current_index': i,
-                'next_index': i + 1,
-                'potential_word': f"{current_words[-1]}|{next_words[0]}",
-                'current_end': current_text[-20:],
-                'next_start': next_text[:20]
-            })
+            flow_analysis["potential_splits"].append(
+                {
+                    "current_index": i,
+                    "next_index": i + 1,
+                    "potential_word": f"{current_words[-1]}|{next_words[0]}",
+                    "current_end": current_text[-20:],
+                    "next_start": next_text[:20],
+                }
+            )
             issues_count += 1
 
         # Check for continuation issues (very short chunks followed by related content)
         current_word_count = len(current_words)
         next_word_count = len(next_words)
 
-        if (current_word_count <= 5 and next_word_count <= 10 and
-            not current_text.endswith(('.', '!', '?'))):
+        if (
+            current_word_count <= 5
+            and next_word_count <= 10
+            and not current_text.endswith((".", "!", "?"))
+        ):
 
-            flow_analysis['continuation_issues'].append({
-                'current_index': i,
-                'next_index': i + 1,
-                'current_words': current_word_count,
-                'next_words': next_word_count,
-                'current_text': current_text,
-                'next_text': next_text[:50]
-            })
+            flow_analysis["continuation_issues"].append(
+                {
+                    "current_index": i,
+                    "next_index": i + 1,
+                    "current_words": current_word_count,
+                    "next_words": next_word_count,
+                    "current_text": current_text,
+                    "next_text": next_text[:50],
+                }
+            )
             issues_count += 1
 
     # Calculate flow score (1.0 = perfect, 0.0 = many issues)
     if total_transitions > 0:
-        flow_analysis['flow_score'] = max(0.0, 1.0 - (issues_count / total_transitions))
+        flow_analysis["flow_score"] = max(0.0, 1.0 - (issues_count / total_transitions))
     else:
-        flow_analysis['flow_score'] = 1.0
+        flow_analysis["flow_score"] = 1.0
 
     return flow_analysis
 
 
-def generate_quality_report(chunks: List[Dict[str, Any]], filename: str = "unknown") -> Dict[str, Any]:
+def generate_quality_report(
+    chunks: List[Dict[str, Any]], filename: str = "unknown"
+) -> Dict[str, Any]:
     """Generate a comprehensive quality report for chunks using centralized thresholds."""
     # Always include summary_stats, even if empty
     summary_stats = {
-        'total_chunks': len(chunks) if chunks else 0,
-        'total_words': 0,
-        'total_characters': 0,
-        'avg_words_per_chunk': 0,
-        'very_short_chunks': 0,
-        'short_chunks': 0,
-        'dialogue_chunks': 0,
-        'flow_issues': 0
+        "total_chunks": len(chunks) if chunks else 0,
+        "total_words": 0,
+        "total_characters": 0,
+        "avg_words_per_chunk": 0,
+        "very_short_chunks": 0,
+        "short_chunks": 0,
+        "dialogue_chunks": 0,
+        "flow_issues": 0,
     }
 
     if not chunks:
         return {
-            'filename': filename,
-            'total_chunks': 0,
-            'quality_score': 0.0,
-            'quality_factors': [],
-            'summary_stats': summary_stats,
-            'size_analysis': {},
-            'short_chunks': {},
-            'dialogue_analysis': {},
-            'flow_analysis': {},
-            'issues': ['No chunks found'],
-            'recommendations': ['Check input file and processing pipeline']
+            "filename": filename,
+            "total_chunks": 0,
+            "quality_score": 0.0,
+            "quality_factors": [],
+            "summary_stats": summary_stats,
+            "size_analysis": {},
+            "short_chunks": {},
+            "dialogue_analysis": {},
+            "flow_analysis": {},
+            "issues": ["No chunks found"],
+            "recommendations": ["Check input file and processing pipeline"],
         }
 
     # Analyze different aspects using centralized thresholds
@@ -368,28 +414,32 @@ def generate_quality_report(chunks: List[Dict[str, Any]], filename: str = "unkno
 
     def _calculate_size_quality_factor() -> Tuple[str, float, float]:
         """Calculate size distribution quality factor."""
-        word_counts = size_analysis['word_counts']
+        word_counts = size_analysis["word_counts"]
         if not word_counts:
-            return ('size_distribution', 0.0, 0.3)
+            return ("size_distribution", 0.0, 0.3)
 
-        very_short_ratio = len(short_chunks['very_short']) / len(chunks)
-        short_ratio = len(short_chunks['short']) / len(chunks)
+        very_short_ratio = len(short_chunks["very_short"]) / len(chunks)
+        short_ratio = len(short_chunks["short"]) / len(chunks)
 
         size_score = 1.0 - (very_short_ratio * 0.8 + short_ratio * 0.4)
-        return ('size_distribution', size_score, 0.3)
+        return ("size_distribution", size_score, 0.3)
 
     def _calculate_dialogue_quality_factor() -> Tuple[str, float, float]:
         """Calculate dialogue handling quality factor."""
-        total_dialogue_chunks = (len(dialogue_analysis['quoted_speech']) +
-                                 len(dialogue_analysis['dialogue_attribution']) +
-                                 len(dialogue_analysis['conversational_responses']))
+        total_dialogue_chunks = (
+            len(dialogue_analysis["quoted_speech"])
+            + len(dialogue_analysis["dialogue_attribution"])
+            + len(dialogue_analysis["conversational_responses"])
+        )
 
         if total_dialogue_chunks == 0:
-            return ('dialogue_handling', 1.0, 0.3)
+            return ("dialogue_handling", 1.0, 0.3)
 
-        fragment_ratio = len(dialogue_analysis['potential_fragments']) / total_dialogue_chunks
+        fragment_ratio = (
+            len(dialogue_analysis["potential_fragments"]) / total_dialogue_chunks
+        )
         dialogue_score = max(0.0, 1.0 - fragment_ratio)
-        return ('dialogue_handling', dialogue_score, 0.3)
+        return ("dialogue_handling", dialogue_score, 0.3)
 
     # Calculate quality factors using helper functions
     quality_factors = []
@@ -401,27 +451,39 @@ def generate_quality_report(chunks: List[Dict[str, Any]], filename: str = "unkno
     quality_factors.append(size_factor)
 
     if size_factor[1] < 0.8:  # If size score is poor
-        very_short_ratio = len(short_chunks['very_short']) / len(chunks)
-        short_ratio = len(short_chunks['short']) / len(chunks)
+        very_short_ratio = len(short_chunks["very_short"]) / len(chunks)
+        short_ratio = len(short_chunks["short"]) / len(chunks)
 
         if very_short_ratio > 0.1:
-            issues.append(f"High ratio of very short chunks (≤{VALIDATION_THRESHOLDS['very_short']} words): {very_short_ratio:.1%}")
-            recommendations.append("Consider adjusting minimum chunk size or improving merging logic")
+            issues.append(
+                f"High ratio of very short chunks (≤{VALIDATION_THRESHOLDS['very_short']} words): {very_short_ratio:.1%}"
+            )
+            recommendations.append(
+                "Consider adjusting minimum chunk size or improving merging logic"
+            )
 
         if short_ratio > 0.2:
-            issues.append(f"High ratio of short chunks (≤{VALIDATION_THRESHOLDS['short']} words): {short_ratio:.1%}")
-            recommendations.append("Review conversational text handling and chunk merging")
+            issues.append(
+                f"High ratio of short chunks (≤{VALIDATION_THRESHOLDS['short']} words): {short_ratio:.1%}"
+            )
+            recommendations.append(
+                "Review conversational text handling and chunk merging"
+            )
 
     # Factor 2: Text flow quality (0.4 weight)
-    flow_score = flow_analysis['flow_score']
-    quality_factors.append(('text_flow', flow_score, 0.4))
+    flow_score = flow_analysis["flow_score"]
+    quality_factors.append(("text_flow", flow_score, 0.4))
 
     if flow_score < 0.8:
         issues.append(f"Poor text flow continuity: {flow_score:.2f}")
-        recommendations.append("Improve page boundary handling and sentence reconstruction")
+        recommendations.append(
+            "Improve page boundary handling and sentence reconstruction"
+        )
 
-    if len(flow_analysis['abrupt_transitions']) > 0:
-        issues.append(f"{len(flow_analysis['abrupt_transitions'])} abrupt transitions detected")
+    if len(flow_analysis["abrupt_transitions"]) > 0:
+        issues.append(
+            f"{len(flow_analysis['abrupt_transitions'])} abrupt transitions detected"
+        )
         recommendations.append("Review semantic chunking boundaries")
 
     # Factor 3: Dialogue handling (0.3 weight)
@@ -429,174 +491,218 @@ def generate_quality_report(chunks: List[Dict[str, Any]], filename: str = "unkno
     quality_factors.append(dialogue_factor)
 
     if dialogue_factor[1] < 0.7:
-        fragment_ratio = len(dialogue_analysis['potential_fragments']) / max(1, len(dialogue_analysis['quoted_speech']) + len(dialogue_analysis['dialogue_attribution']) + len(dialogue_analysis['conversational_responses']))
+        fragment_ratio = len(dialogue_analysis["potential_fragments"]) / max(
+            1,
+            len(dialogue_analysis["quoted_speech"])
+            + len(dialogue_analysis["dialogue_attribution"])
+            + len(dialogue_analysis["conversational_responses"]),
+        )
         issues.append(f"High dialogue fragmentation: {fragment_ratio:.1%}")
         recommendations.append("Improve dialogue pattern detection and merging")
 
     return {
-        'filename': filename,
-        'quality_score': sum(score * weight for _, score, weight in quality_factors),
-        'quality_factors': quality_factors,
-        'summary_stats': {
-            'total_chunks': len(chunks),
-            'total_words': sum(size_analysis['word_counts']),
-            'total_characters': sum(size_analysis['char_counts']),
-            'avg_words_per_chunk': size_analysis['statistics']['words']['mean'],
-            'very_short_chunks': len(short_chunks['very_short']),
-            'short_chunks': len(short_chunks['short']),
-            'dialogue_chunks': (len(dialogue_analysis['quoted_speech']) +
-                                len(dialogue_analysis['dialogue_attribution']) +
-                                len(dialogue_analysis['conversational_responses'])),
-            'flow_issues': len(flow_analysis['abrupt_transitions']) + len(flow_analysis['potential_splits'])
+        "filename": filename,
+        "quality_score": sum(score * weight for _, score, weight in quality_factors),
+        "quality_factors": quality_factors,
+        "summary_stats": {
+            "total_chunks": len(chunks),
+            "total_words": sum(size_analysis["word_counts"]),
+            "total_characters": sum(size_analysis["char_counts"]),
+            "avg_words_per_chunk": size_analysis["statistics"]["words"]["mean"],
+            "very_short_chunks": len(short_chunks["very_short"]),
+            "short_chunks": len(short_chunks["short"]),
+            "dialogue_chunks": (
+                len(dialogue_analysis["quoted_speech"])
+                + len(dialogue_analysis["dialogue_attribution"])
+                + len(dialogue_analysis["conversational_responses"])
+            ),
+            "flow_issues": len(flow_analysis["abrupt_transitions"])
+            + len(flow_analysis["potential_splits"]),
         },
-        'size_analysis': size_analysis,
-        'short_chunks': short_chunks,
-        'dialogue_analysis': dialogue_analysis,
-        'flow_analysis': flow_analysis,
-        'issues': issues,
-        'recommendations': recommendations
+        "size_analysis": size_analysis,
+        "short_chunks": short_chunks,
+        "dialogue_analysis": dialogue_analysis,
+        "flow_analysis": flow_analysis,
+        "issues": issues,
+        "recommendations": recommendations,
     }
 
 
 def detect_word_gluing_issues(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Detect word gluing issues in chunks."""
     import re
-    
+
     gluing_issues = {
         "case_transition_gluing": 0,
         "page_boundary_gluing": 0,
         "quote_boundary_gluing": 0,
         "total_chunks_affected": 0,
-        "examples": []
+        "examples": [],
     }
-    
+
     for i, chunk in enumerate(chunks):
-        text = chunk.get('text', '')
+        text = chunk.get("text", "")
         if not text:
             continue
-        
+
         chunk_has_issues = False
-        
+
         # Check for case transition gluing (lowercase followed by uppercase)
-        case_transitions = re.findall(r'[a-z][A-Z][a-z]', text)
+        case_transitions = re.findall(r"[a-z][A-Z][a-z]", text)
         if case_transitions:
             gluing_issues["case_transition_gluing"] += len(case_transitions)
             chunk_has_issues = True
             if len(gluing_issues["examples"]) < 3:
-                gluing_issues["examples"].append({
-                    "type": "case_transition",
-                    "chunk_index": i,
-                    "example": case_transitions[0],
-                    "context": text[max(0, text.find(case_transitions[0]) - 20):text.find(case_transitions[0]) + 30]
-                })
-        
+                gluing_issues["examples"].append(
+                    {
+                        "type": "case_transition",
+                        "chunk_index": i,
+                        "example": case_transitions[0],
+                        "context": text[
+                            max(0, text.find(case_transitions[0]) - 20) : text.find(
+                                case_transitions[0]
+                            )
+                            + 30
+                        ],
+                    }
+                )
+
         # Check for quote boundary gluing
         quote_gluing = re.findall(r'[a-z]"[a-z]|[a-z]\'[a-z]', text)
         if quote_gluing:
             gluing_issues["quote_boundary_gluing"] += len(quote_gluing)
             chunk_has_issues = True
             if len(gluing_issues["examples"]) < 3:
-                gluing_issues["examples"].append({
-                    "type": "quote_boundary",
-                    "chunk_index": i,
-                    "example": quote_gluing[0],
-                    "context": text[max(0, text.find(quote_gluing[0]) - 20):text.find(quote_gluing[0]) + 30]
-                })
-        
+                gluing_issues["examples"].append(
+                    {
+                        "type": "quote_boundary",
+                        "chunk_index": i,
+                        "example": quote_gluing[0],
+                        "context": text[
+                            max(0, text.find(quote_gluing[0]) - 20) : text.find(
+                                quote_gluing[0]
+                            )
+                            + 30
+                        ],
+                    }
+                )
+
         # Check for potential page boundary issues (very long words that might be glued)
-        long_words = re.findall(r'\b\w{15,}\b', text)
-        suspicious_long_words = [word for word in long_words if re.search(r'[a-z][A-Z]', word)]
+        long_words = re.findall(r"\b\w{15,}\b", text)
+        suspicious_long_words = [
+            word for word in long_words if re.search(r"[a-z][A-Z]", word)
+        ]
         if suspicious_long_words:
             gluing_issues["page_boundary_gluing"] += len(suspicious_long_words)
             chunk_has_issues = True
             if len(gluing_issues["examples"]) < 3:
-                gluing_issues["examples"].append({
-                    "type": "page_boundary",
-                    "chunk_index": i,
-                    "example": suspicious_long_words[0],
-                    "context": text[max(0, text.find(suspicious_long_words[0]) - 20):text.find(suspicious_long_words[0]) + 30]
-                })
-        
+                gluing_issues["examples"].append(
+                    {
+                        "type": "page_boundary",
+                        "chunk_index": i,
+                        "example": suspicious_long_words[0],
+                        "context": text[
+                            max(
+                                0, text.find(suspicious_long_words[0]) - 20
+                            ) : text.find(suspicious_long_words[0])
+                            + 30
+                        ],
+                    }
+                )
+
         if chunk_has_issues:
             gluing_issues["total_chunks_affected"] += 1
-    
+
     return gluing_issues
 
 
 def detect_text_reordering_issues(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Detect text reordering and corruption issues in chunks."""
     import re
-    
+
     reordering_issues = {
         "quote_splitting_issues": 0,
         "sentence_fragmentation": 0,
         "suspicious_starts": 0,
         "json_escaping_issues": 0,
         "total_chunks_affected": 0,
-        "examples": []
+        "examples": [],
     }
-    
+
     for i, chunk in enumerate(chunks):
-        text = chunk.get('text', '')
+        text = chunk.get("text", "")
         if not text:
             continue
-        
+
         chunk_has_issues = False
-        
+
         # Check for quote splitting issues (text starting with quote fragments)
         if re.match(r'^[",]\s*[a-z]', text.strip()):
             reordering_issues["quote_splitting_issues"] += 1
             chunk_has_issues = True
             if len(reordering_issues["examples"]) < 3:
-                reordering_issues["examples"].append({
-                    "type": "quote_splitting",
-                    "chunk_index": i,
-                    "example": text[:50],
-                    "issue": "Chunk starts with quote fragment"
-                })
-        
+                reordering_issues["examples"].append(
+                    {
+                        "type": "quote_splitting",
+                        "chunk_index": i,
+                        "example": text[:50],
+                        "issue": "Chunk starts with quote fragment",
+                    }
+                )
+
         # Check for sentence fragmentation (starts with lowercase, no capital)
-        if text.strip() and text.strip()[0].islower() and not text.strip().startswith(('and', 'but', 'or', 'so')):
+        if (
+            text.strip()
+            and text.strip()[0].islower()
+            and not text.strip().startswith(("and", "but", "or", "so"))
+        ):
             reordering_issues["sentence_fragmentation"] += 1
             chunk_has_issues = True
             if len(reordering_issues["examples"]) < 3:
-                reordering_issues["examples"].append({
-                    "type": "sentence_fragmentation",
-                    "chunk_index": i,
-                    "example": text[:50],
-                    "issue": "Chunk starts with lowercase (possible fragment)"
-                })
-        
+                reordering_issues["examples"].append(
+                    {
+                        "type": "sentence_fragmentation",
+                        "chunk_index": i,
+                        "example": text[:50],
+                        "issue": "Chunk starts with lowercase (possible fragment)",
+                    }
+                )
+
         # Check for suspicious starts (punctuation at beginning)
-        if re.match(r'^[,.;:]\s', text.strip()):
+        if re.match(r"^[,.;:]\s", text.strip()):
             reordering_issues["suspicious_starts"] += 1
             chunk_has_issues = True
             if len(reordering_issues["examples"]) < 3:
-                reordering_issues["examples"].append({
-                    "type": "suspicious_start",
-                    "chunk_index": i,
-                    "example": text[:50],
-                    "issue": "Chunk starts with punctuation"
-                })
-        
+                reordering_issues["examples"].append(
+                    {
+                        "type": "suspicious_start",
+                        "chunk_index": i,
+                        "example": text[:50],
+                        "issue": "Chunk starts with punctuation",
+                    }
+                )
+
         # Check for potential JSON escaping issues
         try:
             import json
+
             json.dumps({"text": text})
         except (json.JSONEncodeError, UnicodeEncodeError):
             reordering_issues["json_escaping_issues"] += 1
             chunk_has_issues = True
             if len(reordering_issues["examples"]) < 3:
-                reordering_issues["examples"].append({
-                    "type": "json_escaping",
-                    "chunk_index": i,
-                    "example": text[:50],
-                    "issue": "Text cannot be JSON serialized"
-                })
-        
+                reordering_issues["examples"].append(
+                    {
+                        "type": "json_escaping",
+                        "chunk_index": i,
+                        "example": text[:50],
+                        "issue": "Text cannot be JSON serialized",
+                    }
+                )
+
         if chunk_has_issues:
             reordering_issues["total_chunks_affected"] += 1
-    
+
     return reordering_issues
 
 
@@ -607,49 +713,55 @@ def validate_text_processing_quality(chunks: List[Dict[str, Any]]) -> Dict[str, 
         "word_gluing_issues": detect_word_gluing_issues(chunks),
         "text_reordering_issues": detect_text_reordering_issues(chunks),
         "overall_quality_score": 0.0,
-        "recommendations": []
+        "recommendations": [],
     }
-    
+
     # Calculate overall quality score
     total_issues = (
-        validation_results["word_gluing_issues"]["total_chunks_affected"] +
-        validation_results["text_reordering_issues"]["total_chunks_affected"]
+        validation_results["word_gluing_issues"]["total_chunks_affected"]
+        + validation_results["text_reordering_issues"]["total_chunks_affected"]
     )
-    
+
     if validation_results["total_chunks"] > 0:
-        quality_score = max(0.0, 1.0 - (total_issues / validation_results["total_chunks"]))
+        quality_score = max(
+            0.0, 1.0 - (total_issues / validation_results["total_chunks"])
+        )
         validation_results["overall_quality_score"] = quality_score
-    
+
     # Generate recommendations
     if validation_results["word_gluing_issues"]["case_transition_gluing"] > 0:
         validation_results["recommendations"].append(
             "Consider enabling enhanced word boundary detection to fix case transition gluing"
         )
-    
+
     if validation_results["text_reordering_issues"]["quote_splitting_issues"] > 0:
         validation_results["recommendations"].append(
             "Consider enabling enhanced quote handling to fix quote splitting issues"
         )
-    
+
     if validation_results["text_reordering_issues"]["json_escaping_issues"] > 0:
         validation_results["recommendations"].append(
             "Consider enabling enhanced JSON safety validation and repair"
         )
-    
+
     if validation_results["overall_quality_score"] < 0.8:
         validation_results["recommendations"].append(
             "Overall text quality is below recommended threshold - consider enabling PyMuPDF4LLM enhancement"
         )
-    
+
     return validation_results
 
 
 def print_text_processing_validation_report(validation_results: Dict[str, Any]):
     """Print a detailed text processing validation report."""
-    print("================================================================================")
+    print(
+        "================================================================================"
+    )
     print("TEXT PROCESSING QUALITY VALIDATION REPORT")
-    print("================================================================================")
-    
+    print(
+        "================================================================================"
+    )
+
     print(f"Total Chunks Analyzed: {validation_results['total_chunks']}")
     print(f"Overall Quality Score: {validation_results['overall_quality_score']:.3f}")
 
@@ -682,9 +794,9 @@ def print_text_processing_validation_report(validation_results: Dict[str, Any]):
         for i, example in enumerate(all_examples[:5]):  # Show up to 5 examples
             print(f"Example {i+1} ({example['type']}):")
             print(f"  Chunk {example['chunk_index']}: {example.get('example', 'N/A')}")
-            if 'context' in example:
+            if "context" in example:
                 print(f"  Context: ...{example['context']}...")
-            if 'issue' in example:
+            if "issue" in example:
                 print(f"  Issue: {example['issue']}")
             print()
 
@@ -695,64 +807,85 @@ def print_text_processing_validation_report(validation_results: Dict[str, Any]):
         for i, rec in enumerate(validation_results["recommendations"], 1):
             print(f"{i}. {rec}")
         print()
-    
 
 
-def compare_quality_reports(report1: Dict[str, Any], report2: Dict[str, Any]) -> Dict[str, Any]:
+def compare_quality_reports(
+    report1: Dict[str, Any], report2: Dict[str, Any]
+) -> Dict[str, Any]:
     """Compare two quality reports and generate improvement analysis."""
     comparison = {
-        'file1': report1['filename'],
-        'file2': report2['filename'],
-        'quality_improvement': report2['quality_score'] - report1['quality_score'],
-        'improvements': [],
-        'regressions': [],
-        'summary': {}
+        "file1": report1["filename"],
+        "file2": report2["filename"],
+        "quality_improvement": report2["quality_score"] - report1["quality_score"],
+        "improvements": [],
+        "regressions": [],
+        "summary": {},
     }
 
     # Compare summary statistics
-    stats1 = report1['summary_stats']
-    stats2 = report2['summary_stats']
+    stats1 = report1["summary_stats"]
+    stats2 = report2["summary_stats"]
 
-    comparison['summary'] = {
-        'chunk_count_change': stats2['total_chunks'] - stats1['total_chunks'],
-        'very_short_change': stats2['very_short_chunks'] - stats1['very_short_chunks'],
-        'short_change': stats2['short_chunks'] - stats1['short_chunks'],
-        'flow_issues_change': stats2['flow_issues'] - stats1['flow_issues'],
-        'dialogue_chunks_change': stats2['dialogue_chunks'] - stats1['dialogue_chunks']
+    comparison["summary"] = {
+        "chunk_count_change": stats2["total_chunks"] - stats1["total_chunks"],
+        "very_short_change": stats2["very_short_chunks"] - stats1["very_short_chunks"],
+        "short_change": stats2["short_chunks"] - stats1["short_chunks"],
+        "flow_issues_change": stats2["flow_issues"] - stats1["flow_issues"],
+        "dialogue_chunks_change": stats2["dialogue_chunks"] - stats1["dialogue_chunks"],
     }
 
     # Analyze improvements and regressions
-    if comparison['summary']['very_short_change'] < 0:
-        comparison['improvements'].append(f"Reduced very short chunks by {-comparison['summary']['very_short_change']}")
-    elif comparison['summary']['very_short_change'] > 0:
-        comparison['regressions'].append(f"Increased very short chunks by {comparison['summary']['very_short_change']}")
+    if comparison["summary"]["very_short_change"] < 0:
+        comparison["improvements"].append(
+            f"Reduced very short chunks by {-comparison['summary']['very_short_change']}"
+        )
+    elif comparison["summary"]["very_short_change"] > 0:
+        comparison["regressions"].append(
+            f"Increased very short chunks by {comparison['summary']['very_short_change']}"
+        )
 
-    if comparison['summary']['short_change'] < 0:
-        comparison['improvements'].append(f"Reduced short chunks by {-comparison['summary']['short_change']}")
-    elif comparison['summary']['short_change'] > 0:
-        comparison['regressions'].append(f"Increased short chunks by {comparison['summary']['short_change']}")
+    if comparison["summary"]["short_change"] < 0:
+        comparison["improvements"].append(
+            f"Reduced short chunks by {-comparison['summary']['short_change']}"
+        )
+    elif comparison["summary"]["short_change"] > 0:
+        comparison["regressions"].append(
+            f"Increased short chunks by {comparison['summary']['short_change']}"
+        )
 
-    if comparison['summary']['flow_issues_change'] < 0:
-        comparison['improvements'].append(f"Reduced flow issues by {-comparison['summary']['flow_issues_change']}")
-    elif comparison['summary']['flow_issues_change'] > 0:
-        comparison['regressions'].append(f"Increased flow issues by {comparison['summary']['flow_issues_change']}")
+    if comparison["summary"]["flow_issues_change"] < 0:
+        comparison["improvements"].append(
+            f"Reduced flow issues by {-comparison['summary']['flow_issues_change']}"
+        )
+    elif comparison["summary"]["flow_issues_change"] > 0:
+        comparison["regressions"].append(
+            f"Increased flow issues by {comparison['summary']['flow_issues_change']}"
+        )
 
     # Compare quality factors
-    factors1 = {name: score for name, score, _ in report1['quality_factors']}
-    factors2 = {name: score for name, score, _ in report2['quality_factors']}
+    factors1 = {name: score for name, score, _ in report1["quality_factors"]}
+    factors2 = {name: score for name, score, _ in report2["quality_factors"]}
 
     for factor_name in factors1:
         if factor_name in factors2:
             improvement = factors2[factor_name] - factors1[factor_name]
             if improvement > 0.05:
-                comparison['improvements'].append(f"Improved {factor_name}: {improvement:+.3f}")
+                comparison["improvements"].append(
+                    f"Improved {factor_name}: {improvement:+.3f}"
+                )
             elif improvement < -0.05:
-                comparison['regressions'].append(f"Degraded {factor_name}: {improvement:+.3f}")
+                comparison["regressions"].append(
+                    f"Degraded {factor_name}: {improvement:+.3f}"
+                )
 
     return comparison
 
 
-def print_quality_report(report: Dict[str, Any], detailed: bool = True, validation_results: Dict[str, Any] = None):
+def print_quality_report(
+    report: Dict[str, Any],
+    detailed: bool = True,
+    validation_results: Dict[str, Any] = None,
+):
     """Print a formatted quality report."""
     print("=" * 80)
     print("CHUNK QUALITY ASSESSMENT REPORT")
@@ -777,10 +910,16 @@ def print_quality_report(report: Dict[str, Any], detailed: bool = True, validati
         reordering = validation_results["text_reordering_issues"]
         print("TEXT REORDERING ISSUES")
         print("----------------------------------------")
-        print(f"Quote Splitting Issues:  {reordering['quote_splitting_issues']} instances")
-        print(f"Sentence Fragmentation:  {reordering['sentence_fragmentation']} instances")
+        print(
+            f"Quote Splitting Issues:  {reordering['quote_splitting_issues']} instances"
+        )
+        print(
+            f"Sentence Fragmentation:  {reordering['sentence_fragmentation']} instances"
+        )
         print(f"Suspicious Starts:       {reordering['suspicious_starts']} instances")
-        print(f"JSON Escaping Issues:    {reordering['json_escaping_issues']} instances")
+        print(
+            f"JSON Escaping Issues:    {reordering['json_escaping_issues']} instances"
+        )
         print(f"Chunks Affected:         {reordering['total_chunks_affected']}")
         print()
 
@@ -791,10 +930,12 @@ def print_quality_report(report: Dict[str, Any], detailed: bool = True, validati
             print("----------------------------------------")
             for i, example in enumerate(all_examples[:5]):  # Show up to 5 examples
                 print(f"Example {i+1} ({example['type']}):")
-                print(f"  Chunk {example['chunk_index']}: {example.get('example', 'N/A')}")
-                if 'context' in example:
+                print(
+                    f"  Chunk {example['chunk_index']}: {example.get('example', 'N/A')}"
+                )
+                if "context" in example:
                     print(f"  Context: ...{example['context']}...")
-                if 'issue' in example:
+                if "issue" in example:
                     print(f"  Issue: {example['issue']}")
                 print()
 
@@ -807,7 +948,7 @@ def print_quality_report(report: Dict[str, Any], detailed: bool = True, validati
             print()
 
     # Summary statistics
-    stats = report.get('summary_stats', {})
+    stats = report.get("summary_stats", {})
     print("SUMMARY STATISTICS")
     print("-" * 40)
     print(f"Total Chunks:           {stats.get('total_chunks', 0)}")
@@ -819,74 +960,94 @@ def print_quality_report(report: Dict[str, Any], detailed: bool = True, validati
     # Chunk size distribution
     print("CHUNK SIZE DISTRIBUTION")
     print("-" * 40)
-    total_chunks = stats.get('total_chunks', 0)
-    very_short = stats.get('very_short_chunks', 0)
-    short = stats.get('short_chunks', 0)
+    total_chunks = stats.get("total_chunks", 0)
+    very_short = stats.get("very_short_chunks", 0)
+    short = stats.get("short_chunks", 0)
     normal = total_chunks - very_short - short if total_chunks else 0
-    print(f"Very Short (≤{VALIDATION_THRESHOLDS['very_short']} words):  {very_short} ({(very_short/total_chunks*100) if total_chunks else 0:.1f}%)")
-    print(f"Short ({VALIDATION_THRESHOLDS['very_short']+1}-{VALIDATION_THRESHOLDS['short']} words):      {short} ({(short/total_chunks*100) if total_chunks else 0:.1f}%)")
+    print(
+        f"Very Short (≤{VALIDATION_THRESHOLDS['very_short']} words):  {very_short} ({(very_short/total_chunks*100) if total_chunks else 0:.1f}%)"
+    )
+    print(
+        f"Short ({VALIDATION_THRESHOLDS['very_short']+1}-{VALIDATION_THRESHOLDS['short']} words):      {short} ({(short/total_chunks*100) if total_chunks else 0:.1f}%)"
+    )
     print(f"Normal (>{VALIDATION_THRESHOLDS['short']} words):      {normal}")
     print()
 
     # Quality factors
     print("QUALITY FACTORS")
     print("-" * 40)
-    for factor in report.get('quality_factors', []):
+    for factor in report.get("quality_factors", []):
         factor_name, score, weight = factor
-        print(f"{factor_name.replace('_', ' ').title():<20} {score:.3f} (weight: {weight:.1f})")
+        print(
+            f"{factor_name.replace('_', ' ').title():<20} {score:.3f} (weight: {weight:.1f})"
+        )
     print()
 
     # Issues and recommendations
-    if report.get('issues'):
+    if report.get("issues"):
         print("ISSUES IDENTIFIED")
         print("-" * 40)
-        for i, issue in enumerate(report['issues'], 1):
+        for i, issue in enumerate(report["issues"], 1):
             print(f"{i}. {issue}")
         print()
 
-    if report.get('recommendations'):
+    if report.get("recommendations"):
         print("RECOMMENDATIONS")
         print("----------------------------------------")
-        for i, rec in enumerate(report['recommendations'], 1):
+        for i, rec in enumerate(report["recommendations"], 1):
             print(f"{i}. {rec}")
         print()
 
     if detailed and total_chunks:
         # Detailed analysis
-        short_chunks = report.get('short_chunks', {})
+        short_chunks = report.get("short_chunks", {})
 
-        if short_chunks.get('very_short'):
+        if short_chunks.get("very_short"):
             print(f"VERY SHORT CHUNKS (≤{VALIDATION_THRESHOLDS['very_short']} words)")
             print("-" * 40)
-            for chunk in short_chunks['very_short'][:5]:
-                print(f"Chunk {chunk['index']}: {chunk['word_count']} words - '{chunk['text_preview']}'")
-            if len(short_chunks['very_short']) > 5:
+            for chunk in short_chunks["very_short"][:5]:
+                print(
+                    f"Chunk {chunk['index']}: {chunk['word_count']} words - '{chunk['text_preview']}'"
+                )
+            if len(short_chunks["very_short"]) > 5:
                 print(f"... and {len(short_chunks['very_short']) - 5} more")
             print()
 
-        if short_chunks.get('short'):
-            print(f"SHORT CHUNKS ({VALIDATION_THRESHOLDS['very_short']+1}-{VALIDATION_THRESHOLDS['short']} words)")
+        if short_chunks.get("short"):
+            print(
+                f"SHORT CHUNKS ({VALIDATION_THRESHOLDS['very_short']+1}-{VALIDATION_THRESHOLDS['short']} words)"
+            )
             print("-" * 40)
-            for chunk in short_chunks['short'][:5]:
-                print(f"Chunk {chunk['index']}: {chunk['word_count']} words - '{chunk['text_preview']}'")
-            if len(short_chunks['short']) > 5:
+            for chunk in short_chunks["short"][:5]:
+                print(
+                    f"Chunk {chunk['index']}: {chunk['word_count']} words - '{chunk['text_preview']}'"
+                )
+            if len(short_chunks["short"]) > 5:
                 print(f"... and {len(short_chunks['short']) - 5} more")
             print()
 
         # Dialogue analysis
-        dialogue = report.get('dialogue_analysis', {})
+        dialogue = report.get("dialogue_analysis", {})
         if any(dialogue.values()):
             print("DIALOGUE ANALYSIS")
             print("-" * 40)
-            print(f"Quoted Speech Chunks:      {len(dialogue.get('quoted_speech', []))}")
-            print(f"Dialogue Attribution:      {len(dialogue.get('dialogue_attribution', []))}")
-            print(f"Conversational Responses:  {len(dialogue.get('conversational_responses', []))}")
-            print(f"Potential Fragments:       {len(dialogue.get('potential_fragments', []))}")
+            print(
+                f"Quoted Speech Chunks:      {len(dialogue.get('quoted_speech', []))}"
+            )
+            print(
+                f"Dialogue Attribution:      {len(dialogue.get('dialogue_attribution', []))}"
+            )
+            print(
+                f"Conversational Responses:  {len(dialogue.get('conversational_responses', []))}"
+            )
+            print(
+                f"Potential Fragments:       {len(dialogue.get('potential_fragments', []))}"
+            )
             print()
 
         # Flow analysis
-        flow = report.get('flow_analysis', {})
-        if flow.get('abrupt_transitions') or flow.get('potential_splits'):
+        flow = report.get("flow_analysis", {})
+        if flow.get("abrupt_transitions") or flow.get("potential_splits"):
             print("TEXT FLOW ISSUES")
             print("-" * 40)
             print(f"Flow Score:           {flow.get('flow_score', 0.0):.3f}")
@@ -907,7 +1068,7 @@ def print_comparison_report(comparison: Dict[str, Any]):
     print()
 
     # Summary changes
-    summary = comparison.get('summary', {})
+    summary = comparison.get("summary", {})
     print("SUMMARY CHANGES")
     print("-" * 40)
     print(f"Chunk Count Change:      {summary.get('chunk_count_change', 0):+d}")
@@ -918,23 +1079,23 @@ def print_comparison_report(comparison: Dict[str, Any]):
     print()
 
     # Improvements
-    if comparison.get('improvements'):
+    if comparison.get("improvements"):
         print("IMPROVEMENTS")
         print("-" * 40)
-        for improvement in comparison['improvements']:
+        for improvement in comparison["improvements"]:
             print(f"✓ {improvement}")
         print()
 
     # Regressions
-    if comparison.get('regressions'):
+    if comparison.get("regressions"):
         print("REGRESSIONS")
         print("-" * 40)
-        for regression in comparison['regressions']:
+        for regression in comparison["regressions"]:
             print(f"✗ {regression}")
         print()
 
     # Overall assessment
-    quality_improvement = comparison.get('quality_improvement', 0.0)
+    quality_improvement = comparison.get("quality_improvement", 0.0)
     print("OVERALL ASSESSMENT")
     print("-" * 40)
     if quality_improvement > 0.05:
@@ -948,7 +1109,9 @@ def print_comparison_report(comparison: Dict[str, Any]):
     print()
 
 
-def generate_chunks_from_pdf(pdf_path: str, traditional: bool = False, enhanced: bool = True) -> List[Dict[str, Any]]:
+def generate_chunks_from_pdf(
+    pdf_path: str, traditional: bool = False, enhanced: bool = True
+) -> List[Dict[str, Any]]:
     """Generate chunks from a PDF using specified approach."""
     import os
 
@@ -963,16 +1126,20 @@ def generate_chunks_from_pdf(pdf_path: str, traditional: bool = False, enhanced:
     # Set environment variables and parameters based on approach
     if traditional:
         # Traditional: disable PyMuPDF4LLM and conversational text handling
-        os.environ['PDF_CHUNKER_USE_PYMUPDF4LLM'] = 'false'
+        os.environ["PDF_CHUNKER_USE_PYMUPDF4LLM"] = "false"
         min_chunk_size = None  # Use default large chunk size
         enable_dialogue_detection = False
-        print(f"Using traditional approach: PyMuPDF4LLM disabled, dialogue detection disabled")
+        print(
+            f"Using traditional approach: PyMuPDF4LLM disabled, dialogue detection disabled"
+        )
     else:
         # Enhanced: enable PyMuPDF4LLM and conversational text handling
-        os.environ['PDF_CHUNKER_USE_PYMUPDF4LLM'] = 'true'
+        os.environ["PDF_CHUNKER_USE_PYMUPDF4LLM"] = "true"
         min_chunk_size = 8  # Use small minimum chunk size for conversational merging
         enable_dialogue_detection = True
-        print(f"Using enhanced approach: PyMuPDF4LLM enabled, dialogue detection enabled")
+        print(
+            f"Using enhanced approach: PyMuPDF4LLM enabled, dialogue detection enabled"
+        )
 
     try:
         # Process the document
@@ -983,7 +1150,7 @@ def generate_chunks_from_pdf(pdf_path: str, traditional: bool = False, enhanced:
             generate_metadata=True,
             ai_enrichment=False,  # Disable AI for faster processing
             min_chunk_size=min_chunk_size,
-            enable_dialogue_detection=enable_dialogue_detection
+            enable_dialogue_detection=enable_dialogue_detection,
         )
         return chunks
     except Exception as e:
@@ -991,53 +1158,69 @@ def generate_chunks_from_pdf(pdf_path: str, traditional: bool = False, enhanced:
         return []
     finally:
         # Clean up environment
-        if 'PDF_CHUNKER_USE_PYMUPDF4LLM' in os.environ:
-            del os.environ['PDF_CHUNKER_USE_PYMUPDF4LLM']
+        if "PDF_CHUNKER_USE_PYMUPDF4LLM" in os.environ:
+            del os.environ["PDF_CHUNKER_USE_PYMUPDF4LLM"]
 
 
 def save_chunks_to_jsonl(chunks: List[Dict[str, Any]], output_path: str):
     """Save chunks to a JSONL file."""
     # Ensure proper .jsonl extension
-    if not output_path.endswith('.jsonl'):
-        output_path = output_path + '.jsonl'
+    if not output_path.endswith(".jsonl"):
+        output_path = output_path + ".jsonl"
 
     try:
-        with open(output_path, 'w', encoding='utf-8') as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             for chunk in chunks:
                 json.dump(chunk, f, ensure_ascii=False)
-                f.write('\n')
+                f.write("\n")
         print(f"Saved {len(chunks)} chunks to {output_path}")
     except Exception as e:
         print(f"Error saving chunks to '{output_path}': {e}", file=sys.stderr)
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Validate chunk quality from JSONL output')
+    parser = argparse.ArgumentParser(
+        description="Validate chunk quality from JSONL output"
+    )
 
     # Main operation modes
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('jsonl_file', nargs='?', help='JSONL file to analyze')
-    group.add_argument('--compare', nargs=2, metavar=('FILE1', 'FILE2'),
-                      help='Compare two JSONL files')
-    group.add_argument('--generate', metavar='PDF_FILE',
-                      help='Generate chunks from PDF and analyze')
+    group.add_argument("jsonl_file", nargs="?", help="JSONL file to analyze")
+    group.add_argument(
+        "--compare", nargs=2, metavar=("FILE1", "FILE2"), help="Compare two JSONL files"
+    )
+    group.add_argument(
+        "--generate", metavar="PDF_FILE", help="Generate chunks from PDF and analyze"
+    )
 
     # Options for single file analysis
-    parser.add_argument('--baseline', metavar='BASELINE_JSONL',
-                       help='Baseline JSONL file for comparison')
-    parser.add_argument('--detailed', action='store_true',
-                       help='Show detailed analysis')
+    parser.add_argument(
+        "--baseline",
+        metavar="BASELINE_JSONL",
+        help="Baseline JSONL file for comparison",
+    )
+    parser.add_argument(
+        "--detailed", action="store_true", help="Show detailed analysis"
+    )
 
     # Options for PDF generation
 
     approach_group = parser.add_mutually_exclusive_group()
-    approach_group.add_argument('--traditional', action='store_true',
-                                help='Use traditional approach (when generating from PDF)')
-    approach_group.add_argument('--enhanced', action='store_true',
-                                help='Use enhanced approach (when generating from PDF)')
-    parser.add_argument('--save-jsonl', metavar='OUTPUT_PATH',
-                        help='Save generated chunks to JSONL file')
-
+    approach_group.add_argument(
+        "--traditional",
+        action="store_true",
+        help="Use traditional approach (when generating from PDF)",
+    )
+    approach_group.add_argument(
+        "--enhanced",
+        action="store_true",
+        help="Use enhanced approach (when generating from PDF)",
+    )
+    parser.add_argument(
+        "--save-jsonl",
+        metavar="OUTPUT_PATH",
+        help="Save generated chunks to JSONL file",
+    )
 
     args = parser.parse_args()
 
@@ -1051,10 +1234,11 @@ def main():
 
         print(f"Generating chunks from PDF: {pdf_path}")
 
-
         # Determine which approach to use
         if args.traditional and args.enhanced:
-            print("ERROR: Cannot specify both --traditional and --enhanced for a single generation. Please choose one.")
+            print(
+                "ERROR: Cannot specify both --traditional and --enhanced for a single generation. Please choose one."
+            )
             sys.exit(1)
         if not args.traditional and not args.enhanced:
             args.enhanced = True
@@ -1067,7 +1251,9 @@ def main():
             enhanced = args.enhanced
 
         # Generate the chunks
-        chunks = generate_chunks_from_pdf(pdf_path, traditional=traditional, enhanced=enhanced)
+        chunks = generate_chunks_from_pdf(
+            pdf_path, traditional=traditional, enhanced=enhanced
+        )
 
         # Determine output path
         if args.save_jsonl:
@@ -1079,8 +1265,12 @@ def main():
         # Analyze
         report = generate_quality_report(chunks, f"{pdf_path} ({approach})")
         # Generate validation_results and pass to print_quality_report
-        validation_results = validate_text_processing_quality(chunks) if args.detailed else None
-        print_quality_report(report, detailed=args.detailed, validation_results=validation_results)
+        validation_results = (
+            validate_text_processing_quality(chunks) if args.detailed else None
+        )
+        print_quality_report(
+            report, detailed=args.detailed, validation_results=validation_results
+        )
 
         if args.detailed and validation_results:
             print("\n")
@@ -1096,7 +1286,9 @@ def main():
         chunks2 = load_jsonl(file2)
 
         if not chunks1 or not chunks2:
-            print("Error: Could not load chunks from one or both files", file=sys.stderr)
+            print(
+                "Error: Could not load chunks from one or both files", file=sys.stderr
+            )
             sys.exit(1)
 
         # Generate reports
@@ -1104,15 +1296,23 @@ def main():
         report2 = generate_quality_report(chunks2, file2)
 
         # Generate validation_results for both files if detailed
-        validation_results1 = validate_text_processing_quality(chunks1) if args.detailed else None
-        validation_results2 = validate_text_processing_quality(chunks2) if args.detailed else None
+        validation_results1 = (
+            validate_text_processing_quality(chunks1) if args.detailed else None
+        )
+        validation_results2 = (
+            validate_text_processing_quality(chunks2) if args.detailed else None
+        )
 
         # Print individual reports
         print(f"\nAnalysis of {file1}:")
-        print_quality_report(report1, detailed=args.detailed, validation_results=validation_results1)
+        print_quality_report(
+            report1, detailed=args.detailed, validation_results=validation_results1
+        )
 
         print(f"\nAnalysis of {file2}:")
-        print_quality_report(report2, detailed=args.detailed, validation_results=validation_results2)
+        print_quality_report(
+            report2, detailed=args.detailed, validation_results=validation_results2
+        )
 
         # Print comparison
         print(f"\nComparison ({file1} vs {file2}):")
@@ -1129,8 +1329,12 @@ def main():
         chunks = load_jsonl(jsonl_file)
         report = generate_quality_report(chunks, jsonl_file)
         # Generate validation_results and pass to print_quality_report
-        validation_results = validate_text_processing_quality(chunks) if args.detailed else None
-        print_quality_report(report, detailed=args.detailed, validation_results=validation_results)
+        validation_results = (
+            validate_text_processing_quality(chunks) if args.detailed else None
+        )
+        print_quality_report(
+            report, detailed=args.detailed, validation_results=validation_results
+        )
 
         if args.detailed and validation_results:
             print("\n")
@@ -1138,18 +1342,23 @@ def main():
 
         if args.baseline:
             if not os.path.exists(args.baseline):
-                print(f"Warning: Baseline file '{args.baseline}' not found", file=sys.stderr)
+                print(
+                    f"Warning: Baseline file '{args.baseline}' not found",
+                    file=sys.stderr,
+                )
             else:
                 print(f"\nLoading baseline from {args.baseline}...")
                 baseline_chunks = load_jsonl(args.baseline)
 
                 if baseline_chunks:
-                    baseline_report = generate_quality_report(baseline_chunks, args.baseline)
+                    baseline_report = generate_quality_report(
+                        baseline_chunks, args.baseline
+                    )
 
                     print(f"\nComparison (Baseline vs Current):")
                     comparison = compare_quality_reports(baseline_report, report)
                     print_comparison_report(comparison)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/validate_readme_functionality.py
+++ b/scripts/validate_readme_functionality.py
@@ -25,12 +25,14 @@ import importlib.util
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+
 class ValidationResult:
     def __init__(self, feature: str, status: str, details: str = "", error: str = ""):
         self.feature = feature
         self.status = status  # "PASS", "FAIL", "MISSING", "PARTIAL"
         self.details = details
         self.error = error
+
 
 class READMEValidator:
     def __init__(self):
@@ -44,12 +46,9 @@ class READMEValidator:
         self.results.append(result)
 
         # Print immediate feedback
-        status_symbol = {
-            "PASS": "✓",
-            "FAIL": "✗",
-            "MISSING": "?",
-            "PARTIAL": "~"
-        }.get(status, "?")
+        status_symbol = {"PASS": "✓", "FAIL": "✗", "MISSING": "?", "PARTIAL": "~"}.get(
+            status, "?"
+        )
 
         print(f"{status_symbol} {feature}: {status}")
         if details:
@@ -83,7 +82,7 @@ class READMEValidator:
             ("pdf_chunker.ai_enrichment", "AI enrichment module"),
             ("pdf_chunker.splitter", "Text splitting module"),
             ("pdf_chunker.utils", "Utility functions"),
-            ("pdf_chunker.pymupdf4llm_integration", "PyMuPDF4LLM integration")
+            ("pdf_chunker.pymupdf4llm_integration", "PyMuPDF4LLM integration"),
         ]
 
         for module_name, description in core_modules:
@@ -103,27 +102,39 @@ class READMEValidator:
             from pdf_chunker.pymupdf4llm_integration import (
                 is_pymupdf4llm_available,
                 extract_with_pymupdf4llm,
-                clean_text_with_pymupdf4llm
+                clean_text_with_pymupdf4llm,
             )
 
             # Test availability check
             available = is_pymupdf4llm_available()
-            self.log_result("PyMuPDF4LLM availability check", "PASS", f"Available: {available}")
+            self.log_result(
+                "PyMuPDF4LLM availability check", "PASS", f"Available: {available}"
+            )
 
             # Test extraction function exists
-            if hasattr(extract_with_pymupdf4llm, '__call__'):
-                self.log_result("PyMuPDF4LLM extract function", "PASS", "Function is callable")
+            if hasattr(extract_with_pymupdf4llm, "__call__"):
+                self.log_result(
+                    "PyMuPDF4LLM extract function", "PASS", "Function is callable"
+                )
             else:
-                self.log_result("PyMuPDF4LLM extract function", "FAIL", "Function not callable")
+                self.log_result(
+                    "PyMuPDF4LLM extract function", "FAIL", "Function not callable"
+                )
 
             # Test cleaning function exists
-            if hasattr(clean_text_with_pymupdf4llm, '__call__'):
-                self.log_result("PyMuPDF4LLM clean function", "PASS", "Function is callable")
+            if hasattr(clean_text_with_pymupdf4llm, "__call__"):
+                self.log_result(
+                    "PyMuPDF4LLM clean function", "PASS", "Function is callable"
+                )
             else:
-                self.log_result("PyMuPDF4LLM clean function", "FAIL", "Function not callable")
+                self.log_result(
+                    "PyMuPDF4LLM clean function", "FAIL", "Function not callable"
+                )
 
         except ImportError as e:
-            self.log_result("PyMuPDF4LLM integration", "MISSING", "Module not found", str(e))
+            self.log_result(
+                "PyMuPDF4LLM integration", "MISSING", "Module not found", str(e)
+            )
         except Exception as e:
             self.log_result("PyMuPDF4LLM integration", "FAIL", "Import error", str(e))
 
@@ -135,24 +146,30 @@ class READMEValidator:
             from pdf_chunker.pdf_parsing import (
                 extract_text_blocks_from_pdf,
                 extract_blocks_from_page,
-                merge_continuation_blocks
+                merge_continuation_blocks,
             )
 
             # Check function signatures and callability
             functions = [
                 ("extract_text_blocks_from_pdf", extract_text_blocks_from_pdf),
                 ("extract_blocks_from_page", extract_blocks_from_page),
-                ("merge_continuation_blocks", merge_continuation_blocks)
+                ("merge_continuation_blocks", merge_continuation_blocks),
             ]
 
             for func_name, func in functions:
-                if hasattr(func, '__call__'):
-                    self.log_result(f"PDF function {func_name}", "PASS", "Function is callable")
+                if hasattr(func, "__call__"):
+                    self.log_result(
+                        f"PDF function {func_name}", "PASS", "Function is callable"
+                    )
                 else:
-                    self.log_result(f"PDF function {func_name}", "FAIL", "Function not callable")
+                    self.log_result(
+                        f"PDF function {func_name}", "FAIL", "Function not callable"
+                    )
 
         except ImportError as e:
-            self.log_result("PDF processing functions", "MISSING", "Module not found", str(e))
+            self.log_result(
+                "PDF processing functions", "MISSING", "Module not found", str(e)
+            )
         except Exception as e:
             self.log_result("PDF processing functions", "FAIL", "Import error", str(e))
 
@@ -164,32 +181,46 @@ class READMEValidator:
             from pdf_chunker.epub_parsing import (
                 extract_text_blocks_from_epub,
                 list_epub_spines,
-                process_epub_item
+                process_epub_item,
             )
 
             # Check EPUB functions
             functions = [
                 ("extract_text_blocks_from_epub", extract_text_blocks_from_epub),
                 ("list_epub_spines", list_epub_spines),
-                ("process_epub_item", process_epub_item)
+                ("process_epub_item", process_epub_item),
             ]
 
             for func_name, func in functions:
-                if hasattr(func, '__call__'):
-                    self.log_result(f"EPUB function {func_name}", "PASS", "Function is callable")
+                if hasattr(func, "__call__"):
+                    self.log_result(
+                        f"EPUB function {func_name}", "PASS", "Function is callable"
+                    )
                 else:
-                    self.log_result(f"EPUB function {func_name}", "FAIL", "Function not callable")
+                    self.log_result(
+                        f"EPUB function {func_name}", "FAIL", "Function not callable"
+                    )
 
             # Check for spine discovery functionality
             try:
                 import inspect
+
                 sig = inspect.signature(list_epub_spines)
-                self.log_result("EPUB spine discovery", "PASS", f"Function signature: {sig}")
+                self.log_result(
+                    "EPUB spine discovery", "PASS", f"Function signature: {sig}"
+                )
             except Exception as e:
-                self.log_result("EPUB spine discovery", "PARTIAL", "Function exists but signature check failed", str(e))
+                self.log_result(
+                    "EPUB spine discovery",
+                    "PARTIAL",
+                    "Function exists but signature check failed",
+                    str(e),
+                )
 
         except ImportError as e:
-            self.log_result("EPUB processing functions", "MISSING", "Module not found", str(e))
+            self.log_result(
+                "EPUB processing functions", "MISSING", "Module not found", str(e)
+            )
         except Exception as e:
             self.log_result("EPUB processing functions", "FAIL", "Import error", str(e))
 
@@ -201,32 +232,46 @@ class READMEValidator:
             from pdf_chunker.ai_enrichment import (
                 classify_chunk_utterance,
                 _process_chunk_for_file,
-                _load_tag_configs
+                _load_tag_configs,
             )
 
             # Check AI enrichment functions
             functions = [
                 ("classify_chunk_utterance", classify_chunk_utterance),
                 ("_process_chunk_for_file", _process_chunk_for_file),
-                ("_load_tag_configs", _load_tag_configs)
+                ("_load_tag_configs", _load_tag_configs),
             ]
 
             for func_name, func in functions:
-                if hasattr(func, '__call__'):
-                    self.log_result(f"AI function {func_name}", "PASS", "Function is callable")
+                if hasattr(func, "__call__"):
+                    self.log_result(
+                        f"AI function {func_name}", "PASS", "Function is callable"
+                    )
                 else:
-                    self.log_result(f"AI function {func_name}", "FAIL", "Function not callable")
+                    self.log_result(
+                        f"AI function {func_name}", "FAIL", "Function not callable"
+                    )
 
             # Check for tag configuration loading
             try:
                 import inspect
+
                 sig = inspect.signature(_load_tag_configs)
-                self.log_result("Tag configuration loading", "PASS", f"Function signature: {sig}")
+                self.log_result(
+                    "Tag configuration loading", "PASS", f"Function signature: {sig}"
+                )
             except Exception as e:
-                self.log_result("Tag configuration loading", "PARTIAL", "Function exists but signature check failed", str(e))
+                self.log_result(
+                    "Tag configuration loading",
+                    "PARTIAL",
+                    "Function exists but signature check failed",
+                    str(e),
+                )
 
         except ImportError as e:
-            self.log_result("AI enrichment functions", "MISSING", "Module not found", str(e))
+            self.log_result(
+                "AI enrichment functions", "MISSING", "Module not found", str(e)
+            )
         except Exception as e:
             self.log_result("AI enrichment functions", "FAIL", "Import error", str(e))
 
@@ -240,24 +285,30 @@ class READMEValidator:
                 clean_text,
                 normalize_ligatures,
                 normalize_quotes,
-                fix_hyphenated_linebreaks
+                fix_hyphenated_linebreaks,
             )
 
             cleaning_functions = [
                 ("clean_text", clean_text),
                 ("normalize_ligatures", normalize_ligatures),
                 ("normalize_quotes", normalize_quotes),
-                ("fix_hyphenated_linebreaks", fix_hyphenated_linebreaks)
+                ("fix_hyphenated_linebreaks", fix_hyphenated_linebreaks),
             ]
 
             for func_name, func in cleaning_functions:
-                if hasattr(func, '__call__'):
-                    self.log_result(f"Text cleaning {func_name}", "PASS", "Function is callable")
+                if hasattr(func, "__call__"):
+                    self.log_result(
+                        f"Text cleaning {func_name}", "PASS", "Function is callable"
+                    )
                 else:
-                    self.log_result(f"Text cleaning {func_name}", "FAIL", "Function not callable")
+                    self.log_result(
+                        f"Text cleaning {func_name}", "FAIL", "Function not callable"
+                    )
 
         except ImportError as e:
-            self.log_result("Text cleaning functions", "MISSING", "Module not found", str(e))
+            self.log_result(
+                "Text cleaning functions", "MISSING", "Module not found", str(e)
+            )
         except Exception as e:
             self.log_result("Text cleaning functions", "FAIL", "Import error", str(e))
 
@@ -266,23 +317,29 @@ class READMEValidator:
             from pdf_chunker.text_processing import (
                 normalize_quotes,
                 detect_and_fix_word_gluing,
-                _fix_case_transition_gluing
+                _fix_case_transition_gluing,
             )
 
             processing_functions = [
                 ("normalize_quotes", normalize_quotes),
                 ("detect_and_fix_word_gluing", detect_and_fix_word_gluing),
-                ("_fix_case_transition_gluing", _fix_case_transition_gluing)
+                ("_fix_case_transition_gluing", _fix_case_transition_gluing),
             ]
 
             for func_name, func in processing_functions:
-                if hasattr(func, '__call__'):
-                    self.log_result(f"Text processing {func_name}", "PASS", "Function is callable")
+                if hasattr(func, "__call__"):
+                    self.log_result(
+                        f"Text processing {func_name}", "PASS", "Function is callable"
+                    )
                 else:
-                    self.log_result(f"Text processing {func_name}", "FAIL", "Function not callable")
+                    self.log_result(
+                        f"Text processing {func_name}", "FAIL", "Function not callable"
+                    )
 
         except ImportError as e:
-            self.log_result("Text processing functions", "MISSING", "Module not found", str(e))
+            self.log_result(
+                "Text processing functions", "MISSING", "Module not found", str(e)
+            )
         except Exception as e:
             self.log_result("Text processing functions", "FAIL", "Import error", str(e))
 
@@ -294,20 +351,24 @@ class READMEValidator:
             from pdf_chunker.splitter import (
                 semantic_chunker,
                 detect_dialogue_patterns,
-                merge_conversational_chunks
+                merge_conversational_chunks,
             )
 
             chunking_functions = [
                 ("semantic_chunker", semantic_chunker),
                 ("detect_dialogue_patterns", detect_dialogue_patterns),
-                ("merge_conversational_chunks", merge_conversational_chunks)
+                ("merge_conversational_chunks", merge_conversational_chunks),
             ]
 
             for func_name, func in chunking_functions:
-                if hasattr(func, '__call__'):
-                    self.log_result(f"Chunking {func_name}", "PASS", "Function is callable")
+                if hasattr(func, "__call__"):
+                    self.log_result(
+                        f"Chunking {func_name}", "PASS", "Function is callable"
+                    )
                 else:
-                    self.log_result(f"Chunking {func_name}", "FAIL", "Function not callable")
+                    self.log_result(
+                        f"Chunking {func_name}", "FAIL", "Function not callable"
+                    )
 
         except ImportError as e:
             self.log_result("Chunking functions", "MISSING", "Module not found", str(e))
@@ -322,20 +383,24 @@ class READMEValidator:
             from pdf_chunker.utils import (
                 format_chunks_with_metadata,
                 _generate_chunk_id,
-                _compute_readability
+                _compute_readability,
             )
 
             utility_functions = [
                 ("format_chunks_with_metadata", format_chunks_with_metadata),
                 ("_generate_chunk_id", _generate_chunk_id),
-                ("_compute_readability", _compute_readability)
+                ("_compute_readability", _compute_readability),
             ]
 
             for func_name, func in utility_functions:
-                if hasattr(func, '__call__'):
-                    self.log_result(f"Utility {func_name}", "PASS", "Function is callable")
+                if hasattr(func, "__call__"):
+                    self.log_result(
+                        f"Utility {func_name}", "PASS", "Function is callable"
+                    )
                 else:
-                    self.log_result(f"Utility {func_name}", "FAIL", "Function not callable")
+                    self.log_result(
+                        f"Utility {func_name}", "FAIL", "Function not callable"
+                    )
 
         except ImportError as e:
             self.log_result("Utility functions", "MISSING", "Module not found", str(e))
@@ -349,25 +414,35 @@ class READMEValidator:
         try:
             from pdf_chunker.core import process_document
 
-            if hasattr(process_document, '__call__'):
-                self.log_result("Core process_document function", "PASS", "Function is callable")
+            if hasattr(process_document, "__call__"):
+                self.log_result(
+                    "Core process_document function", "PASS", "Function is callable"
+                )
 
                 # Check function signature for expected parameters
                 import inspect
+
                 sig = inspect.signature(process_document)
                 params = list(sig.parameters.keys())
 
                 # Updated to match actual function signature
-                expected_params = ['filepath', 'chunk_size', 'overlap']
+                expected_params = ["filepath", "chunk_size", "overlap"]
                 missing_params = [p for p in expected_params if p not in params]
 
                 if missing_params:
-                    self.log_result("Core function parameters", "PARTIAL",
-                                  f"Missing expected params: {missing_params}, Found: {params}")
+                    self.log_result(
+                        "Core function parameters",
+                        "PARTIAL",
+                        f"Missing expected params: {missing_params}, Found: {params}",
+                    )
                 else:
-                    self.log_result("Core function parameters", "PASS", f"Parameters: {params}")
+                    self.log_result(
+                        "Core function parameters", "PASS", f"Parameters: {params}"
+                    )
             else:
-                self.log_result("Core process_document function", "FAIL", "Function not callable")
+                self.log_result(
+                    "Core process_document function", "FAIL", "Function not callable"
+                )
 
         except ImportError as e:
             self.log_result("Core processing", "MISSING", "Module not found", str(e))
@@ -386,15 +461,27 @@ class READMEValidator:
             sig = inspect.signature(process_document)
             params = list(sig.parameters.keys())
 
-            page_exclusion_params = [p for p in params if 'page' in p.lower() or 'exclude' in p.lower()]
+            page_exclusion_params = [
+                p for p in params if "page" in p.lower() or "exclude" in p.lower()
+            ]
 
             if page_exclusion_params:
-                self.log_result("Page exclusion parameters", "PASS", f"Found: {page_exclusion_params}")
+                self.log_result(
+                    "Page exclusion parameters",
+                    "PASS",
+                    f"Found: {page_exclusion_params}",
+                )
             else:
-                self.log_result("Page exclusion parameters", "MISSING", "No page exclusion parameters found")
+                self.log_result(
+                    "Page exclusion parameters",
+                    "MISSING",
+                    "No page exclusion parameters found",
+                )
 
         except Exception as e:
-            self.log_result("Page exclusion functionality", "FAIL", "Could not validate", str(e))
+            self.log_result(
+                "Page exclusion functionality", "FAIL", "Could not validate", str(e)
+            )
 
     def validate_chunk_quality(self):
         """Validate chunk quality validation and size limits"""
@@ -403,13 +490,16 @@ class READMEValidator:
         # Check for existing chunk quality validation script
         quality_script = self.project_root / "scripts" / "validate_chunk_quality.py"
         if quality_script.exists():
-            self.log_result("Chunk quality script", "PASS", f"Found at {quality_script}")
+            self.log_result(
+                "Chunk quality script", "PASS", f"Found at {quality_script}"
+            )
         else:
             self.log_result("Chunk quality script", "MISSING", "Script not found")
 
         # Check for quality validation in utils
         try:
             from pdf_chunker.utils import _compute_readability
+
             self.log_result("Readability computation", "PASS", "Function available")
         except ImportError:
             self.log_result("Readability computation", "MISSING", "Function not found")
@@ -428,16 +518,26 @@ class READMEValidator:
             # Check for tags directory
             tags_dir = config_dir / "tags"
             if tags_dir.exists():
-                self.log_result("Tags configuration directory", "PASS", f"Found at {tags_dir}")
+                self.log_result(
+                    "Tags configuration directory", "PASS", f"Found at {tags_dir}"
+                )
 
                 # Check for any tag files
                 tag_files = list(tags_dir.glob("*.yaml")) + list(tags_dir.glob("*.yml"))
                 if tag_files:
-                    self.log_result("Tag configuration files", "PASS", f"Found {len(tag_files)} files")
+                    self.log_result(
+                        "Tag configuration files",
+                        "PASS",
+                        f"Found {len(tag_files)} files",
+                    )
                 else:
-                    self.log_result("Tag configuration files", "MISSING", "No YAML tag files found")
+                    self.log_result(
+                        "Tag configuration files", "MISSING", "No YAML tag files found"
+                    )
             else:
-                self.log_result("Tags configuration directory", "MISSING", "Directory not found")
+                self.log_result(
+                    "Tags configuration directory", "MISSING", "Directory not found"
+                )
         else:
             self.log_result("Configuration directory", "MISSING", "Directory not found")
 
@@ -473,14 +573,16 @@ class READMEValidator:
         # Check requirements.txt
         requirements_file = self.project_root / "requirements.txt"
         if requirements_file.exists():
-            self.log_result("Requirements file", "PASS", f"Found at {requirements_file}")
+            self.log_result(
+                "Requirements file", "PASS", f"Found at {requirements_file}"
+            )
 
             # Read and check for key dependencies mentioned in README
             try:
-                with open(requirements_file, 'r') as f:
+                with open(requirements_file, "r") as f:
                     requirements = f.read()
 
-                key_deps = ['pymupdf', 'beautifulsoup4', 'lxml', 'ebooklib']
+                key_deps = ["pymupdf", "beautifulsoup4", "lxml", "ebooklib"]
                 found_deps = []
                 missing_deps = []
 
@@ -491,19 +593,29 @@ class READMEValidator:
                         missing_deps.append(dep)
 
                 if found_deps:
-                    self.log_result("Key dependencies found", "PASS", f"Found: {found_deps}")
+                    self.log_result(
+                        "Key dependencies found", "PASS", f"Found: {found_deps}"
+                    )
                 if missing_deps:
-                    self.log_result("Key dependencies missing", "PARTIAL", f"Missing: {missing_deps}")
+                    self.log_result(
+                        "Key dependencies missing",
+                        "PARTIAL",
+                        f"Missing: {missing_deps}",
+                    )
 
             except Exception as e:
-                self.log_result("Requirements parsing", "FAIL", "Could not parse requirements", str(e))
+                self.log_result(
+                    "Requirements parsing",
+                    "FAIL",
+                    "Could not parse requirements",
+                    str(e),
+                )
         else:
             self.log_result("Requirements file", "MISSING", "File not found")
 
     def run_functional_tests(self):
         """Run basic functional tests if test data is available"""
         print("\n=== Functional Tests ===")
-
 
         # Look for PDF files in both project root and test_data directory
         pdf_files = []
@@ -525,15 +637,18 @@ class READMEValidator:
             epub_files = list(self.test_data_dir.glob("*.epub"))
 
         if pdf_files:
-            self.log_result("Test PDF files", "PASS", f"Found {len(pdf_files)} PDF files")
+            self.log_result(
+                "Test PDF files", "PASS", f"Found {len(pdf_files)} PDF files"
+            )
         else:
             self.log_result("Test PDF files", "MISSING", "No PDF test files found")
 
         if epub_files:
-            self.log_result("Test EPUB files", "PASS", f"Found {len(epub_files)} EPUB files")
+            self.log_result(
+                "Test EPUB files", "PASS", f"Found {len(epub_files)} EPUB files"
+            )
         else:
             self.log_result("Test EPUB files", "MISSING", "No EPUB test files found")
-    
 
         # Try basic processing if we have test files and core module works
         if pdf_files:
@@ -548,18 +663,24 @@ class READMEValidator:
                     # This is just a signature check - we're not actually running it
                     # to avoid potential errors with missing dependencies
                     import inspect
+
                     sig = inspect.signature(process_document)
-                    self.log_result("Core processing test setup", "PASS",
-                                  f"Can call process_document with {test_pdf}")
+                    self.log_result(
+                        "Core processing test setup",
+                        "PASS",
+                        f"Can call process_document with {test_pdf}",
+                    )
 
             except Exception as e:
-                self.log_result("Core processing test", "FAIL", "Could not set up test", str(e))
+                self.log_result(
+                    "Core processing test", "FAIL", "Could not set up test", str(e)
+                )
 
     def generate_report(self):
         """Generate a comprehensive validation report"""
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print("README FUNCTIONALITY VALIDATION REPORT")
-        print("="*60)
+        print("=" * 60)
 
         # Count results by status
         status_counts = {}
@@ -581,23 +702,23 @@ class READMEValidator:
             by_status[result.status].append(result)
 
         # Report failures and missing functionality
-        if 'FAIL' in by_status:
+        if "FAIL" in by_status:
             print(f"\nFAILED FEATURES ({len(by_status['FAIL'])}):")
-            for result in by_status['FAIL']:
+            for result in by_status["FAIL"]:
                 print(f"  ✗ {result.feature}")
                 if result.error:
                     print(f"    Error: {result.error}")
 
-        if 'MISSING' in by_status:
+        if "MISSING" in by_status:
             print(f"\nMISSING FEATURES ({len(by_status['MISSING'])}):")
-            for result in by_status['MISSING']:
+            for result in by_status["MISSING"]:
                 print(f"  ? {result.feature}")
                 if result.details:
                     print(f"    Details: {result.details}")
 
-        if 'PARTIAL' in by_status:
+        if "PARTIAL" in by_status:
             print(f"\nPARTIAL FEATURES ({len(by_status['PARTIAL'])}):")
-            for result in by_status['PARTIAL']:
+            for result in by_status["PARTIAL"]:
                 print(f"  ~ {result.feature}")
                 if result.details:
                     print(f"    Details: {result.details}")
@@ -605,30 +726,30 @@ class READMEValidator:
         # Calculate overall health score
         total = len(self.results)
         if total > 0:
-            pass_count = status_counts.get('PASS', 0)
-            partial_count = status_counts.get('PARTIAL', 0)
+            pass_count = status_counts.get("PASS", 0)
+            partial_count = status_counts.get("PARTIAL", 0)
             health_score = (pass_count + partial_count * 0.5) / total * 100
             print(f"\nOVERALL HEALTH SCORE: {health_score:.1f}%")
 
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
 
         # Return summary for programmatic use
         return {
-            'total_features': total,
-            'pass_count': status_counts.get('PASS', 0),
-            'fail_count': status_counts.get('FAIL', 0),
-            'missing_count': status_counts.get('MISSING', 0),
-            'partial_count': status_counts.get('PARTIAL', 0),
-            'health_score': health_score if total > 0 else 0,
-            'results': [
+            "total_features": total,
+            "pass_count": status_counts.get("PASS", 0),
+            "fail_count": status_counts.get("FAIL", 0),
+            "missing_count": status_counts.get("MISSING", 0),
+            "partial_count": status_counts.get("PARTIAL", 0),
+            "health_score": health_score if total > 0 else 0,
+            "results": [
                 {
-                    'feature': r.feature,
-                    'status': r.status,
-                    'details': r.details,
-                    'error': r.error
+                    "feature": r.feature,
+                    "status": r.status,
+                    "details": r.details,
+                    "error": r.error,
                 }
                 for r in self.results
-            ]
+            ],
         }
 
     def run_all_validations(self):
@@ -656,6 +777,7 @@ class READMEValidator:
         # Generate final report
         return self.generate_report()
 
+
 def main():
     """Main entry point"""
     validator = READMEValidator()
@@ -665,13 +787,13 @@ def main():
 
         # Save detailed report to file
         report_file = validator.project_root / "validation_report.json"
-        with open(report_file, 'w') as f:
+        with open(report_file, "w") as f:
             json.dump(summary, f, indent=2)
 
         print(f"\nDetailed report saved to: {report_file}")
 
         # Exit with appropriate code
-        if summary['fail_count'] > 0 or summary['missing_count'] > 0:
+        if summary["fail_count"] > 0 or summary["missing_count"] > 0:
             print("\nValidation completed with issues found.")
             sys.exit(1)
         else:
@@ -682,6 +804,7 @@ def main():
         print(f"\nValidation failed with error: {e}")
         traceback.print_exc()
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/epub_spine_test.py
+++ b/tests/epub_spine_test.py
@@ -2,74 +2,94 @@
 
 import sys
 import os
-sys.path.insert(0, '.')
+
+sys.path.insert(0, ".")
 
 from pdf_chunker.core import process_document
 from pdf_chunker.parsing import extract_structured_text
+
 
 def test_epub_spine_exclusion():
     """Test EPUB spine exclusion functionality"""
 
     # Use a specific, known-good test EPUB file
-    test_epub_path = os.path.join('test_data', 'sample_test.epub')
+    test_epub_path = os.path.join("test_data", "sample_test.epub")
     if not os.path.exists(test_epub_path):
-        print(f'Known-good test EPUB not found at {test_epub_path}.')
-        print('Please generate it with scripts/generate_test_epub.py.')
+        print(f"Known-good test EPUB not found at {test_epub_path}.")
+        print("Please generate it with scripts/generate_test_epub.py.")
         return False
 
-    print(f'Testing spine-based exclusion functionality with known-good EPUB: {test_epub_path}')
+    print(
+        f"Testing spine-based exclusion functionality with known-good EPUB: {test_epub_path}"
+    )
     success_count = 0
 
     epub_file = test_epub_path
-    print(f'Testing spine exclusion with: {epub_file}')
+    print(f"Testing spine exclusion with: {epub_file}")
 
     try:
         # First, extract without exclusions to get baseline
-        print(f'  Baseline extraction (no exclusions):')
+        print(f"  Baseline extraction (no exclusions):")
         baseline_blocks = extract_structured_text(epub_file)
 
         if baseline_blocks:
             # Get spine information from baseline
             spine_items = set()
             for block in baseline_blocks:
-                location = block.get('source', {}).get('location')
+                location = block.get("source", {}).get("location")
                 if location:
                     spine_items.add(location)
 
             total_spines = len(spine_items)
-            print(f'    Total spine items in document: {total_spines}')
-            print(f'    Baseline blocks extracted: {len(baseline_blocks)}')
-            print(f'    Spine items with content: {sorted(list(spine_items)[:5])}...')  # Show first 5
+            print(f"    Total spine items in document: {total_spines}")
+            print(f"    Baseline blocks extracted: {len(baseline_blocks)}")
+            print(
+                f"    Spine items with content: {sorted(list(spine_items)[:5])}..."
+            )  # Show first 5
 
             if total_spines >= 3:
                 # Test excluding first spine item
-                print(f'  Test 1: Excluding spine item 1')
+                print(f"  Test 1: Excluding spine item 1")
                 try:
-                    excluded_blocks = extract_structured_text(epub_file, exclude_pages='1')
+                    excluded_blocks = extract_structured_text(
+                        epub_file, exclude_pages="1"
+                    )
                     excluded_spines = set()
                     for block in excluded_blocks:
-                        location = block.get('source', {}).get('location')
+                        location = block.get("source", {}).get("location")
                         if location:
                             excluded_spines.add(location)
 
                     # Check if first spine item content is missing
-                    first_spine_content = [block for block in baseline_blocks if block.get('source', {}).get('location') == sorted(spine_items)[0]]
-                    first_spine_in_excluded = [block for block in excluded_blocks if block.get('source', {}).get('location') == sorted(spine_items)[0]]
+                    first_spine_content = [
+                        block
+                        for block in baseline_blocks
+                        if block.get("source", {}).get("location")
+                        == sorted(spine_items)[0]
+                    ]
+                    first_spine_in_excluded = [
+                        block
+                        for block in excluded_blocks
+                        if block.get("source", {}).get("location")
+                        == sorted(spine_items)[0]
+                    ]
 
                     if first_spine_in_excluded:
-                        print(f'    ERROR: First spine item content still appears in output!')
+                        print(
+                            f"    ERROR: First spine item content still appears in output!"
+                        )
                     else:
-                        print(f'    SUCCESS: First spine item successfully excluded')
+                        print(f"    SUCCESS: First spine item successfully excluded")
                         success_count += 1
 
-                    print(f'    Blocks after exclusion: {len(excluded_blocks)}')
-                    print(f'    Spine items with content: {len(excluded_spines)}')
+                    print(f"    Blocks after exclusion: {len(excluded_blocks)}")
+                    print(f"    Spine items with content: {len(excluded_spines)}")
 
                 except Exception as e:
-                    print(f'    ERROR: Spine exclusion failed: {e}')
+                    print(f"    ERROR: Spine exclusion failed: {e}")
 
                 # Test full pipeline with spine exclusions
-                print(f'  Test 2: Full pipeline with spine exclusions')
+                print(f"  Test 2: Full pipeline with spine exclusions")
                 try:
                     chunks = process_document(
                         epub_file,
@@ -77,48 +97,62 @@ def test_epub_spine_exclusion():
                         overlap=30,
                         generate_metadata=True,
                         ai_enrichment=False,
-                        exclude_pages='1'
+                        exclude_pages="1",
                     )
 
                     if chunks:
                         # Check that excluded spine items don't appear in final chunks
                         chunk_locations = set()
                         for chunk in chunks:
-                            location = chunk.get('metadata', {}).get('location')
+                            location = chunk.get("metadata", {}).get("location")
                             if location:
                                 chunk_locations.add(location)
 
                         sorted_spines = sorted(spine_items)
-                        first_spine_in_chunks = sorted_spines[0] in chunk_locations if sorted_spines else False
+                        first_spine_in_chunks = (
+                            sorted_spines[0] in chunk_locations
+                            if sorted_spines
+                            else False
+                        )
 
                         if first_spine_in_chunks:
-                            print(f'    ERROR: Excluded first spine item appears in final chunks!')
+                            print(
+                                f"    ERROR: Excluded first spine item appears in final chunks!"
+                            )
                         else:
-                            print(f'    SUCCESS: Spine exclusion works in full pipeline')
+                            print(
+                                f"    SUCCESS: Spine exclusion works in full pipeline"
+                            )
                             success_count += 1
 
-                        print(f'    Final chunks generated: {len(chunks)}')
-                        print(f'    Spine items in final chunks: {len(chunk_locations)}')
+                        print(f"    Final chunks generated: {len(chunks)}")
+                        print(
+                            f"    Spine items in final chunks: {len(chunk_locations)}"
+                        )
                     else:
-                        print(f'    ERROR: No chunks generated in full pipeline')
+                        print(f"    ERROR: No chunks generated in full pipeline")
 
                 except Exception as e:
-                    print(f'    ERROR: Full pipeline with exclusions failed: {e}')
+                    print(f"    ERROR: Full pipeline with exclusions failed: {e}")
 
             else:
-                print(f'    SKIP: Document too short ({total_spines} spine items) for comprehensive testing')
+                print(
+                    f"    SKIP: Document too short ({total_spines} spine items) for comprehensive testing"
+                )
 
         else:
-            print(f'    ERROR: No baseline blocks extracted')
+            print(f"    ERROR: No baseline blocks extracted")
 
     except Exception as e:
-        print(f'  ERROR: Baseline extraction failed: {e}')
+        print(f"  ERROR: Baseline extraction failed: {e}")
         import traceback
+
         traceback.print_exc()
 
     print()
     return success_count > 0
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     success = test_epub_spine_exclusion()
     sys.exit(0 if success else 1)

--- a/tests/indented_block_test.py
+++ b/tests/indented_block_test.py
@@ -6,7 +6,9 @@ import pytest
 from pdf_chunker.pdf_parsing import extract_text_blocks_from_pdf
 
 
-@pytest.mark.skip(reason="sample_book3.pdf no longer contains an indented block example")
+@pytest.mark.skip(
+    reason="sample_book3.pdf no longer contains an indented block example"
+)
 def test_indented_block_no_double_newline():
     blocks = extract_text_blocks_from_pdf("sample_book3.pdf")
     blob = "\n\n".join(b["text"] for b in blocks)

--- a/tests/pdf_extraction_test.py
+++ b/tests/pdf_extraction_test.py
@@ -2,94 +2,116 @@
 
 import sys
 import os
-sys.path.insert(0, '.')
+
+sys.path.insert(0, ".")
 
 from pdf_chunker.parsing import extract_structured_text
 
+
 def test_pdf_extraction():
     """Test enhanced PDF extraction with fallback strategy"""
-    
+
     # Find PDF files for testing
     test_files = []
-    for root, dirs, files in os.walk('.'):
+    for root, dirs, files in os.walk("."):
         for file in files:
-            if file.lower().endswith('.pdf'):
+            if file.lower().endswith(".pdf"):
                 test_files.append(os.path.join(root, file))
 
     if not test_files:
-        print('No PDF files found for testing. Please add a PDF file to test the extraction.')
+        print(
+            "No PDF files found for testing. Please add a PDF file to test the extraction."
+        )
         return False
 
-    print(f'Found {len(test_files)} PDF file(s) for testing:')
+    print(f"Found {len(test_files)} PDF file(s) for testing:")
     success_count = 0
-    
+
     for pdf_file in test_files[:3]:  # Test up to 3 PDFs
-        print(f'Testing: {pdf_file}')
+        print(f"Testing: {pdf_file}")
         try:
             blocks = extract_structured_text(pdf_file)
-            
+
             if blocks:
-                print(f'  Extracted {len(blocks)} text blocks')
-                
+                print(f"  Extracted {len(blocks)} text blocks")
+
                 # Analyze text quality
-                total_text = ' '.join(block.get('text', '') for block in blocks)
-                lines = total_text.split('\n')
+                total_text = " ".join(block.get("text", "") for block in blocks)
+                lines = total_text.split("\n")
                 non_empty_lines = [line for line in lines if line.strip()]
-                
+
                 if non_empty_lines:
-                    avg_line_length = sum(len(line) for line in non_empty_lines) / len(non_empty_lines)
+                    avg_line_length = sum(len(line) for line in non_empty_lines) / len(
+                        non_empty_lines
+                    )
                     total_chars = sum(len(line) for line in non_empty_lines)
-                    total_spaces = sum(line.count(' ') for line in non_empty_lines)
+                    total_spaces = sum(line.count(" ") for line in non_empty_lines)
                     space_density = total_spaces / total_chars if total_chars > 0 else 0
-                    
-                    print(f'  Quality metrics:')
-                    print(f'    Average line length: {avg_line_length:.1f} characters')
-                    print(f'    Space density: {space_density:.3f}')
-                    print(f'    Total blocks: {len(blocks)}')
-                    
+
+                    print(f"  Quality metrics:")
+                    print(f"    Average line length: {avg_line_length:.1f} characters")
+                    print(f"    Space density: {space_density:.3f}")
+                    print(f"    Total blocks: {len(blocks)}")
+
                     # Check for problematic patterns
                     long_lines = [line for line in non_empty_lines if len(line) > 1000]
                     if long_lines:
-                        print(f'  WARNING: Found {len(long_lines)} lines longer than 1000 characters')
-                        print(f'    Longest line: {len(max(long_lines, key=len))} characters')
-                    
+                        print(
+                            f"  WARNING: Found {len(long_lines)} lines longer than 1000 characters"
+                        )
+                        print(
+                            f"    Longest line: {len(max(long_lines, key=len))} characters"
+                        )
+
                     if space_density < 0.05:
-                        print(f'  WARNING: Very low space density detected ({space_density:.3f})')
-                    
+                        print(
+                            f"  WARNING: Very low space density detected ({space_density:.3f})"
+                        )
+
                     # Show sample text from first few blocks
-                    print(f'  Sample text from first block:')
+                    print(f"  Sample text from first block:")
                     if blocks:
-                        sample_text = blocks[0].get('text', '')[:200]
+                        sample_text = blocks[0].get("text", "")[:200]
                         print(f'    "{sample_text}..."')
-                        
+
                     # Check extraction method used
-                    if blocks and 'source' in blocks[0]:
-                        method = blocks[0]['source'].get('method', 'PyMuPDF')
-                        print(f'  Extraction method: {method}')
-                    
+                    if blocks and "source" in blocks[0]:
+                        method = blocks[0]["source"].get("method", "PyMuPDF")
+                        print(f"  Extraction method: {method}")
+
                     # Check heading detection
-                    headings = [block for block in blocks if block.get('type') == 'heading']
-                    paragraphs = [block for block in blocks if block.get('type') == 'paragraph']
-                    print(f'  Block types: {len(headings)} headings, {len(paragraphs)} paragraphs')
-                    
+                    headings = [
+                        block for block in blocks if block.get("type") == "heading"
+                    ]
+                    paragraphs = [
+                        block for block in blocks if block.get("type") == "paragraph"
+                    ]
+                    print(
+                        f"  Block types: {len(headings)} headings, {len(paragraphs)} paragraphs"
+                    )
+
                     if headings:
-                        print(f'  Sample heading: "{headings[0].get("text", "")[:100]}..."')
-                        
+                        print(
+                            f'  Sample heading: "{headings[0].get("text", "")[:100]}..."'
+                        )
+
                     success_count += 1
                 else:
-                    print(f'  WARNING: No text content extracted')
+                    print(f"  WARNING: No text content extracted")
             else:
-                print(f'  ERROR: Failed to extract structured text')
-                
+                print(f"  ERROR: Failed to extract structured text")
+
         except Exception as e:
-            print(f'  ERROR: {str(e)}')
+            print(f"  ERROR: {str(e)}")
             import traceback
+
             traceback.print_exc()
-        
+
         print()
 
     return success_count > 0
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     success = test_pdf_extraction()
     sys.exit(0 if success else 1)

--- a/tests/semantic_chunking_test.py
+++ b/tests/semantic_chunking_test.py
@@ -2,132 +2,157 @@
 
 import sys
 import os
-sys.path.insert(0, '.')
+
+sys.path.insert(0, ".")
 
 from pdf_chunker.core import process_document
 
+
 def test_semantic_chunking():
     """Test semantic chunking with proper size validation"""
-    
+
     # Test with all available PDF files to verify chunk sizes
     test_files = []
-    for root, dirs, files in os.walk('.'):
+    for root, dirs, files in os.walk("."):
         for file in files:
-            if file.lower().endswith('.pdf'):
+            if file.lower().endswith(".pdf"):
                 test_files.append(os.path.join(root, file))
 
     if not test_files:
-        print('No PDF files found for testing semantic chunking.')
+        print("No PDF files found for testing semantic chunking.")
         return False
 
-    print(f'Testing semantic chunking with {len(test_files)} PDF file(s):')
+    print(f"Testing semantic chunking with {len(test_files)} PDF file(s):")
     success_count = 0
 
     for pdf_file in test_files[:2]:  # Test up to 2 PDFs to avoid long processing
-        print(f'Testing full pipeline with: {pdf_file}')
+        print(f"Testing full pipeline with: {pdf_file}")
         try:
             # Process document with semantic chunking (no AI enrichment for speed)
             chunks = process_document(
                 pdf_file,
                 chunk_size=500,  # 500 words target
-                overlap=50,      # 50 words overlap
+                overlap=50,  # 50 words overlap
                 generate_metadata=True,
-                ai_enrichment=False  # Disable AI for faster testing
+                ai_enrichment=False,  # Disable AI for faster testing
             )
-            
+
             if chunks:
-                print(f'  SUCCESS: Generated {len(chunks)} chunks')
-                
+                print(f"  SUCCESS: Generated {len(chunks)} chunks")
+
                 # Analyze chunk sizes with strict validation
-                chunk_sizes = [len(chunk.get('text', '')) for chunk in chunks]
+                chunk_sizes = [len(chunk.get("text", "")) for chunk in chunks]
                 max_size = max(chunk_sizes) if chunk_sizes else 0
                 avg_size = sum(chunk_sizes) / len(chunk_sizes) if chunk_sizes else 0
-                
-                print(f'  Chunk size analysis:')
-                print(f'    Average chunk size: {avg_size:.0f} characters')
-                print(f'    Maximum chunk size: {max_size} characters')
-                print(f'    Minimum chunk size: {min(chunk_sizes) if chunk_sizes else 0} characters')
-                
+
+                print(f"  Chunk size analysis:")
+                print(f"    Average chunk size: {avg_size:.0f} characters")
+                print(f"    Maximum chunk size: {max_size} characters")
+                print(
+                    f"    Minimum chunk size: {min(chunk_sizes) if chunk_sizes else 0} characters"
+                )
+
                 # Check for oversized chunks with strict limits
-                oversized_chunks = [i for i, size in enumerate(chunk_sizes) if size > 10000]
+                oversized_chunks = [
+                    i for i, size in enumerate(chunk_sizes) if size > 10000
+                ]
                 if oversized_chunks:
-                    print(f'  ERROR: Found {len(oversized_chunks)} chunks exceeding 10k characters:')
+                    print(
+                        f"  ERROR: Found {len(oversized_chunks)} chunks exceeding 10k characters:"
+                    )
                     for i in oversized_chunks[:3]:  # Show first 3 oversized chunks
-                        print(f'    Chunk {i}: {chunk_sizes[i]} characters')
+                        print(f"    Chunk {i}: {chunk_sizes[i]} characters")
                 else:
-                    print(f'  SUCCESS: All chunks are properly sized (<10k characters)')
-                
+                    print(f"  SUCCESS: All chunks are properly sized (<10k characters)")
+
                 # Check for extremely long chunks (the original problem)
-                extreme_chunks = [i for i, size in enumerate(chunk_sizes) if size > 25000]
+                extreme_chunks = [
+                    i for i, size in enumerate(chunk_sizes) if size > 25000
+                ]
                 if extreme_chunks:
-                    print(f'  CRITICAL ERROR: Found {len(extreme_chunks)} extremely long chunks (>25k chars):')
+                    print(
+                        f"  CRITICAL ERROR: Found {len(extreme_chunks)} extremely long chunks (>25k chars):"
+                    )
                     for i in extreme_chunks:
-                        print(f'    Chunk {i}: {chunk_sizes[i]} characters')
+                        print(f"    Chunk {i}: {chunk_sizes[i]} characters")
                 else:
-                    print(f'  SUCCESS: No extremely long chunks found')
-                
+                    print(f"  SUCCESS: No extremely long chunks found")
+
                 # Validate JSONL line length compatibility
                 jsonl_line_lengths = []
                 for chunk in chunks:
                     # Simulate JSONL serialization
                     import json
+
                     jsonl_line = json.dumps(chunk)
                     jsonl_line_lengths.append(len(jsonl_line))
-                
+
                 max_jsonl_line = max(jsonl_line_lengths) if jsonl_line_lengths else 0
-                print(f'  JSONL line analysis:')
-                print(f'    Maximum JSONL line length: {max_jsonl_line} characters')
-                
-                long_jsonl_lines = [i for i, length in enumerate(jsonl_line_lengths) if length > 30000]
+                print(f"  JSONL line analysis:")
+                print(f"    Maximum JSONL line length: {max_jsonl_line} characters")
+
+                long_jsonl_lines = [
+                    i for i, length in enumerate(jsonl_line_lengths) if length > 30000
+                ]
                 if long_jsonl_lines:
-                    print(f'  ERROR: Found {len(long_jsonl_lines)} JSONL lines exceeding 30k characters!')
+                    print(
+                        f"  ERROR: Found {len(long_jsonl_lines)} JSONL lines exceeding 30k characters!"
+                    )
                     for i in long_jsonl_lines[:3]:
-                        print(f'    JSONL line {i}: {jsonl_line_lengths[i]} characters')
+                        print(f"    JSONL line {i}: {jsonl_line_lengths[i]} characters")
                 else:
-                    print(f'  SUCCESS: All JSONL lines are reasonable length')
-                
+                    print(f"  SUCCESS: All JSONL lines are reasonable length")
+
                 # Test refactored modules by importing them
-                print(f'  Testing refactored modules:')
+                print(f"  Testing refactored modules:")
                 try:
                     from pdf_chunker.text_cleaning import clean_paragraph
                     from pdf_chunker.heading_detection import _detect_heading_fallback
-                    from pdf_chunker.extraction_fallbacks import _assess_text_quality, _extract_with_pdftotext
-                    print(f'    SUCCESS: All refactored modules imported successfully')
-                    
+                    from pdf_chunker.extraction_fallbacks import (
+                        _assess_text_quality,
+                        _extract_with_pdftotext,
+                    )
+
+                    print(f"    SUCCESS: All refactored modules imported successfully")
+
                     # Test a few functions to ensure they work
-                    test_text = 'This is a test para-graph with hyphenated words.'
+                    test_text = "This is a test para-graph with hyphenated words."
                     cleaned = clean_paragraph(test_text)
                     print(f'    Text cleaning test: "{test_text}" -> "{cleaned}"')
-                    
-                    heading_test = _detect_heading_fallback('Chapter 1: Introduction')
-                    print(f'    Heading detection test: "Chapter 1: Introduction" -> {heading_test}')
-                    
+
+                    heading_test = _detect_heading_fallback("Chapter 1: Introduction")
+                    print(
+                        f'    Heading detection test: "Chapter 1: Introduction" -> {heading_test}'
+                    )
+
                     success_count += 1
-                    
+
                 except ImportError as e:
-                    print(f'    ERROR: Failed to import refactored modules: {e}')
+                    print(f"    ERROR: Failed to import refactored modules: {e}")
                 except Exception as e:
-                    print(f'    ERROR: Refactored module test failed: {e}')
-                
+                    print(f"    ERROR: Refactored module test failed: {e}")
+
                 # Show sample chunks
-                print(f'  Sample chunks:')
+                print(f"  Sample chunks:")
                 for i in range(min(3, len(chunks))):
-                    chunk_text = chunks[i].get('text', '')
-                    preview = chunk_text[:100] if chunk_text else 'Empty chunk'
+                    chunk_text = chunks[i].get("text", "")
+                    preview = chunk_text[:100] if chunk_text else "Empty chunk"
                     print(f'    Chunk {i} ({len(chunk_text)} chars): "{preview}..."')
-                    
+
             else:
-                print(f'  ERROR: No chunks generated')
-                
+                print(f"  ERROR: No chunks generated")
+
         except Exception as e:
-            print(f'  ERROR: Pipeline failed: {e}')
+            print(f"  ERROR: Pipeline failed: {e}")
             import traceback
+
             traceback.print_exc()
-        
+
         print()
 
     return success_count > 0
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     success = test_semantic_chunking()
     sys.exit(0 if success else 1)

--- a/tests/test_text_processing.py
+++ b/tests/test_text_processing.py
@@ -1,26 +1,33 @@
 import unittest
 from pdf_chunker.text_processing import (
-    normalize_quotes, detect_and_fix_word_gluing, _fix_quote_boundary_gluing,
-    _fix_quote_splitting_issues, _detect_text_reordering, _validate_chunk_integrity,
-    _repair_json_escaping_issues, _remove_control_characters, _validate_json_safety
+    normalize_quotes,
+    detect_and_fix_word_gluing,
+    _fix_quote_boundary_gluing,
+    _fix_quote_splitting_issues,
+    _detect_text_reordering,
+    _validate_chunk_integrity,
+    _repair_json_escaping_issues,
+    _remove_control_characters,
+    _validate_json_safety,
 )
 
+
 class TestQuoteHandling(unittest.TestCase):
-    
+
     def test_smart_quote_normalization(self):
         """Test conversion of smart quotes to standard quotes."""
-        text = 'He said "Hello world" and \'goodbye\'.'
+        text = "He said \"Hello world\" and 'goodbye'."
         normalized = normalize_quotes(text)
         self.assertIn('"Hello world"', normalized)
         self.assertIn("'goodbye'", normalized)
 
         # Should not contain smart quotes
-        self.assertNotIn('“', normalized)
-        self.assertNotIn('”', normalized)
-    
-        self.assertNotIn('’', normalized)
-        self.assertNotIn('‘', normalized)
-    
+        self.assertNotIn("“", normalized)
+        self.assertNotIn("”", normalized)
+
+        self.assertNotIn("’", normalized)
+        self.assertNotIn("‘", normalized)
+
     def test_quote_spacing_fixes(self):
         """Test fixing of quote spacing issues."""
         text = 'He said"Hello" and left.'
@@ -28,70 +35,72 @@ class TestQuoteHandling(unittest.TestCase):
         self.assertIn('said "Hello"', normalized)
         # Should not have quotes glued to words
         self.assertNotIn('said"Hello"', normalized)
-    
+
     def test_quote_continuation_detection(self):
         """Test detection of quote continuations across blocks."""
         chunks = [
             'He said, "This is the beginning',
-            'of a long quote that continues here."'
+            'of a long quote that continues here."',
         ]
         # This should not be merged as it's a legitimate quote continuation
         result = _fix_quote_splitting_issues(chunks)
         self.assertEqual(len(result), 2)  # Should remain separate
-    
+
     def test_quote_splitting_repair(self):
         """Test repair of incorrectly split quotes."""
         chunks = [
             'Finally, Part III, "What Does Success Look Like?',
-            '", pulls it all together.'
+            '", pulls it all together.',
         ]
         fixed_chunks = _fix_quote_splitting_issues(chunks)
         self.assertEqual(len(fixed_chunks), 1)
         merged_text = fixed_chunks[0]
         self.assertIn('"What Does Success Look Like?"', merged_text)
 
+
 class TestJSONSafety(unittest.TestCase):
     """Test JSON safety and escaping functionality."""
-    
+
     def test_json_escaping_repair(self):
         """Test repair of JSON escaping issues."""
         problematic_text = '", corrupted fragment...'
         cleaned = _repair_json_escaping_issues(problematic_text)
         self.assertFalse(cleaned.startswith('",'))
-        self.assertIn('corrupted fragment', cleaned)
-    
+        self.assertIn("corrupted fragment", cleaned)
+
     def test_control_character_removal(self):
         """Test removal of control characters that break JSON."""
         text_with_controls = "Normal text\x00\x01\x02 with controls"
         cleaned = _repair_json_escaping_issues(text_with_controls)
-        self.assertNotIn('\x00', cleaned)
-        self.assertNotIn('\x01', cleaned)
-        self.assertNotIn('\x02', cleaned)
-        self.assertIn('Normal text', cleaned)
-        self.assertIn('with controls', cleaned)
-    
+        self.assertNotIn("\x00", cleaned)
+        self.assertNotIn("\x01", cleaned)
+        self.assertNotIn("\x02", cleaned)
+        self.assertIn("Normal text", cleaned)
+        self.assertIn("with controls", cleaned)
+
     def test_json_safety_validation(self):
         """Test detection of JSON safety issues."""
         unsafe_text = 'Text with "unescaped quotes and \x00 controls'
         # This test passes - it's testing detection
-        self.assertTrue(any(ord(c) < 32 for c in unsafe_text if c not in '\t\n\r'))
+        self.assertTrue(any(ord(c) < 32 for c in unsafe_text if c not in "\t\n\r"))
+
 
 class TestWordGluingDetection(unittest.TestCase):
     """Test word gluing detection and repair functionality."""
-    
+
     def test_case_transition_gluing(self):
         """Test detection and fixing of case transition gluing."""
         text = "This is a testCase where wordsAre glued together."
         fixed_text = detect_and_fix_word_gluing(text)
         self.assertIn("test Case", fixed_text)
         self.assertIn("words Are", fixed_text)
-    
+
     def test_page_boundary_gluing(self):
         """Test detection and fixing of page boundary gluing."""
         text = "This sentence ends hereThe next sentence starts."
         fixed_text = detect_and_fix_word_gluing(text)
         self.assertIn("here The", fixed_text)
-    
+
     def test_quote_boundary_gluing(self):
         """Test detection and fixing of quote boundary gluing."""
         text = 'He said"Hello"and left quickly.'
@@ -99,7 +108,7 @@ class TestWordGluingDetection(unittest.TestCase):
         self.assertIn('said "Hello" and', fixed_text)
         # Should not have quotes glued to words
         self.assertNotIn('said"Hello"and', fixed_text)
-    
+
     def test_legitimate_compound_words_preserved(self):
         """Test that legitimate compound words are not broken."""
         text = "The JavaScript framework and iPhone app work well."
@@ -107,20 +116,21 @@ class TestWordGluingDetection(unittest.TestCase):
         self.assertIn("JavaScript", fixed_text)
         self.assertIn("iPhone", fixed_text)
 
+
 class TestBlockMerging(unittest.TestCase):
     """Test block merging functionality."""
-    
+
     def test_quote_aware_merging(self):
         """Test that block merging properly handles quotes."""
         blocks = [
-            'This is a complete sentence.',
+            "This is a complete sentence.",
             'This starts a quote: "Hello',
-            'world" and continues here.'
+            'world" and continues here.',
         ]
         # This test passes - it's testing awareness, not actual merging
         quote_blocks = [b for b in blocks if '"' in b]
         self.assertEqual(len(quote_blocks), 2)
-    
+
     def test_legitimate_quote_boundary(self):
         """Test that legitimate quote boundaries are respected."""
         text = 'He said "Hello" and then "Goodbye".'
@@ -128,61 +138,67 @@ class TestBlockMerging(unittest.TestCase):
         quote_count = text.count('"')
         self.assertEqual(quote_count, 4)
 
+
 class TestChunkIntegrity(unittest.TestCase):
     """Test chunk integrity validation."""
-    
+
     def test_chunk_integrity_validation(self):
         """Test validation of chunk integrity."""
         chunks = [
             "This is a normal chunk.",
             "Another normal chunk here.",
-            "Final chunk with proper ending."
+            "Final chunk with proper ending.",
         ]
         # This test passes - it's testing validation logic
         self.assertTrue(all(len(chunk.strip()) > 0 for chunk in chunks))
-    
+
     def test_corrupted_chunk_detection(self):
         """Test detection and repair of corrupted chunks."""
         chunks = [
             "Original text here.",
             '", corrupted fragment...',
             "Normal chunk.",
-            "Another chunk."
+            "Another chunk.",
         ]
         # This test passes - it's testing detection and logging
         corrupted_count = sum(1 for chunk in chunks if chunk.strip().startswith('",'))
         self.assertGreater(corrupted_count, 0)
 
+
 class TestTextCorruptionDetection(unittest.TestCase):
     """Test text corruption detection functionality."""
-    
+
     def test_word_gluing_detection(self):
         """Test detection of word gluing issues in chunks."""
         text = "This hasWordGluing and moreIssues here."
         # This test passes - it's testing detection
         gluing_detected = any(
-            i > 0 and text[i-1].islower() and text[i].isupper()
+            i > 0 and text[i - 1].islower() and text[i].isupper()
             for i in range(len(text))
         )
         self.assertTrue(gluing_detected)
-    
+
     def test_text_reordering_detection(self):
         """Test detection of text reordering issues."""
         original_order = ["First sentence.", "Second sentence.", "Third sentence."]
         reordered = ["Second sentence.", "First sentence.", "Third sentence."]
         # This test passes - it's testing detection logic
         self.assertNotEqual(original_order, reordered)
-    
+
     def test_comprehensive_validation(self):
         """Test comprehensive text processing quality validation."""
         text = "This is well-formatted text with proper spacing and punctuation."
         # This test passes - it's testing validation
         issues = []
-        if any(i > 0 and text[i-1].islower() and text[i].isupper() for i in range(len(text))):
+        if any(
+            i > 0 and text[i - 1].islower() and text[i].isupper()
+            for i in range(len(text))
+        ):
             issues.append("word_gluing")
         if '",' in text:
             issues.append("json_escaping")
         self.assertEqual(len(issues), 0)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- configure Black via pyproject with line length 88
- reformat modules in pdf_chunker, scripts, and tests

## Testing
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: Argument 1 to "maketrans" has incompatible type; missing return statement; untyped imports; etc.)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `PYTHONPATH=. pytest tests/`
- `bash tests/run_all_tests.sh` *(fails: ModuleNotFoundError: No module named 'pdf_chunker'; Known-good test EPUB not found; PDF page exclusion broken)*

------
https://chatgpt.com/codex/tasks/task_e_6892758c5e608325a33bdf49464bef41