### PR TITLE
fix: merge list items ending with chapter references

### DIFF
--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -378,7 +378,12 @@ def _ends_with_chapter_reference(text: str) -> bool:
 def _merge_chapter_reference(prev: str, part: str) -> str | None:
     """Merge numbered list items ending in a chapter reference with following text."""
     first = prev.lstrip().splitlines()[0]
-    if not _starts_list_item(first) or _starts_new_list_item(part):
+    next_line = part.strip().splitlines()[0]
+    if (
+        not _starts_list_item(first)
+        or _starts_new_list_item(part)
+        or _is_probable_heading(next_line)
+    ):
         return None
     match = CHAPTER_INLINE_RE.search(prev)
     if match:

--- a/tests/newline_cleanup_test.py
+++ b/tests/newline_cleanup_test.py
@@ -55,6 +55,19 @@ class TestNewlineCleanup(unittest.TestCase):
         )
         self.assertEqual(clean_text(text), expected)
 
+    def test_chapter_reference_followed_by_heading(self):
+        text = (
+            "2. Another item to mention in Chapter 10.\n\n"
+            "Conclusion\n\n"
+            "The paragraph continues."
+        )
+        expected = (
+            "2. Another item to mention in Chapter 10.\n\n"
+            "Conclusion\n\n"
+            "The paragraph continues."
+        )
+        self.assertEqual(clean_text(text), expected)
+
     def test_merge_break_in_quoted_title(self):
         text = (
             '" Vulnerability sounds like truth": Brené Brown, '


### PR DESCRIPTION
## Summary
- avoid treating `Chapter N.` at end of numbered list items as a new heading
- merge following text back into the list item to remove spurious double newlines
- adjust newline cleanup test for chapter references

## Testing
- `black pdf_chunker/text_cleaning.py tests/newline_cleanup_test.py`
- `flake8 pdf_chunker/text_cleaning.py tests/newline_cleanup_test.py`
- `mypy pdf_chunker`
- `pytest tests/newline_cleanup_test.py`
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689deadc2470832587ef950767abae0f