### PR TITLE
fix: avoid breaking numbered items before acronyms

### DIFF
--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -178,7 +178,7 @@ def remove_stray_bullet_lines(text: str) -> str:
 NUMBERED_AFTER_COLON_RE = re.compile(r":\s*(?!\n)(\d{1,3}[.)])")
 NUMBERED_INLINE_RE = re.compile(r"(\d{1,3}[.)][^\n]+?)\s+(?=\d{1,3}[.)])")
 NUMBERED_END_RE = re.compile(
-    rf"(\d{{1,3}}[.)][^\n]+?)(?=\s+(?:[{BULLET_CHARS_ESC}]|[A-Z]|$))"
+    rf"(\d{{1,3}}[.)][^\n]+?)(?=\s+(?:[{BULLET_CHARS_ESC}]|[A-Z][a-z]+\b|$))"
 )
 
 

--- a/tests/numbered_list_test.py
+++ b/tests/numbered_list_test.py
@@ -5,7 +5,10 @@ import pytest
 sys.path.insert(0, ".")
 
 from pdf_chunker.pdf_parsing import extract_text_blocks_from_pdf
-from pdf_chunker.text_cleaning import collapse_single_newlines
+from pdf_chunker.text_cleaning import (
+    collapse_single_newlines,
+    insert_numbered_list_newlines,
+)
 
 
 def test_numbered_list_preservation():
@@ -33,3 +36,15 @@ def test_numbered_list_preservation():
 )
 def test_number_suffix_not_list(raw: str, expected: str) -> None:
     assert collapse_single_newlines(raw) == expected
+
+
+def test_abbreviation_inside_numbered_item() -> None:
+    text = (
+        "1. First item.\n"
+        "2. Second item references the SaaS paradigm for clarity.\n"
+        "Following paragraph."
+    )
+    cleaned = insert_numbered_list_newlines(text)
+    cleaned = collapse_single_newlines(cleaned)
+    assert "the\n\nSaaS" not in cleaned
+    assert "paradigm for clarity.\n\nFollowing" in cleaned


### PR DESCRIPTION
## Summary
- avoid inserting paragraph breaks in numbered list items when followed by mixed-case acronyms
- add regression test for acronym inside numbered list items

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/ scripts/ tests/`
- `mypy pdf_chunker/`
- `pytest tests/`
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a5cb7c68c83259971af38c9338447