### PR TITLE
feat(passes): add extraction_fallback pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,12 @@ pdf_chunker/
 │   ├── splitter.py                # Semantic Pass: chunk splitting and boundaries
 │   ├── text_cleaning.py           # Ligature, quote, control-character cleanup
 │   ├── text_processing.py         # Shared text manipulation utilities
+│   ├── passes/                    # Registered pipeline passes
+│   │   ├── __init__.py
+│   │   ├── extraction_fallback.py
+│   │   ├── heading_detect.py
+│   │   ├── pdf_parse.py
+│   │   └── text_clean.py
 │   └── utils.py                   # Metadata mapping and glue logic
 ├── scripts/
 │   ├── AGENTS.md                # Guidance for maintenance scripts

--- a/pdf_chunker/passes/__init__.py
+++ b/pdf_chunker/passes/__init__.py
@@ -1,3 +1,4 @@
 from .heading_detect import heading_detect  # noqa: F401
 from .pdf_parse import pdf_parse  # noqa: F401
 from .text_clean import text_clean  # noqa: F401
+from .extraction_fallback import extraction_fallback  # noqa: F401

--- a/pdf_chunker/passes/extraction_fallback.py
+++ b/pdf_chunker/passes/extraction_fallback.py
@@ -1,0 +1,53 @@
+from typing import Any, Dict, List
+
+from pdf_chunker.framework import Artifact, register
+
+Block = Dict[str, Any]
+
+
+def _blocks_doc(blocks: List[Block], source: str) -> Dict[str, Any]:
+    return {"type": "blocks", "blocks": blocks, "source_path": source}
+
+
+def _quality(blocks: List[Block]) -> Dict[str, float]:
+    from pdf_chunker.extraction_fallbacks import _assess_text_quality
+
+    text = "\n".join(b.get("text", "") for b in blocks)
+    return _assess_text_quality(text)
+
+
+def _extract(path: str, reason: str | None) -> List[Block]:
+    from pdf_chunker.extraction_fallbacks import execute_fallback_extraction
+
+    return execute_fallback_extraction(path, fallback_reason=reason)
+
+
+def _meta(
+    meta: Dict[str, Any] | None,
+    reason: str | None,
+    quality: Dict[str, float],
+) -> Dict[str, Any]:
+    base = dict(meta or {})
+    metrics = base.setdefault("metrics", {}).setdefault("extraction_fallback", {})
+    if reason:
+        metrics["reason"] = reason
+    metrics["quality_score"] = quality.get("quality_score", 0.0)
+    return base
+
+
+class _ExtractionFallbackPass:
+    name = "extraction_fallback"
+    input_type = dict
+    output_type = dict
+
+    def __call__(self, a: Artifact) -> Artifact:
+        doc = a.payload if isinstance(a.payload, dict) else {}
+        path = doc.get("source_path", "")
+        reason = (a.meta or {}).get("fallback_reason")
+        blocks = _extract(path, reason)
+        quality = _quality(blocks)
+        meta = _meta(a.meta, reason, quality)
+        return Artifact(payload=_blocks_doc(blocks, path), meta=meta)
+
+
+extraction_fallback = register(_ExtractionFallbackPass())

--- a/tests/bootstrap/test_run_report.py
+++ b/tests/bootstrap/test_run_report.py
@@ -1,5 +1,6 @@
-import pytest
 from pathlib import Path
+
+import pytest
 
 
 @pytest.mark.xfail(reason="run_report emission is implemented in later stories", strict=True)


### PR DESCRIPTION
## Summary
- add functional extraction_fallback pass capturing fallback reason and quality score
- register new pass and document passes directory in AGENTS
- format bootstrap test imports

## Testing
- `nox -s lint typecheck tests`
- `pytest tests/bootstrap`


------
https://chatgpt.com/codex/tasks/task_e_68a0ddfce61083258439c89ad01a508a