### PR TITLE
refactor(core): integrate adapters with run_convert

### DIFF
--- a/pdf_chunker/adapters/__init__.py
+++ b/pdf_chunker/adapters/__init__.py
@@ -1,3 +1,8 @@
-from . import emit_jsonl, io_epub, io_pdf
+from . import emit_jsonl, io_pdf
+
+try:  # pragma: no cover - optional dependency
+    from . import io_epub  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    io_epub = None  # type: ignore
 
 __all__ = ["emit_jsonl", "io_epub", "io_pdf"]

--- a/pdf_chunker/adapters/emit_jsonl.py
+++ b/pdf_chunker/adapters/emit_jsonl.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable, Iterator
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator
+from typing import Any
 
 from pdf_chunker.framework import Artifact
 
 
-def _rows(payload: Any) -> Iterable[Dict[str, Any]]:
+def _rows(payload: Any) -> Iterable[dict[str, Any]]:
     """Yield rows when payload is a list of dictionaries."""
     return payload if isinstance(payload, list) else []
 
 
-def _serialize(rows: Iterable[Dict[str, Any]]) -> Iterator[str]:
+def _serialize(rows: Iterable[dict[str, Any]]) -> Iterator[str]:
     """Serialize dictionaries to JSON lines."""
     return (json.dumps(r, ensure_ascii=False) for r in rows)
 
@@ -25,7 +26,7 @@ def _write(path: str, lines: Iterable[str]) -> None:
 
 
 def maybe_write(
-    artifact: Artifact, options: Dict[str, Any], timings: Dict[str, float] | None = None
+    artifact: Artifact, options: dict[str, Any], timings: dict[str, float] | None = None
 ) -> None:
     """Write artifact payload to JSONL if ``output_path`` is specified."""
     out_path = options.get("output_path")

--- a/pdf_chunker/adapters/io_pdf.py
+++ b/pdf_chunker/adapters/io_pdf.py
@@ -1,29 +1,30 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from itertools import groupby
 from pathlib import Path
-from typing import Any, Dict, Iterable, List
-
-from pdf_chunker.pdf_parsing import extract_text_blocks_from_pdf
+from typing import Any
 
 
-def _page_key(block: Dict[str, Any]) -> int:
+def _page_key(block: dict[str, Any]) -> int:
     """Page number for grouping; defaults to 0 when missing."""
     return block.get("source", {}).get("page", 0)
 
 
