### PR TITLE
Handle multiline bullet items without stray markers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ pdf_chunker/
     ├── hyphenation_test.py
     ├── indented_block_test.py
     ├── list_detection_edge_case_test.py
+    ├── multiline_bullet_test.py
     ├── newline_cleanup_test.py
     ├── numbered_list_chunk_test.py
     ├── numbered_list_test.py

--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -143,6 +143,15 @@ def collapse_artifact_breaks(text: str) -> str:
     return re.sub(r"([._])\n(\w)", r"\1 \2", text)
 
 
+STRAY_BULLET_RE = re.compile(rf"\n[{BULLET_CHARS_ESC}](?:\n+|$)")
+
+
+def remove_stray_bullet_lines(text: str) -> str:
+    """Collapse bullet markers that appear alone or mid-item."""
+    text = STRAY_BULLET_RE.sub(" ", text)
+    return re.sub(rf"(?<=\S)[ \t][{BULLET_CHARS_ESC}]\s+", " ", text)
+
+
 NUMBERED_AFTER_COLON_RE = re.compile(r":\s*(?!\n)(\d{1,3}[.)])")
 NUMBERED_INLINE_RE = re.compile(r"(\d{1,3}[.)][^\n]+?)\s+(?=\d{1,3}[.)])")
 NUMBERED_END_RE = re.compile(
@@ -371,6 +380,7 @@ def clean_paragraph(paragraph: str) -> str:
         paragraph,
         fix_hyphenated_linebreaks,
         collapse_artifact_breaks,
+        remove_stray_bullet_lines,
         _preserve_list_newlines,
         normalize_quotes,
         remove_control_characters,

--- a/tests/multiline_bullet_test.py
+++ b/tests/multiline_bullet_test.py
@@ -1,0 +1,16 @@
+import sys
+
+sys.path.insert(0, ".")
+
+from pdf_chunker.core import process_document
+
+
+def test_multiline_bullet_items():
+    chunks = process_document("sample_book-bullets.pdf", 400, 50)
+    text = "\n".join(c["text"] for c in chunks)
+    assert (
+        "\u2022 All sound heard at the greatest possible distance? "
+        "Produces one? Vibration? Atmosphere?" in text
+    )
+    assert "\u2022\n\nAtmosphere?" not in text
+    assert "our eyes?\n\u2022\n\u2022 There" not in text


### PR DESCRIPTION
## Summary
- collapse stray bullet markers and join mid-item lines during text cleaning
- merge short bullet fragments with preceding list items
- cover multiline bullet parsing with a new regression test

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/ scripts/ tests/`
- `mypy pdf_chunker/`
- `bash scripts/validate_chunks.sh output_chunks.json` *(fails: No valid chunks found in file.)*
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_68994aac8b1c832584a669db2afccc8c