### PR TITLE
fix: avoid newline after quoted question in numbered items

### DIFF
--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -177,8 +177,10 @@ def remove_stray_bullet_lines(text: str) -> str:
 
 NUMBERED_AFTER_COLON_RE = re.compile(r":\s*(?!\n)(\d{1,3}[.)])")
 NUMBERED_INLINE_RE = re.compile(r"(\d{1,3}[.)][^\n]+?)\s+(?=\d{1,3}[.)])")
+# Avoid inserting paragraph breaks when a numbered item ends with a quoted
+# question or exclamation that continues the same sentence.
 NUMBERED_END_RE = re.compile(
-    rf"(\d{{1,3}}[.)][^\n]+?)(?=\s+(?:[{BULLET_CHARS_ESC}]|[A-Z][a-z]+\b|$))"
+    rf"(\d{{1,3}}[.)][^\n]+?)(?<![?!]\")(?=\s+(?:[{BULLET_CHARS_ESC}]|[A-Z][a-z]+\b|$))"
 )
 
 

--- a/tests/numbered_list_test.py
+++ b/tests/numbered_list_test.py
@@ -48,3 +48,14 @@ def test_abbreviation_inside_numbered_item() -> None:
     cleaned = collapse_single_newlines(cleaned)
     assert "the\n\nSaaS" not in cleaned
     assert "paradigm for clarity.\n\nFollowing" in cleaned
+
+
+def test_quoted_question_inside_numbered_item() -> None:
+    text = (
+        '1. Item with a quote "Why did this need to happen at all?" '
+        "Then proceed with more details."
+    )
+    cleaned = insert_numbered_list_newlines(text)
+    cleaned = collapse_single_newlines(cleaned)
+    assert "\n\nThen" not in cleaned
+    assert '"Why did this need to happen at all?" Then' in cleaned


### PR DESCRIPTION
## Summary
- refine numbered list regex to ignore quoted question or exclamation endings
- cover quoted question handling in numbered lists with new test

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/ scripts/ tests/`
- `mypy pdf_chunker/`
- `pytest tests/`
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b5c5631fc8325be8a70822160d0e6