### PR TITLE
chore: add default pipeline spec

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,0 +1,21 @@
+pipeline:
+  - pdf_parse
+  - text_clean
+  - heading_detect
+  - split_semantic
+  - ai_enrich
+  - emit_jsonl
+
+options:
+  pdf_parse:
+    engine: "native"
+  text_clean:
+    normalize_quotes: true
+    repair_ligatures: true
+  split_semantic:
+    target_tokens: 800
+    hard_page_boundaries: false
+  ai_enrich:
+    tags_file: "tags.yaml"
+  emit_jsonl:
+    output_path: "out.jsonl"


### PR DESCRIPTION
## Summary
- add default pipeline spec yaml

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_689f8044760483258a3a4d98c0f5d0b8