### PR TITLE
Add registry sync test

### DIFF
--- a/tests/bootstrap/test_registry_sync.py
+++ b/tests/bootstrap/test_registry_sync.py
@@ -1,0 +1,12 @@
+from pdf_chunker.framework import registry
+
+
+def test_registry_is_mapping():
+    reg = registry()
+    assert isinstance(reg, dict)
+
+
+def test_registry_expected_keys_subset():
+    # Update this set as passes are registered (e.g., {"pdf_parse", "text_clean", ...})
+    expected = set()
+    assert expected.issubset(set(registry().keys()))


### PR DESCRIPTION
## Summary
- add bootstrap registry sync test for framework registry

## Testing
- `nox -s lint typecheck tests`
- `bash scripts/validate_chunks.sh` (fails: File 'output_chunks_pdf.jsonl' not found)


------
https://chatgpt.com/codex/tasks/task_e_689f9d39085083259ad3a9e08a3d1bac