### PR TITLE
Add property-based tests and chunk_pdf integration test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ pdf_chunker/
     ├── AGENTS.md
     ├── ai_enrichment_test.py
     ├── bullet_list_test.py
+    ├── chunk_pdf_integration_test.py
     ├── cross_page_sentence_test.py
     ├── epub_spine_test.py
     ├── heading_boundary_test.py
@@ -61,6 +62,7 @@ pdf_chunker/
     ├── page_utils_test.py
     ├── pdf_extraction_test.py
     ├── process_document_override_test.py
+    ├── property_based_text_test.py
     ├── run_all_tests.sh           # Orchestrates all test modules
     ├── semantic_chunking_test.py
     ├── source_matchers_test.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -145,3 +145,4 @@ zipp==3.23.0
 zstandard==0.23.0
 flake8
 black
+hypothesis

--- a/tests/chunk_pdf_integration_test.py
+++ b/tests/chunk_pdf_integration_test.py
@@ -1,0 +1,29 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_chunk_pdf_generates_jsonl(tmp_path: Path) -> None:
+    pdf = Path("test_data/sample_test.pdf").resolve()
+    script = Path("scripts/chunk_pdf.py").resolve()
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    result = subprocess.run(
+        ["python", str(script), str(pdf)],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=env,
+        check=True,
+    )
+    lines = [
+        json.loads(line)
+        for line in result.stdout.splitlines()
+        if line.strip().startswith("{")
+    ]
+    assert lines and all(
+        {"text", "metadata"} <= line.keys()
+        and {"chunk_id", "source"} <= line["metadata"].keys()
+        for line in lines
+    )
+    assert not any(tmp_path.iterdir())

--- a/tests/property_based_text_test.py
+++ b/tests/property_based_text_test.py
@@ -1,0 +1,18 @@
+from hypothesis import given, strategies as st
+from pdf_chunker.text_cleaning import clean_text
+from pdf_chunker import splitter
+
+
+@given(st.text())
+def test_clean_text_idempotent(sample: str) -> None:
+    cleaned = clean_text(sample)
+    assert clean_text(cleaned) == cleaned
+    assert all(ord(ch) >= 32 or ch == "\n" for ch in cleaned)
+
+
+@given(st.text(min_size=1, max_size=200))
+def test_split_text_preserves_non_whitespace(sample: str) -> None:
+    chunks = splitter._split_text_into_chunks(sample, chunk_size=50, overlap=0)
+    joined = "".join(chunks)
+    strip_ws = lambda s: "".join(ch for ch in s if not ch.isspace())
+    assert set(strip_ws(joined)) <= set(strip_ws(sample))


### PR DESCRIPTION
## Summary
- add hypothesis-based property tests for text cleaning and splitting
- verify chunk_pdf CLI emits valid JSONL metadata without side effects
- document new tests and include Hypothesis dependency

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/`
- `mypy pdf_chunker/` *(hangs, interrupted)*
- `bash scripts/validate_chunks.sh output_chunks.json` *(fails: No valid chunks found)*
- `pytest tests/`
- `bash tests/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6892810ec4d88325b8697d24fb8c8f28