### PR TITLE
Handle multi-line hyphenated words

### DIFF
--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -39,12 +39,34 @@ SOFT_HYPHEN_RE = re.compile("\u00ad")
 BULLET_CHARS_ESC = re.escape("*•")
 
 
-def _join_broken_words(text: str) -> str:
+def _merge_double_newlines(text: str) -> str:
+    """Join hyphenated words separated by multiple newlines."""
+
     bullet_opt = rf"(?:[{BULLET_CHARS_ESC}]\s*)?"
-    pattern_break = rf"(\w)[{HYPHEN_CHARS_ESC}]\s*\n\s*{bullet_opt}(\w)"
-    pattern_space = rf"(\w)[{HYPHEN_CHARS_ESC}]\s+{bullet_opt}([a-z])"
-    text = re.sub(pattern_break, r"\1\2", text)
-    return re.sub(pattern_space, r"\1\2", text)
+    pattern = re.compile(rf"(\w)[{HYPHEN_CHARS_ESC}]\s*(?:\n\s*){{2,}}{bullet_opt}(\w)")
+    return pattern.sub(r"\1\2", text)
+
+
+def _merge_single_newlines(text: str) -> str:
+    """Join hyphenated words split by a single newline."""
+
+    bullet_opt = rf"(?:[{BULLET_CHARS_ESC}]\s*)?"
+    pattern = re.compile(rf"(\w)[{HYPHEN_CHARS_ESC}]\s*\n\s*{bullet_opt}(\w)")
+    return pattern.sub(r"\1\2", text)
+
+
+def _merge_split_words(text: str) -> str:
+    """Join hyphenated words split by spaces without newlines."""
+
+    bullet_opt = rf"(?:[{BULLET_CHARS_ESC}]\s*)?"
+    pattern = re.compile(rf"(\w)[{HYPHEN_CHARS_ESC}]\s+{bullet_opt}([a-z])")
+    return pattern.sub(r"\1\2", text)
+
+
+def _join_broken_words(text: str) -> str:
+    return pipe(
+        text, _merge_double_newlines, _merge_single_newlines, _merge_split_words
+    )
 
 
 def _remove_soft_hyphens(text: str) -> str:

--- a/tests/hyphenation_test.py
+++ b/tests/hyphenation_test.py
@@ -53,3 +53,14 @@ def test_bullet_hyphen_continuation():
     cleaned = clean_text(text)
     assert "ambiguous" in cleaned
     assert cleaned.count("*") == 1
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("put-\n\nting", "putting"),
+        ("spea-\n\nking", "speaking"),
+    ],
+)
+def test_multi_newline_hyphenation(text, expected):
+    assert clean_text(text) == expected


### PR DESCRIPTION
## Summary
- handle hyphenated words split across multiple newlines or spaces via regex pipeline
- add regression tests for multi-line hyphenation cases from sample_book-footer.pdf

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: F821 undefined name 'traceback'...)*
- `flake8 pdf_chunker/text_cleaning.py tests/hyphenation_test.py`
- `mypy pdf_chunker/` *(fails: Argument 1 to "maketrans"...)*
- `bash scripts/validate_chunks.sh sample_book-footer.jsonl` *(fails: Validation FAILED - anomalies detected in sample_book-footer.jsonl)*
- `PYTHONPATH=. pytest tests/`
- `bash tests/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68964704feb88325a67c2a5b9b34d177