### PR TITLE
fix: keep list items within chunks

### DIFF
--- a/pdf_chunker/splitter.py
+++ b/pdf_chunker/splitter.py
@@ -9,7 +9,11 @@ from haystack.components.preprocessors import DocumentSplitter
 from haystack import Document
 
 from .text_cleaning import _is_probable_heading
-from .list_detection import starts_with_bullet
+from .list_detection import (
+    starts_with_bullet,
+    is_bullet_fragment,
+    is_bullet_continuation,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -276,6 +280,14 @@ def _extract_bullet_tail(lines: List[str]) -> Tuple[List[str], List[str]]:
     return lines[:idx], lines[idx:]
 
 
+def _merge_bullet_fragment(curr: str, nxt: str) -> Tuple[str, str]:
+    """Attach trailing bullet line from ``curr`` to the start of ``nxt``."""
+    lines = curr.rstrip().splitlines()
+    head, tail = lines[:-1], lines[-1]
+    merged_next = f"{tail} {nxt.lstrip()}".strip()
+    return "\n".join(head), merged_next
+
+
 def _rebalance_bullet_chunks(chunks: List[str]) -> List[str]:
     """Move trailing bullet lists to following chunks to keep lists intact."""
     if not chunks:
@@ -283,6 +295,8 @@ def _rebalance_bullet_chunks(chunks: List[str]) -> List[str]:
     result: List[str] = []
     current = chunks[0]
     for nxt in chunks[1:]:
+        if is_bullet_fragment(current, nxt) or is_bullet_continuation(current, nxt):
+            current, nxt = _merge_bullet_fragment(current, nxt)
         curr_lines = current.rstrip().splitlines()
         next_lines = nxt.lstrip().splitlines()
         head, tail = _extract_bullet_tail(curr_lines)
@@ -308,9 +322,11 @@ def _rebalance_bullet_chunks(chunks: List[str]) -> List[str]:
             combined = cleaned
             current = "\n".join(head)
             nxt = "\n".join(combined)
-        result.append(current.rstrip())
+        if current.strip():
+            result.append(current.rstrip())
         current = nxt
-    result.append(current.rstrip())
+    if current.strip():
+        result.append(current.rstrip())
     return result
 
 

--- a/tests/multiline_bullet_test.py
+++ b/tests/multiline_bullet_test.py
@@ -3,6 +3,10 @@ import sys
 sys.path.insert(0, ".")
 
 from pdf_chunker.core import process_document
+from pdf_chunker.list_detection import (
+    is_bullet_continuation,
+    is_bullet_fragment,
+)
 
 
 def test_multiline_bullet_items():
@@ -27,3 +31,8 @@ def test_multiline_bullet_items():
     assert "by accident one\n\u2022 a bar behind another" not in text
     assert "mourning women\n\u2022 their" not in text
     assert "(Souls\n\u2022 that" not in text
+    texts = [c["text"] for c in chunks]
+    assert all(
+        not (is_bullet_fragment(a, b) or is_bullet_continuation(a, b))
+        for a, b in zip(texts, texts[1:])
+    )


### PR DESCRIPTION
## Summary
- prevent bullet-list fragments from being split across chunks
- verify multiline bullet items stay in the same JSONL chunk

## Testing
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_689a2a9f92d08325b678c5f1f822c64d