### PR TITLE
Normalize superscript footnote markers

### DIFF
--- a/tests/page_artifact_detection_test.py
+++ b/tests/page_artifact_detection_test.py
@@ -70,6 +70,11 @@ class TestPageArtifactDetection(unittest.TestCase):
         cleaned = remove_page_artifact_lines(text, 2)
         self.assertEqual(cleaned, "Paragraph text\nNext paragraph")
 
+    def test_inline_footnote_marker(self):
+        text = "Can exist.3\n3 Footnote text.\n\nThis is next"
+        cleaned = remove_page_artifact_lines(text, 2)
+        self.assertEqual(cleaned, "Can exist.[3] This is next")
+
     def test_remove_header_and_footnote(self):
         text = (
             "First part of sentence\n\n"


### PR DESCRIPTION
## Summary
- normalize trailing footnote markers so `sentence.3` becomes `sentence.[3]`
- compose page artifact cleaners via functional pipeline
- verify footnote marker normalization

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/ scripts/ tests/`
- `mypy pdf_chunker/`
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_689a6237521c8325a5a7a6831699d4e0