### PR TITLE
feat(passes): record fallback metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ pdf_chunker/
     ├── cross_page_sentence_test.py
     ├── env_utils_test.py
     ├── epub_spine_test.py
+    ├── extraction_fallback_pass_test.py
     ├── heading_boundary_test.py
     ├── heading_detection_test.py
     ├── hyphenation_test.py

--- a/tests/extraction_fallback_pass_test.py
+++ b/tests/extraction_fallback_pass_test.py
@@ -1,0 +1,17 @@
+from pdf_chunker.framework import Artifact
+from pdf_chunker.passes.extraction_fallback import extraction_fallback
+
+
+def test_extraction_fallback_records_metrics(monkeypatch):
+    def fake_extract(path: str, reason: str | None):
+        return [{"text": "hello"}]
+
+    monkeypatch.setattr("pdf_chunker.passes.extraction_fallback._extract", fake_extract)
+
+    artifact = Artifact(payload={"source_path": "dummy"}, meta={"fallback_reason": "low_quality"})
+    result = extraction_fallback(artifact)
+
+    assert artifact.meta == {"fallback_reason": "low_quality"}
+    metrics = result.meta["metrics"]["extraction_fallback"]
+    assert metrics["reason"] == "low_quality"
+    assert metrics["score"] > 0


### PR DESCRIPTION
## Summary
- record extraction fallback reason and score in metrics
- test extraction fallback pass metrics and immutability

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`
- `bash scripts/validate_chunks.sh dummy.jsonl`


------
https://chatgpt.com/codex/tasks/task_e_68a109172c1083258bd719e4acd17a5c