### PR TITLE
Normalize numbered list newlines

### DIFF
--- a/pdf_chunker/pymupdf4llm_integration.py
+++ b/pdf_chunker/pymupdf4llm_integration.py
@@ -486,6 +486,7 @@ def clean_text_with_pymupdf4llm(text: str, pdf_path: Optional[str] = None) -> st
             fix_hyphenated_linebreaks,
             _fix_double_newlines,
             _fix_split_words,
+            insert_numbered_list_newlines,
             normalize_ligatures,
             consolidate_whitespace,
         )
@@ -503,6 +504,10 @@ def clean_text_with_pymupdf4llm(text: str, pdf_path: Optional[str] = None) -> st
         text = _fix_double_newlines(text)
         logger.debug(f"After _fix_double_newlines: {repr(text[:100])}")
 
+        logger.debug("Applying insert_numbered_list_newlines in PyMuPDF4LLM path")
+        text = insert_numbered_list_newlines(text)
+        logger.debug(f"After insert_numbered_list_newlines: {repr(text[:100])}")
+
         logger.debug("Applying collapse_single_newlines in PyMuPDF4LLM path")
         text = collapse_single_newlines(text)
         logger.debug(f"After collapse_single_newlines: {repr(text[:100])}")
@@ -519,6 +524,7 @@ def clean_text_with_pymupdf4llm(text: str, pdf_path: Optional[str] = None) -> st
         paragraphs = []
         for p in text.split("\n\n"):
             if p.strip():
+                p = consolidate_whitespace(p)
                 p = normalize_ligatures(p)
                 p = consolidate_whitespace(p)
                 paragraphs.append(p)

--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -132,6 +132,16 @@ def collapse_artifact_breaks(text: str) -> str:
     return re.sub(r"([._])\n(\w)", r"\1 \2", text)
 
 
+NUMBERED_AFTER_COLON_RE = re.compile(r":\s*(?!\n)(\d{1,3}[.)])")
+NUMBERED_INLINE_RE = re.compile(r"(\d{1,3}[.)][^\n]+?)\s+(?=\d{1,3}[.)])")
+
+
+def insert_numbered_list_newlines(text: str) -> str:
+    """Insert newlines before numbered list items lacking explicit breaks."""
+    text = NUMBERED_AFTER_COLON_RE.sub(r":\n\1", text)
+    return NUMBERED_INLINE_RE.sub(r"\1\n", text)
+
+
 def _preserve_list_newlines(text: str) -> str:
     """Keep newlines that precede bullets or enumerated items."""
     placeholder = "[[LIST_BREAK]]"
@@ -338,9 +348,10 @@ def clean_paragraph(paragraph: str) -> str:
         fix_hyphenated_linebreaks,
         collapse_artifact_breaks,
         _preserve_list_newlines,
-        normalize_ligatures,
         normalize_quotes,
         remove_control_characters,
+        consolidate_whitespace,
+        normalize_ligatures,
         consolidate_whitespace,
     )
 
@@ -401,6 +412,10 @@ def clean_text(text: str) -> str:
     logger.debug("Calling _fix_double_newlines")
     text = _fix_double_newlines(text)
     logger.debug(f"After _fix_double_newlines: {repr(text[:100])}")
+
+    logger.debug("Calling insert_numbered_list_newlines")
+    text = insert_numbered_list_newlines(text)
+    logger.debug(f"After insert_numbered_list_newlines: {repr(text[:100])}")
 
     # Collapse single line breaks except paragraph breaks
     logger.debug("Calling collapse_single_newlines")

--- a/tests/sample_local_pdf_list_test.py
+++ b/tests/sample_local_pdf_list_test.py
@@ -1,0 +1,29 @@
+import re
+import sys
+
+sys.path.insert(0, ".")
+
+from pdf_chunker.pdf_parsing import extract_text_blocks_from_pdf
+
+
+def test_sample_local_pdf_lists_have_newlines():
+    blocks = extract_text_blocks_from_pdf("sample-local-pdf.pdf")
+    blob = "\n\n".join(b["text"] for b in blocks)
+
+    assert ":\n1. First numbered item" in blob
+    assert "\n2. Second numbered item" in blob
+    assert "\n3. Third numbered item" in blob
+
+    numbered = [
+        line.strip() for line in blob.splitlines() if re.match(r"\d+\.", line.strip())
+    ]
+    assert numbered[0] == "1. First numbered item"
+    assert numbered[1] == "2. Second numbered item"
+    assert numbered[2].startswith("3. Third numbered item")
+
+    bullets = [
+        line.strip() for line in blob.splitlines() if line.strip().startswith("•")
+    ]
+    assert "• First bullet point" in bullets
+    assert "• Second bullet point" in bullets
+    assert any(b.startswith("• Third bullet point") for b in bullets)


### PR DESCRIPTION
## Summary
- ensure numbered list items are split onto separate lines like bullet lists
- adjust PyMuPDF4LLM cleanup and paragraph cleaning for idempotent whitespace handling
- add regression test for numbered list newline normalization

## Testing
- `black pdf_chunker/ tests/ scripts/`
- `flake8 pdf_chunker/ scripts/ tests/`
- `mypy pdf_chunker/`
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_6898abc038308325b0fd6db8ad87441d