### PR TITLE
feat(config): introduce PipelineSpec

### DIFF
--- a/pdf_chunker/config.py
+++ b/pdf_chunker/config.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+import pathlib
+from typing import Any, Dict, List
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class PipelineSpec(BaseModel):
+    """Declarative pipeline specification."""
+
+    pipeline: List[str] = Field(default_factory=list)
+    options: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+
+
+def _read_yaml(path: str | os.PathLike | None) -> Dict[str, Any]:
+    """Return a dict from YAML or {} if path is None/missing/empty."""
+    if not path:
+        return {}
+    p = pathlib.Path(path)
+    if not p.exists():
+        return {}
+    data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise TypeError("pipeline.yaml must contain a top-level mapping")
+    return data
+
+
+def _env_overrides() -> Dict[str, Dict[str, Any]]:
+    """
+    Map STEP__key=value → options[step][key]=value (step/key lower-cased).
+    Values are YAML-coerced (so 'true', '42' etc. become bool/int).
+    """
+    out: Dict[str, Dict[str, Any]] = {}
+    for k, v in os.environ.items():
+        if "__" not in k:
+            continue
+        step, key = k.lower().split("__", 1)
+        try:
+            val = yaml.safe_load(v)
+        except Exception:
+            val = v
+        out.setdefault(step, {})[key] = val
+    return out
+
+
+def _merge_options(
+    base: Dict[str, Dict[str, Any]], override: Dict[str, Dict[str, Any]]
+) -> Dict[str, Dict[str, Any]]:
+    """Shallow-merge per-step options with comprehension; override wins."""
+    return {
+        s: {**base.get(s, {}), **override.get(s, {})}
+        for s in set(base) | set(override)
+    }
+
+
+def load_spec(path: str | os.PathLike | None = "pipeline.yaml") -> PipelineSpec:
+    """Load YAML + env overrides into a validated PipelineSpec."""
+    data = _read_yaml(path)
+    opts = data.get("options", {})
+    merged = _merge_options(opts, _env_overrides())
+    if merged:
+        data = {**data, "options": merged}
+    return PipelineSpec.model_validate(data)


### PR DESCRIPTION
## Summary
- add `PipelineSpec` model to load pipeline YAML with environment overrides

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_689f8732d6fc83258e09d5514c42104f