### PR TITLE
Fix cross-page bullet list continuation

### DIFF
--- a/tests/bullet_list_test.py
+++ b/tests/bullet_list_test.py
@@ -14,3 +14,5 @@ def test_bullet_list_preservation():
     assert len(items) == 3
     assert all(not item.rstrip().endswith(".") for item in items)
     assert "•\n\n•" not in blob
+    assert "\n\nswamp" not in blob
+    assert "swamp\n\nFollow" in blob


### PR DESCRIPTION
## Summary
- handle list items split across pages by detecting bullet fragments
- merge bullet fragments without swallowing following paragraphs
- assert final bullet word remains before paragraph break

## Testing
- `flake8 pdf_chunker/list_detection.py pdf_chunker/pdf_parsing.py tests/bullet_list_test.py` *(passes; repository-wide run fails: `scripts/benchmark_extraction.py:718:9: F821 undefined name 'traceback'`)*
- `mypy pdf_chunker/list_detection.py pdf_chunker/pdf_parsing.py` *(fails: missing stubs and incompatible defaults)*
- `pytest tests/`
- `bash tests/run_all_tests.sh`
- `bash scripts/validate_chunks.sh /tmp/sample_book3.jsonl` *(fails: chunk starts mid-sentence)*

------
https://chatgpt.com/codex/tasks/task_e_6892c2ea2a6083258e274465feb2be0c