### PR TITLE
docs: refresh AGENTS listings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,9 @@ If possible, check to make sure the tree below reflects the current state of the
 Document newly introduced modules (e.g., list detection utilities) here to keep this reference current.
 ```
 pdf_chunker/
-├── .env                           # API keys and configuration secrets
+├── _apply.sh                    # Batch apply scripts across multiple files
+├── _e2e_check.sh                # End-to-end pipeline check
+├── .env                         # API keys and configuration secrets
 ├── config/
 │   └── tags/                      # External tag configuration (YAML vocabularies)
 │       ├── generic.yaml           # Base tag categories
@@ -40,30 +42,47 @@ pdf_chunker/
 │   ├── text_processing.py         # Shared text manipulation utilities
 │   └── utils.py                   # Metadata mapping and glue logic
 ├── scripts/
-│   ├── _apply.sh                  # Batch apply scripts across multiple files
-│   ├── chunk_pdf.py               # CLI for running the full pipeline
-│   ├── detect_duplicates.py       # Overlap and duplicate detection
-│   └── validate_chunks.sh         # Quality and boundary validation
-└── tests/                         # Modular test architecture
+│   ├── AGENTS.md                # Guidance for maintenance scripts
+│   ├── benchmark_extraction.py  # Compare extraction strategies
+│   ├── chunk_pdf.py             # CLI for running the full pipeline
+│   ├── compare_text_quality.py  # Inspect text differences across engines
+│   ├── detect_duplicates.py     # Overlap and duplicate detection
+│   ├── diagnose_hyphens.py      # Report hyphenation issues
+│   ├── experiment_pymupdf4llm.py # Prototype PyMuPDF4LLM integration
+│   ├── find_glued_words.py      # Detect concatenated words
+│   ├── fix_newlines.py          # Normalize newlines in text
+│   ├── fix_newlines_jsonl.py    # Fix newline issues in JSONL chunks
+│   ├── generate_test_epub.py    # Build minimal EPUB fixtures
+│   ├── generate_test_pdf.py     # Build minimal PDF fixtures
+│   ├── llm_correction.py        # Apply LLM-based corrections
+│   ├── test_page_boundaries.py  # Inspect chunk boundaries against pages
+│   ├── validate_chunk_quality.py # Evaluate chunk content quality
+│   ├── validate_chunks.sh       # Quality and boundary validation
+│   └── validate_readme_functionality.py # Check README code snippets
+└── tests/                        # Modular test architecture
     ├── AGENTS.md
     ├── ai_enrichment_test.py
     ├── bullet_list_test.py
     ├── chunk_pdf_integration_test.py
     ├── cross_page_sentence_test.py
+    ├── env_utils_test.py
     ├── epub_spine_test.py
     ├── heading_boundary_test.py
     ├── hyphenation_test.py
     ├── indented_block_test.py
+    ├── list_detection_edge_case_test.py
     ├── newline_cleanup_test.py
     ├── numbered_list_chunk_test.py
     ├── numbered_list_test.py
     ├── page_artifact_detection_test.py
+    ├── page_artifacts_edge_case_test.py
     ├── page_exclusion_test.py
     ├── page_utils_test.py
     ├── pdf_extraction_test.py
     ├── process_document_override_test.py
     ├── property_based_text_test.py
     ├── run_all_tests.sh           # Orchestrates all test modules
+    ├── scripts_cli_test.py
     ├── semantic_chunking_test.py
     ├── source_matchers_test.py
     ├── test_text_processing.py
@@ -73,6 +92,11 @@ pdf_chunker/
     └── utils_test.py
 `````
 
+---
+
+## Formatting Standards
+
+All Python modules, scripts, and tests must be formatted with **Black**, linted with **flake8**, and type-checked using **mypy** before submission.
 
 ---
 
@@ -240,7 +264,7 @@ Tests must:
 
 ```bash
 black pdf_chunker/ scripts/ tests/
-flake8 pdf_chunker/
+flake8 pdf_chunker/ scripts/ tests/
 mypy pdf_chunker/
 bash scripts/validate_chunks.sh
 `````

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -12,6 +12,11 @@ Test modules validating behavior of parsing, chunking, and enrichment layers.
 - `page_exclusion_test.py`: Page range and filter correctness
 - `epub_spine_test.py`: Spine index parsing and exclusion logic
 - `process_document_override_test.py`: Callable override injection
+- `env_utils_test.py`: Environment flag toggles via `monkeypatch`
+- `list_detection_edge_case_test.py`: Bullet list parsing edge cases
+- `page_artifact_detection_test.py`: Header/footer removal accuracy
+- `page_artifacts_edge_case_test.py`: Page artifact suffix handling
+- `scripts_cli_test.py`: CLI invocation sanity checks
 - `run_all_tests.sh`: Orchestrates full suite
 - Duplicate detection thresholds (via `detect_duplicates.py`).
 
@@ -22,6 +27,19 @@ Test modules validating behavior of parsing, chunking, and enrichment layers.
 - Use idempotent tests.
 - Prefer functional assertions on outputs.
 - Leverage ```tests/utils/common.sh` for shared setup.
+
+## Utilities & Fixtures
+- `tests/utils/common.sh`: Shell helpers for CLI-oriented tests
+- `pytest.monkeypatch`: Controls environment variables in `env_utils_test.py`
+
+## Formatting
+Run repository formatters before committing test changes:
+
+```bash
+black tests/
+flake8 tests/
+mypy pdf_chunker/
+```
 
 ## Known Issues
 - Test suite may not fully reflect current pipeline logic


### PR DESCRIPTION
## Summary
- catalog new maintenance scripts and test modules in AGENTS
- note Black, flake8, and mypy formatting requirements
- describe shared test utilities and fixtures

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: F821 undefined name 'traceback', E203 whitespace before ':', E722 do not use bare 'except', E401 multiple imports on one line, E731 do not assign a lambda expression)*
- `mypy pdf_chunker/` *(fails: Argument 1 to "maketrans" of "str" has incompatible type "dict[str, str]", Missing return statement, incompatible defaults, Need type annotation for variable, etc.)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/`
- `bash tests/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6892bc3f3fd88325bedefb00572dee98