### PR TITLE
feat(adapters): add io_epub adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ pdf_chunker/
 │       └── project_management.yaml # PM domain tags
 ├── pdf_chunker/
 │   ├── __init__.py                # Package initializer
+│   ├── adapters/
+│   │   ├── __init__.py
+│   │   ├── io_pdf.py
+│   │   └── io_epub.py
 │   ├── ai_enrichment.py           # AI Pass: classification and YAML-based tagging
 │   ├── core.py                    # Orchestrates the three-pass pipeline
 │   ├── env_utils.py               # Environment flag helpers

--- a/pdf_chunker/adapters/__init__.py
+++ b/pdf_chunker/adapters/__init__.py
@@ -1,3 +1,3 @@
-from . import io_pdf
+from . import io_epub, io_pdf
 
-__all__ = ["io_pdf"]
+__all__ = ["io_pdf", "io_epub"]

--- a/pdf_chunker/adapters/io_epub.py
+++ b/pdf_chunker/adapters/io_epub.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from functools import partial
+from itertools import groupby
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from pdf_chunker.epub_parsing import (
+    extract_text_blocks_from_epub,
+    list_epub_spines,
+)
+
+
+def _spine_map(path: str) -> Dict[str, int]:
+    """Map spine locations to their 1-based indices."""
+    return {item["filename"]: item["index"] for item in list_epub_spines(path)}
+
+
+def _spine_key(block: Dict[str, Any], mapping: Dict[str, int]) -> int:
+    """Spine index for grouping; defaults to 0 when missing."""
+    location = block.get("source", {}).get("location", "")
+    return mapping.get(location, 0)
+
+
+def _group_blocks(blocks: Iterable[Dict[str, Any]], mapping: Dict[str, int]) -> List[Dict[str, Any]]:
+    """Group blocks by spine index in ascending order."""
+    key = partial(_spine_key, mapping=mapping)
+    sorted_blocks = sorted(blocks, key=key)
+    return [{"page": page, "blocks": list(group)} for page, group in groupby(sorted_blocks, key)]
+
+
+def _extract_blocks(path: str, exclude_spines: str | None) -> List[Dict[str, Any]]:
+    return extract_text_blocks_from_epub(path, exclude_spines=exclude_spines)
+
+
+def read(path: str, exclude_pages: str | None = None) -> Dict[str, Any]:
+    """Return a page_blocks document for the given EPUB."""
+    abs_path = str(Path(path))
+    blocks = _extract_blocks(abs_path, exclude_pages)
+    mapping = _spine_map(abs_path)
+    return {
+        "type": "page_blocks",
+        "source_path": abs_path,
+        "pages": _group_blocks(blocks, mapping),
+    }


### PR DESCRIPTION
## Summary
- implement io_epub adapter mirroring PDF grouping semantics for EPUB files
- expose epub adapter via adapters package and project docs

## Testing
- `nox -s lint typecheck tests`


------
https://chatgpt.com/codex/tasks/task_e_68a0f5426560832597a959067781dda7