### PR TITLE
fix list chunking

### DIFF
--- a/tests/list_chunk_merge_test.py
+++ b/tests/list_chunk_merge_test.py
@@ -1,0 +1,14 @@
+import sys
+
+sys.path.insert(0, ".")
+
+from pdf_chunker.splitter import _merge_standalone_lists
+
+
+def test_merge_bullet_and_numbered_lists():
+    cases = [
+        (["Intro", "• a", "• b", "End"], ["Intro\n• a\n• b", "End"]),
+        (["Intro", "1. a", "2. b", "End"], ["Intro\n1. a\n2. b", "End"]),
+    ]
+    for chunks, expected in cases:
+        assert _merge_standalone_lists(chunks) == expected


### PR DESCRIPTION
## Summary
- keep bullet/numbered lists with preceding text so JSONL lines do not start with list markers
- cover standalone list merging in tests

## Testing
- `python -m black pdf_chunker/ tests/ scripts/`
- `flake8 pdf_chunker/ tests/ scripts/`
- `mypy --ignore-missing-imports pdf_chunker/`
- `pytest tests -q`
- `bash scripts/validate_chunks.sh output_chunks.json` *(fails: Duplicate detection failed)*

------
https://chatgpt.com/codex/tasks/task_e_689a2f0e1b6483258283b15d93218003