### PR TITLE
Avoid false numbered list detection

### DIFF
--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -146,18 +146,23 @@ def collapse_artifact_breaks(text: str) -> str:
 STRAY_BULLET_RE = re.compile(rf"\n[{BULLET_CHARS_ESC}](?:\n+|$)")
 
 
-NUMBER_SUFFIX_LINE_RE = re.compile(r"\n(\d+\.)\s*(?=\n|$)")
+NUMBER_SUFFIX_LINE_RE = re.compile(r"\n(\d+\.)(\s*)")
 
 
 def merge_number_suffix_lines(text: str) -> str:
-    """Join lines where a terminal number is isolated on its own line."""
+    """Join lines where a terminal number is split onto its own line."""
 
     def repl(match: re.Match[str]) -> str:
         start = match.start()
         prev = text[text.rfind("\n", 0, start) + 1 : start].strip()
-        if prev.endswith(":") or re.match(r"\d+[.)]", prev):
+        if (
+            not prev
+            or prev.endswith(":")
+            or re.match(r"\d+[.)]", prev)
+            or re.search(r"[.!?]$", prev)
+        ):
             return match.group(0)
-        return f" {match.group(1)}"
+        return f" {match.group(1)}{match.group(2)}"
 
     return NUMBER_SUFFIX_LINE_RE.sub(repl, text)
 

--- a/tests/numbered_list_test.py
+++ b/tests/numbered_list_test.py
@@ -25,6 +25,10 @@ def test_numbered_list_preservation():
     [
         ("scope of Tier\n1.", "scope of Tier 1."),
         ("scope of Tier\n1.\nNext", "scope of Tier 1. Next"),
+        (
+            "scope of Tier\n1. T2 support engineers",
+            "scope of Tier 1. T2 support engineers",
+        ),
     ],
 )
 def test_number_suffix_not_list(raw: str, expected: str) -> None:

--- a/tests/numbered_list_test.py
+++ b/tests/numbered_list_test.py
@@ -1,9 +1,11 @@
 import sys
 import re
+import pytest
 
 sys.path.insert(0, ".")
 
 from pdf_chunker.pdf_parsing import extract_text_blocks_from_pdf
+from pdf_chunker.text_cleaning import collapse_single_newlines
 
 
 def test_numbered_list_preservation():
@@ -16,3 +18,14 @@ def test_numbered_list_preservation():
     assert "\n\n2." not in blob
     assert "\n\n3." not in blob
     assert "\n\n4." not in blob
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("scope of Tier\n1.", "scope of Tier 1."),
+        ("scope of Tier\n1.\nNext", "scope of Tier 1. Next"),
+    ],
+)
+def test_number_suffix_not_list(raw: str, expected: str) -> None:
+    assert collapse_single_newlines(raw) == expected


### PR DESCRIPTION
## Summary
- prevent isolated numeric sentences from being treated as numbered list items
- add regression tests for sentence-ending numbers

## Testing
- `black pdf_chunker/ tests/ scripts/`
- `flake8 pdf_chunker/ scripts/ tests/`
- `mypy pdf_chunker/`
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_689a3b7cccc08325b88b5114366749c7