### PR TITLE
Guard against empty chunk outputs

### DIFF
--- a/pdf_chunker/chunk_validation.py
+++ b/pdf_chunker/chunk_validation.py
@@ -20,10 +20,15 @@ class ValidationReport:
     duplications: List[Dict[str, Any]]
     boundary_overlaps: List[Dict[str, Any]]
 
-    def has_issues(self) -> bool:
-        """Return ``True`` if any anomalies or duplicates were found."""
+    def is_empty(self) -> bool:
+        """Return ``True`` when no chunks were provided."""
 
-        return any(
+        return self.total_chunks == 0
+
+    def has_issues(self) -> bool:
+        """Return ``True`` if the report contains anomalies or is empty."""
+
+        return self.is_empty() or any(
             (
                 self.empty_text,
                 self.mid_sentence_starts,

--- a/scripts/validate_chunks.sh
+++ b/scripts/validate_chunks.sh
@@ -17,6 +17,12 @@ if [[ ! -f "$JSONL_FILE" ]]; then
     exit $EXIT_FILE_NOT_FOUND
 fi
 
+# Fail fast if the file contains no chunks
+if ! grep -q '[^[:space:]]' "$JSONL_FILE"; then
+    echo "Error: No chunks found in '$JSONL_FILE'" >&2
+    exit $EXIT_VALIDATION_FAILED
+fi
+
 echo "Validating chunks in: $JSONL_FILE"
 
 # Initialize counters

--- a/tests/empty_chunk_validation_test.py
+++ b/tests/empty_chunk_validation_test.py
@@ -1,0 +1,7 @@
+from pdf_chunker.chunk_validation import validate_chunks
+
+
+def test_empty_chunks_flagged():
+    report = validate_chunks([])
+    assert report.is_empty()
+    assert report.has_issues()


### PR DESCRIPTION
## Summary
- treat absence of chunks as a validation issue via `ValidationReport.is_empty`
- fail early in `validate_chunks.sh` when JSONL file has no content
- add regression test to ensure empty chunk lists are flagged

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/ scripts/ tests/`
- `mypy pdf_chunker/`
- `pytest tests/`
- `bash scripts/validate_chunks.sh tmp_sample.jsonl`


------
https://chatgpt.com/codex/tasks/task_e_689ba1c43fe083258018ffd8ca19830f