### PR TITLE
Handle quoted sentence endings in numbered list detection

### DIFF
--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -52,6 +52,9 @@ SOFT_HYPHEN_RE = re.compile("\u00ad")
 
 BULLET_CHARS_ESC = re.escape("*•")
 
+# Terminal punctuation considered for quoted sentence continuation
+END_PUNCT = ".!?…"
+
 
 def _join_hyphenated_words(text: str) -> str:
     """Merge words broken with hyphenation across line breaks."""
@@ -178,9 +181,9 @@ def remove_stray_bullet_lines(text: str) -> str:
 NUMBERED_AFTER_COLON_RE = re.compile(r":\s*(?!\n)(\d{1,3}[.)])")
 NUMBERED_INLINE_RE = re.compile(r"(\d{1,3}[.)][^\n]+?)\s+(?=\d{1,3}[.)])")
 # Avoid inserting paragraph breaks when a numbered item ends with a quoted
-# question or exclamation that continues the same sentence.
+# sentence ('.', '!', '?', or '…') that continues the same sentence.
 NUMBERED_END_RE = re.compile(
-    rf"(\d{{1,3}}[.)][^\n]+?)(?<![?!]\")(?=\s+(?:[{BULLET_CHARS_ESC}]|[A-Z][a-z]+\b|$))"
+    rf"(\d{{1,3}}[.)][^\n]+?)(?<![{re.escape(END_PUNCT)}]\")(?=\s+(?:[{BULLET_CHARS_ESC}]|[A-Z][a-z]+\b|$))"
 )
 
 

--- a/tests/numbered_list_test.py
+++ b/tests/numbered_list_test.py
@@ -59,3 +59,15 @@ def test_quoted_question_inside_numbered_item() -> None:
     cleaned = collapse_single_newlines(cleaned)
     assert "\n\nThen" not in cleaned
     assert '"Why did this need to happen at all?" Then' in cleaned
+
+
+@pytest.mark.parametrize("punct", list(".…"))
+def test_quoted_sentence_endings_inside_numbered_item(punct: str) -> None:
+    text = (
+        f'1. Item with a quote "quoted sentence{punct}" '
+        "Then proceed with more details."
+    )
+    cleaned = insert_numbered_list_newlines(text)
+    cleaned = collapse_single_newlines(cleaned)
+    assert "\n\nThen" not in cleaned
+    assert f'"quoted sentence{punct}" Then' in cleaned


### PR DESCRIPTION
## Summary
- generalize numbered list ending regex with a shared END_PUNCT constant
- ensure periods and ellipses in quoted sentences don't trigger paragraph breaks
- add regression coverage for numbered items ending with quoted sentences.

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/ scripts/ tests/`
- `mypy pdf_chunker/`
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/ -q`


------
https://chatgpt.com/codex/tasks/task_e_689b65c63a708325a02e9efec37b884b