### PR TITLE
test: add coverage for env flags and CLI helpers

### DIFF
--- a/tests/env_utils_test.py
+++ b/tests/env_utils_test.py
@@ -1,0 +1,20 @@
+import pytest
+from pdf_chunker.env_utils import use_pymupdf4llm
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, True),
+        ("true", True),
+        ("false", False),
+        ("0", False),
+        ("off", False),
+    ],
+)
+def test_use_pymupdf4llm(monkeypatch, value, expected):
+    if value is None:
+        monkeypatch.delenv("PDF_CHUNKER_USE_PYMUPDF4LLM", raising=False)
+    else:
+        monkeypatch.setenv("PDF_CHUNKER_USE_PYMUPDF4LLM", value)
+    assert use_pymupdf4llm() is expected

--- a/tests/hyphenation_test.py
+++ b/tests/hyphenation_test.py
@@ -1,56 +1,55 @@
-import os
-import sys
-import unittest
-
-sys.path.insert(0, ".")
-
+import pytest
 from pdf_chunker.text_cleaning import clean_text
 import pdf_chunker.pymupdf4llm_integration as p4l
 
 
-class TestHyphenationFix(unittest.TestCase):
-    def test_hyphenation_fix_with_pymupdf4llm(self):
-        sample = "a con-\n tainer and special-\n ists in man-\n agement"
-        os.environ["PDF_CHUNKER_USE_PYMUPDF4LLM"] = "true"
-        original = p4l.is_pymupdf4llm_available
-        try:
-            p4l.is_pymupdf4llm_available = lambda: True
-            cleaned = clean_text(sample)
-        finally:
-            p4l.is_pymupdf4llm_available = original
-            del os.environ["PDF_CHUNKER_USE_PYMUPDF4LLM"]
-        self.assertIn("container", cleaned)
-        self.assertIn("specialists", cleaned)
-        self.assertIn("management", cleaned)
-        self.assertNotIn("con- tainer", cleaned)
-        self.assertNotIn("special- ists", cleaned)
-        self.assertNotIn("man- agement", cleaned)
-
-    def test_clean_block_hyphen_fix(self):
-        block = {"text": "Storage engi‐\n neer", "source": {"page": 1}}
-        cleaned = p4l._clean_pymupdf4llm_block(block)
-        self.assertIsNotNone(cleaned)
-        self.assertEqual(cleaned["text"], "Storage engineer")
-
-    def test_preserve_existing_hyphens(self):
-        text = "We sell business-critical, off-the-shelf solutions."
-        cleaned = clean_text(text)
-        self.assertIn("business-critical", cleaned)
-        self.assertIn("off-the-shelf", cleaned)
-
-    def test_bullet_hyphen_continuation(self):
-        text = "* Some text before ambig-\n* uous word"
-        cleaned = clean_text(text)
-        self.assertIn("ambiguous", cleaned)
-        self.assertEqual(cleaned.count("*"), 1)
-
-    def test_underscore_hyphen_cleanup(self):
-        """Ensure underscore emphasis and hyphen breaks are cleaned."""
-        block = {"text": "_respon-\n_sibility_", "source": {"page": 1}}
-        cleaned = p4l._clean_pymupdf4llm_block(block)
-        self.assertIsNotNone(cleaned)
-        self.assertEqual(cleaned["text"], "responsibility")
+@pytest.fixture
+def force_pymupdf4llm(monkeypatch):
+    monkeypatch.setenv("PDF_CHUNKER_USE_PYMUPDF4LLM", "true")
+    monkeypatch.setattr(p4l, "is_pymupdf4llm_available", lambda: True)
+    yield
+    monkeypatch.delenv("PDF_CHUNKER_USE_PYMUPDF4LLM", raising=False)
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_hyphenation_fix_with_pymupdf4llm(force_pymupdf4llm):
+    sample = "a con-\n tainer and special-\n ists in man-\n agement"
+    cleaned = clean_text(sample)
+    assert all(word in cleaned for word in ("container", "specialists", "management"))
+    assert all(
+        broken not in cleaned
+        for broken in ("con- tainer", "special- ists", "man- agement")
+    )
+
+
+@pytest.mark.parametrize(
+    "block,expected",
+    [
+        ({"text": "Storage engi-\n neer", "source": {"page": 1}}, "Storage engineer"),
+        ({"text": "_respon-\n_sibility_", "source": {"page": 1}}, "responsibility"),
+    ],
+)
+def test_clean_block_hyphen_fix(block, expected):
+    cleaned = p4l._clean_pymupdf4llm_block(block)
+    assert cleaned is not None
+    assert cleaned["text"] == expected
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        (
+            "We sell business-critical, off-the-shelf solutions.",
+            ("business-critical", "off-the-shelf"),
+        ),
+    ],
+)
+def test_preserve_existing_hyphens(text, expected):
+    cleaned = clean_text(text)
+    assert all(word in cleaned for word in expected)
+
+
+def test_bullet_hyphen_continuation():
+    text = "* Some text before ambig-\n* uous word"
+    cleaned = clean_text(text)
+    assert "ambiguous" in cleaned
+    assert cleaned.count("*") == 1

--- a/tests/list_detection_edge_case_test.py
+++ b/tests/list_detection_edge_case_test.py
@@ -1,0 +1,9 @@
+import pytest
+from pdf_chunker.list_detection import is_bullet_list_pair
+
+
+@pytest.mark.parametrize("bullet", ["\u2022", "*"])
+def test_is_bullet_list_pair_with_colon(bullet):
+    curr = f"Intro: {bullet} first"
+    nxt = f"{bullet} second"
+    assert is_bullet_list_pair(curr, nxt)

--- a/tests/page_artifacts_edge_case_test.py
+++ b/tests/page_artifacts_edge_case_test.py
@@ -1,0 +1,13 @@
+import pytest
+from pdf_chunker.page_artifacts import strip_page_artifact_suffix
+
+
+@pytest.mark.parametrize(
+    "text,page,expected",
+    [
+        ("content | IV", 4, "content"),
+        ("content | iv", 4, "content"),
+    ],
+)
+def test_strip_page_artifact_suffix_roman(text, page, expected):
+    assert strip_page_artifact_suffix(text, page) == expected

--- a/tests/scripts_cli_test.py
+++ b/tests/scripts_cli_test.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+SCRIPTS = [
+    ("chunk_pdf.py", ["--help"], 0, "usage"),
+    ("detect_duplicates.py", [], 1, "usage"),
+]
+
+
+@pytest.mark.parametrize("script,args,code,keyword", SCRIPTS)
+def test_cli_invocation(script, args, code, keyword):
+    result = subprocess.run(
+        ["python", str(Path("scripts") / script), *args],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": "."},
+    )
+    assert result.returncode == code
+    output = (result.stdout + result.stderr).lower()
+    assert keyword in output


### PR DESCRIPTION
## Summary
- migrate hyphenation tests to pytest with fixtures and parametrization
- verify env flag `use_pymupdf4llm` handling
- exercise CLI scripts and edge cases in list detection and page artifacts

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(fails: missing stubs and typing issues)*
- `bash scripts/validate_chunks.sh` *(fails: file 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_68927d999658832597cb322ce476dbb7