-def _group_blocks(blocks: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def _group_blocks(blocks: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
     """Group blocks by page in ascending order."""
     key = _page_key
     sorted_blocks = sorted(blocks, key=key)
     return [{"page": page, "blocks": list(group)} for page, group in groupby(sorted_blocks, key)]
 
 
-def _extract_blocks(path: str, exclude_pages: str | None) -> List[Dict[str, Any]]:
+def _extract_blocks(path: str, exclude_pages: str | None) -> list[dict[str, Any]]:
+    from pdf_chunker.pdf_parsing import extract_text_blocks_from_pdf
+
     return extract_text_blocks_from_pdf(path, exclude_pages)
 
 
-def read(path: str, exclude_pages: str | None = None) -> Dict[str, Any]:
+def read(path: str, exclude_pages: str | None = None) -> dict[str, Any]:
     """Return a page_blocks document for the given PDF."""
     abs_path = str(Path(path))
     blocks = _extract_blocks(abs_path, exclude_pages)

--- a/pdf_chunker/cli.py
+++ b/pdf_chunker/cli.py
@@ -11,13 +11,10 @@ app = typer.Typer(add_completion=False, no_args_is_help=True)
 
 
 @app.command()
-def convert(spec: str = "pipeline.yaml"):
-    """
-    Run the configured pipeline. This command does not perform IO; it only
-    exercises registered passes over an empty Artifact until adapters exist.
-    """
+def convert(input_path: str, spec: str = "pipeline.yaml"):
+    """Run the configured pipeline on ``input_path``."""
     s = load_spec(spec)
-    _ = run_convert(s)  # result kept in memory for now
+    _ = run_convert(input_path, s)
     typer.echo("convert: OK")
 
 

--- a/pdf_chunker/core_new.py
+++ b/pdf_chunker/core_new.py
@@ -1,22 +1,64 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Iterable
+from pathlib import Path
 
+from pdf_chunker.adapters import emit_jsonl, io_pdf
 from pdf_chunker.config import PipelineSpec
 from pdf_chunker.framework import Artifact, registry, run_pipeline
 
 
-def run_convert(spec: PipelineSpec, initial: Artifact | None = None) -> Artifact:
-    """Sequentially run registered passes from the spec; record simple timings."""
-    a = initial or Artifact(payload=None, meta={"metrics": {}})
+def _adapter_for(path: str):
+    """Return the IO adapter based on file extension."""
+    ext = Path(path).suffix.lower()
+    if ext == ".epub":
+        from pdf_chunker.adapters import io_epub
+
+        return io_epub
+    return io_pdf
+
+
+def _initial_artifact(path: str) -> Artifact:
+    """Load document via chosen adapter into an Artifact."""
+    adapter = _adapter_for(path)
+    payload = adapter.read(path)
+    return Artifact(payload=payload, meta={"metrics": {}, "input": path})
+
+
+def _pass_steps(spec: PipelineSpec) -> list[str]:
+    """Filter pipeline steps to registered passes; error on unknown ones."""
+    regs = registry()
+    unknown = [s for s in spec.pipeline if s not in regs and s != "emit_jsonl"]
+    if unknown:
+        raise KeyError(f"unknown steps: {unknown}")
+    return [s for s in spec.pipeline if s in regs]
+
+
+def _run_passes(steps: Iterable[str], a: Artifact) -> tuple[Artifact, dict[str, float]]:
+    """Run pipeline steps sequentially while recording timings."""
     timings: dict[str, float] = {}
-    for s in spec.pipeline:
+    for s in steps:
         t0 = time.time()
         a = run_pipeline([s], a)
         timings[s] = time.time() - t0
     meta = dict(a.meta or {})
     meta.setdefault("metrics", {})["_timings"] = timings
-    return Artifact(payload=a.payload, meta=meta)
+    return Artifact(payload=a.payload, meta=meta), timings
+
+
+def _emit(a: Artifact, spec: PipelineSpec, timings: dict[str, float]) -> None:
+    """Emit the artifact using the JSONL adapter when configured."""
+    emit_jsonl.maybe_write(a, spec.options.get("emit_jsonl", {}), timings)
+
+
+def run_convert(input_path: str, spec: PipelineSpec) -> Artifact:
+    """Load ``input_path``, run declared passes, and maybe write JSONL."""
+    a = _initial_artifact(input_path)
+    steps = _pass_steps(spec)
+    a, timings = _run_passes(steps, a)
+    _emit(a, spec, timings)
+    return a
 
 
 def run_inspect() -> dict[str, dict[str, str]]:

--- a/tests/bootstrap/test_run_convert_adapter.py
+++ b/tests/bootstrap/test_run_convert_adapter.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pdf_chunker.adapters.io_pdf as io_pdf
+from pdf_chunker.config import PipelineSpec
+from pdf_chunker.core_new import run_convert
+
+
+def test_run_convert_writes_jsonl(tmp_path, monkeypatch):
+    def fake_read(path, exclude_pages=None):
+        return {"type": "page_blocks", "source_path": path, "pages": []}
+
+    monkeypatch.setattr(io_pdf, "read", fake_read)
+    spec = PipelineSpec(
+        pipeline=["pdf_parse", "emit_jsonl"],
+        options={"emit_jsonl": {"output_path": str(tmp_path / "out.jsonl")}},
+    )
+    pdf_path = Path("test_data") / "sample_test.pdf"
+    artifact = run_convert(str(pdf_path), spec)
+    out_file = tmp_path / "out.jsonl"
+    assert out_file.exists()
+    assert artifact.meta.get("input") == str(pdf_path)


### PR DESCRIPTION
## Summary
- wire run_convert to choose PDF or EPUB adapters and emit JSONL output
- expose input path in CLI convert command
- add smoke test for adapter-based conversion

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68a0fc0bbf908325840daff4aa5dd28d