### PR TITLE
Strip markdown table artifacts and refine paragraph splitting

### DIFF
--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -263,16 +263,21 @@ def clean_paragraph(paragraph: str) -> str:
     Cleans a single paragraph: removes mid-line hyphens, artifacts,
     collapses all newlines (if present) to spaces, and normalizes.
     """
-    return pipe(
-        paragraph,
-        fix_hyphenated_linebreaks,
-        collapse_artifact_breaks,
-        _preserve_list_newlines,
-        normalize_ligatures,
-        normalize_quotes,
-        remove_control_characters,
-        consolidate_whitespace,
+    parts = filter(None, re.split(r"<br>\s*|\n", paragraph))
+    cleaned_parts = (
+        pipe(
+            part,
+            fix_hyphenated_linebreaks,
+            collapse_artifact_breaks,
+            _preserve_list_newlines,
+            normalize_ligatures,
+            normalize_quotes,
+            remove_control_characters,
+            consolidate_whitespace,
+        )
+        for part in parts
     )
+    return "\n".join(cleaned_parts)
 
 
 def clean_text(text: str) -> str:

--- a/tests/page_artifact_detection_test.py
+++ b/tests/page_artifact_detection_test.py
@@ -5,6 +5,7 @@ from pdf_chunker.page_artifacts import (
     strip_page_artifact_suffix,
     remove_page_artifact_lines,
 )
+from pdf_chunker.pymupdf4llm_integration import clean_text_with_pymupdf4llm
 
 
 class TestPageArtifactDetection(unittest.TestCase):
@@ -99,6 +100,23 @@ class TestPageArtifactDetection(unittest.TestCase):
         self.assertTrue(is_page_artifact_text(line, 19))
         cleaned = remove_page_artifact_lines(line, 19)
         self.assertEqual(cleaned, "")
+
+    def test_header_deduplication_and_br_removal(self):
+        raw = (
+            "| Col1 | Col2 |\n"
+            "|---|---|\n"
+            "Title<br>\n"
+            "Author<br>\n"
+            "Location<br>\n"
+            "Title<br>\n"
+            "Author<br>\n"
+            "Location\n"
+        )
+        cleaned = clean_text_with_pymupdf4llm(raw)
+        self.assertEqual(cleaned.count("Title"), 1)
+        self.assertEqual(cleaned.count("Author"), 1)
+        self.assertEqual(cleaned.count("Location"), 1)
+        self.assertNotIn("<br>", cleaned)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove markdown table remnants and collapse repeated lines before PyMuPDF4LLM text cleaning
- use generator-based pipeline in `clean_paragraph` to split chapter titles, authors, and locations
- test that title, author, and location lines appear once without `<br>` tags

## Testing
- `black pdf_chunker/pymupdf4llm_integration.py pdf_chunker/text_cleaning.py tests/page_artifact_detection_test.py`
- `flake8 pdf_chunker/pymupdf4llm_integration.py pdf_chunker/text_cleaning.py tests/page_artifact_detection_test.py`
- `mypy pdf_chunker/pymupdf4llm_integration.py pdf_chunker/text_cleaning.py` *(fails: Incompatible default for argument "exclude_pages" and missing library stubs)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `PYTHONPATH=. pytest tests/page_artifact_detection_test.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68963db5d5108325adff1915865dd7ae