### PR TITLE
feat(core): enforce pipeline invariants

### DIFF
--- a/tests/bootstrap/test_invariants.py
+++ b/tests/bootstrap/test_invariants.py
@@ -1,0 +1,21 @@
+import pytest
+
+from pdf_chunker.config import PipelineSpec
+from pdf_chunker.core_new import _enforce_invariants
+
+
+def test_clean_before_split_enforced() -> None:
+    spec = PipelineSpec(pipeline=["split_semantic", "text_clean"])
+    with pytest.raises(ValueError):
+        _enforce_invariants(spec, input_path="dummy.pdf")
+
+
+def test_pdf_epub_separation_enforced() -> None:
+    spec = PipelineSpec(pipeline=["pdf_parse", "epub_parse"])
+    with pytest.raises(ValueError):
+        _enforce_invariants(spec, input_path="dummy.pdf")
+
+
+def test_valid_pipeline_passes() -> None:
+    spec = PipelineSpec(pipeline=["pdf_parse", "text_clean", "split_semantic"])
+    _enforce_invariants(spec, input_path="dummy.pdf")


### PR DESCRIPTION
## Summary
- ensure `text_clean` precedes any split step and reject pipelines mixing PDF and EPUB passes
- add unit tests covering pipeline invariants

## Testing
- `nox -s lint typecheck tests`
- `black pdf_chunker/core_new.py tests/bootstrap/test_invariants.py`
- `flake8 pdf_chunker/core_new.py tests/bootstrap/test_invariants.py`
- `mypy pdf_chunker/core_new.py` *(fails: repository contains pre-existing typing errors outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68a10022ef148325b2364d2b1f35a239