### PR TITLE
Handle markdown tables during text cleanup

### DIFF
--- a/tests/footer_table_cleanup_test.py
+++ b/tests/footer_table_cleanup_test.py
@@ -1,0 +1,16 @@
+import sys
+
+sys.path.insert(0, ".")
+
+from pdf_chunker.core import process_document
+
+
+def test_footer_table_cleanup():
+    chunks = process_document("sample_book-footer.pdf", 400, 50)
+    first_lines = chunks[0]["text"].splitlines()[:3]
+    assert first_lines == [
+        "This closed car smells of salt fish",
+        "Person Name, PMP",
+        "Alma, Quebec, Canada",
+    ]
+    assert chunks[0]["text"].count("Person Name, PMP") == 1


### PR DESCRIPTION
## Summary
- add markdown table stripping and HTML break handling to `clean_text`
- factor text transforms into composable steps with debug logging
- add regression test for footer table cleanup

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: undefined name 'traceback' and other style issues)*
- `mypy pdf_chunker/` *(fails: missing stubs and incompatible types)*
- `bash scripts/validate_chunks.sh temp_output/sample_book-footer_clean.jsonl` *(fails: mid-sentence chunk)*
- `pytest tests/footer_table_cleanup_test.py -q` *(fails: assertion on cleaned lines)*

------
https://chatgpt.com/codex/tasks/task_e_689642b8fa88832588545c1b5c5f1fb7