### PR TITLE
feat(passes): add split_semantic pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ pdf_chunker/
 │   │   ├── extraction_fallback.py
 │   │   ├── heading_detect.py
 │   │   ├── pdf_parse.py
+│   │   ├── split_semantic.py
 │   │   └── text_clean.py
 │   └── utils.py                   # Metadata mapping and glue logic
 ├── scripts/

--- a/pdf_chunker/passes/__init__.py
+++ b/pdf_chunker/passes/__init__.py
@@ -2,3 +2,4 @@ from .heading_detect import heading_detect  # noqa: F401
 from .pdf_parse import pdf_parse  # noqa: F401
 from .text_clean import text_clean  # noqa: F401
 from .extraction_fallback import extraction_fallback  # noqa: F401
+from .split_semantic import split_semantic  # noqa: F401

--- a/pdf_chunker/passes/split_semantic.py
+++ b/pdf_chunker/passes/split_semantic.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from pdf_chunker.framework import Artifact, register
+
+Block = dict[str, Any]
+Doc = dict[str, Any]
+
+
+def _iter_text(doc: Doc) -> Iterable[str]:
+    return (
+        block.get("text", "") for page in doc.get("pages", []) for block in page.get("blocks", [])
+    )
+
+
+def _split(doc: Doc) -> list[dict[str, str]]:
+    from pdf_chunker.splitter import semantic_chunker  # local import to avoid heavy deps
+
+    text = "\n".join(_iter_text(doc))
+    return [{"text": chunk} for chunk in semantic_chunker(text)]
+
+
+def _update_meta(meta: dict[str, Any] | None, count: int) -> dict[str, Any]:
+    base = dict(meta or {})
+    base.setdefault("metrics", {}).setdefault("split_semantic", {})["chunks"] = count
+    return base
+
+
+class _SplitSemanticPass:
+    name = "split_semantic"
+    input_type = dict
+    output_type = list
+
+    def __call__(self, a: Artifact) -> Artifact:
+        doc = a.payload
+        if not isinstance(doc, dict) or doc.get("type") != "page_blocks":
+            return a
+        chunks = _split(doc)
+        meta = _update_meta(a.meta, len(chunks))
+        return Artifact(payload=chunks, meta=meta)
+
+
+split_semantic = register(_SplitSemanticPass())

--- a/tests/bootstrap/test_registry_sync.py
+++ b/tests/bootstrap/test_registry_sync.py
@@ -7,6 +7,12 @@ def test_registry_is_mapping():
 
 
 def test_registry_expected_keys_subset():
-    # Update this set as passes are registered (e.g., {"pdf_parse", "text_clean", ...})
-    expected = set()
+    # Update this set as passes are registered
+    expected = {
+        "pdf_parse",
+        "text_clean",
+        "heading_detect",
+        "extraction_fallback",
+        "split_semantic",
+    }
     assert expected.issubset(set(registry().keys()))


### PR DESCRIPTION
## Summary
- add split_semantic pass that converts page blocks into semantic chunks
- register split_semantic and sync AGENTS tree
- expand registry test to cover split_semantic

## Testing
- `nox -s lint typecheck tests`
- `bash scripts/validate_chunks.sh output_chunks.json` *(fails: No chunks found)*
- `mypy pdf_chunker/passes/split_semantic.py` *(fails: errors in dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e13e880c8325bd6cff9dc77f0232