### PR TITLE
feat(cli): add Typer app with convert and inspect

### DIFF
--- a/pdf_chunker/cli.py
+++ b/pdf_chunker/cli.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+
+import typer
+
+from pdf_chunker.config import load_spec
+from pdf_chunker.core_new import run_convert, run_inspect
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
+
+
+@app.command()
+def convert(spec: str = "pipeline.yaml"):
+    """
+    Run the configured pipeline. This command does not perform IO; it only
+    exercises registered passes over an empty Artifact until adapters exist.
+    """
+    s = load_spec(spec)
+    _ = run_convert(s)  # result kept in memory for now
+    typer.echo("convert: OK")
+
+
+@app.command()
+def inspect():
+    """Print registered passes with their declared input/output types."""
+    typer.echo(json.dumps(run_inspect(), indent=2))
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Summary
- add Typer-based CLI exposing `convert` and `inspect` commands
- `convert` loads pipeline spec and runs conversion stub
- `inspect` prints registered passes as formatted JSON

## Testing
- `black pdf_chunker/cli.py`
- `flake8 pdf_chunker/cli.py`
- `mypy pdf_chunker/cli.py` *(fails: missing type annotations and deps)*
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`
- `bash scripts/validate_chunks.sh` *(fails: output file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f999acba88325b5fddcb274eb5f2d