### PR TITLE
feat(passes): add pdf_parse pass

### DIFF
--- a/pdf_chunker/__init__.py
+++ b/pdf_chunker/__init__.py
@@ -1,1 +1,4 @@
-__all__ = []
+# Auto-register passes on package import (e.g., when importing any submodule)
+from . import passes  # noqa: F401
+
+__all__: list[str] = []

--- a/pdf_chunker/passes/__init__.py
+++ b/pdf_chunker/passes/__init__.py
@@ -1,0 +1,1 @@
+from .pdf_parse import pdf_parse  # noqa: F401

--- a/pdf_chunker/passes/pdf_parse.py
+++ b/pdf_chunker/passes/pdf_parse.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+from pdf_chunker.framework import Artifact, register
+
+
+def _default_doc(src: Mapping[str, Any]) -> Dict[str, Any]:
+    return {
+        "type": "page_blocks",
+        "source_path": src.get("source_path", "<memory>"),
+        "pages": [{"page": 1, "blocks": [{"text": "<stub pdf_parse>"}]}],
+    }
+
+
+def _update_meta(meta: Dict[str, Any] | None, pages: int) -> Dict[str, Any]:
+    base = dict(meta or {})
+    metrics = base.setdefault("metrics", {})
+    metrics.setdefault("pdf_parse", {})["pages"] = pages
+    return base
+
+
+class _PdfParsePass:
+    """
+    Minimal stub: turn any payload into a simple page_blocks dict.
+    Pure function; no side effects.
+    """
+
+    name = "pdf_parse"
+    input_type = dict
+    output_type = dict
+
+    def __call__(self, a: Artifact) -> Artifact:
+        src = a.payload if isinstance(a.payload, dict) else {}
+        doc = _default_doc(src)
+        meta = _update_meta(a.meta, len(doc["pages"]))
+        return Artifact(payload=doc, meta=meta)
+
+
+pdf_parse = register(_PdfParsePass())


### PR DESCRIPTION
## Summary
- add minimal `pdf_parse` pass with metrics stub
- auto-register passes when `pdf_chunker` is imported

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`
- `python -m pdf_chunker.cli inspect`

------
https://chatgpt.com/codex/tasks/task_e_689ff582447c832580e64382fdac08f4