### PR TITLE
Fix newline handling for quoted numbered list items

### DIFF
--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -186,7 +186,8 @@ def insert_numbered_list_newlines(text: str) -> str:
     """Insert newlines around numbered list items and terminate the list with a paragraph break."""
     text = NUMBERED_AFTER_COLON_RE.sub(r":\n\1", text)
     text = NUMBERED_INLINE_RE.sub(r"\1\n", text)
-    return NUMBERED_END_RE.sub(r"\1\n\n", text)
+    text = NUMBERED_END_RE.sub(r"\1\n\n", text)
+    return re.sub(r'(["\'])\n{2,}(?=\S)', r"\1\n", text)
 
 
 def _preserve_list_newlines(text: str) -> str:

--- a/tests/numbered_list_test.py
+++ b/tests/numbered_list_test.py
@@ -48,3 +48,17 @@ def test_abbreviation_inside_numbered_item() -> None:
     cleaned = collapse_single_newlines(cleaned)
     assert "the\n\nSaaS" not in cleaned
     assert "paradigm for clarity.\n\nFollowing" in cleaned
+
+
+def test_quote_continuation_inside_numbered_item() -> None:
+    text = (
+        '1. whosoever that can answer the question "Why did this need to happen at all?"\n'
+        "Then come towards"
+    )
+    cleaned = insert_numbered_list_newlines(text)
+    cleaned = collapse_single_newlines(cleaned)
+    expected = (
+        '1. whosoever that can answer the question "Why did this need to happen at all?" '
+        "Then come towards"
+    )
+    assert cleaned.strip() == expected


### PR DESCRIPTION
## Summary
- prevent double newlines after closing quotes in numbered list items
- add regression test for quoted numbered list continuation

## Testing
- `black pdf_chunker/ tests/`
- `flake8 pdf_chunker/ tests/`
- `mypy pdf_chunker/`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_689aa1de0e4083258a49a0916afda1db