### PR TITLE
feat: add Python chunk validation helper

### DIFF
--- a/pdf_chunker/chunk_validation.py
+++ b/pdf_chunker/chunk_validation.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List
+import importlib
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    """Structured result from :func:`validate_chunks`.
+
+    Attributes capture anomaly counts and duplication analysis while
+    remaining hashable for deterministic comparisons in tests.
+    """
+
+    total_chunks: int
+    empty_text: int
+    mid_sentence_starts: int
+    overlong: int
+    duplications: List[Dict[str, Any]]
+    boundary_overlaps: List[Dict[str, Any]]
+
+    def has_issues(self) -> bool:
+        """Return ``True`` if any anomalies or duplicates were found."""
+
+        return any(
+            (
+                self.empty_text,
+                self.mid_sentence_starts,
+                self.overlong,
+                self.duplications,
+                self.boundary_overlaps,
+            )
+        )
+
+
+def _extract_texts(chunks: Iterable[Dict[str, Any]]) -> List[str]:
+    return [chunk.get("text", "") for chunk in chunks]
+
+
+def _count(predicate, texts: Iterable[str]) -> int:
+    return sum(1 for text in texts if predicate(text))
+
+
+def _is_empty(text: str) -> bool:
+    return not text.strip()
+
+
+def _starts_mid_sentence(text: str) -> bool:
+    stripped = text.lstrip()
+    return bool(stripped) and stripped[0].islower()
+
+
+def _is_overlong(text: str, limit: int = 8000) -> bool:
+    return len(text) > limit
+
+
+def validate_chunks(chunks: Iterable[Dict[str, Any]]) -> ValidationReport:
+    """Validate chunk structures and content.
+
+    Parameters
+    ----------
+    chunks:
+        Iterable of chunk dictionaries containing at minimum a ``text`` key.
+
+    Returns
+    -------
+    ValidationReport
+        Dataclass summarising counts and duplication analysis.
+    """
+
+    chunk_list = list(chunks)
+    texts = _extract_texts(chunk_list)
+    detect_duplicates = importlib.import_module("scripts.detect_duplicates")
+
+    return ValidationReport(
+        total_chunks=len(chunk_list),
+        empty_text=_count(_is_empty, texts),
+        mid_sentence_starts=_count(_starts_mid_sentence, texts),
+        overlong=_count(_is_overlong, texts),
+        duplications=detect_duplicates.detect_duplications(
+            chunk_list, window_size=50, min_overlap=10
+        ),
+        boundary_overlaps=detect_duplicates.analyze_chunk_boundaries(chunk_list)[
+            "boundary_overlaps"
+        ],
+    )

--- a/tests/bullet_list_test.py
+++ b/tests/bullet_list_test.py
@@ -3,10 +3,19 @@ import sys
 sys.path.insert(0, ".")
 
 from pdf_chunker.pdf_parsing import extract_text_blocks_from_pdf
+from pdf_chunker.chunk_validation import validate_chunks
 
 
 def test_bullet_list_preservation():
     blocks = extract_text_blocks_from_pdf("sample_book3.pdf")
+    report = validate_chunks(blocks)
+    assert report.total_chunks == len(blocks)
+    assert report.empty_text == 0
+    assert report.mid_sentence_starts == 1
+    assert report.overlong == 0
+    assert report.duplications == []
+    assert report.boundary_overlaps == []
+
     blob = "\n\n".join(b["text"] for b in blocks)
     items = [
         line.strip() for line in blob.splitlines() if line.lstrip().startswith("•")

--- a/tests/footer_artifact_test.py
+++ b/tests/footer_artifact_test.py
@@ -3,11 +3,21 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from pdf_chunker.core import process_document
+from pdf_chunker.chunk_validation import validate_chunks
 
 
 def test_footer_and_subfooter_removed():
     pdf = Path(__file__).resolve().parent.parent / "sample_book-footer.pdf"
-    texts = [c["text"] for c in process_document(str(pdf), 400, 50)]
+    chunks = list(process_document(str(pdf), 400, 50))
+    report = validate_chunks(chunks)
+    assert report.total_chunks == len(chunks)
+    assert report.empty_text == 0
+    assert report.mid_sentence_starts == 0
+    assert report.overlong == 0
+    assert report.duplications == []
+    assert report.boundary_overlaps == []
+
+    texts = [c["text"] for c in chunks]
     assert len(texts) == 2
     assert all("spam.com" not in t.lower() for t in texts)
     assert all("Bearings of Cattle Like Leaves Know" not in t for t in texts)
@@ -20,5 +30,8 @@ def test_footer_and_subfooter_removed():
 
 def test_footer_pdf_includes_second_page_text():
     pdf = Path(__file__).resolve().parent.parent / "sample_book-footer.pdf"
-    text = " ".join(c["text"] for c in process_document(str(pdf), 400, 50))
+    chunks = list(process_document(str(pdf), 400, 50))
+    report = validate_chunks(chunks)
+    assert report.empty_text == 0
+    text = " ".join(c["text"] for c in chunks)
     assert "cattle-train bearing the cattle of a thousand hills" in text


### PR DESCRIPTION
## Summary
- add `ValidationReport` helper to analyze chunk metadata and duplication
- exercise chunk validation in bullet list and footer artifact tests

## Testing
- `python -m black pdf_chunker/ scripts/ tests/`
- `python -m flake8 pdf_chunker/ scripts/ tests/`
- `python -m mypy pdf_chunker/`
- `bash scripts/validate_chunks.sh sample_chunks.jsonl`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_6897f449a70c8325abaf972fea759bb8