### PR TITLE
feat(core): emit run_report.json

### DIFF
--- a/tests/bootstrap/test_run_convert_adapter.py
+++ b/tests/bootstrap/test_run_convert_adapter.py
@@ -12,10 +12,15 @@ def test_run_convert_writes_jsonl(tmp_path, monkeypatch):
     monkeypatch.setattr(io_pdf, "read", fake_read)
     spec = PipelineSpec(
         pipeline=["pdf_parse", "emit_jsonl"],
-        options={"emit_jsonl": {"output_path": str(tmp_path / "out.jsonl")}},
+        options={
+            "emit_jsonl": {"output_path": str(tmp_path / "out.jsonl")},
+            "run_report": {"output_path": str(tmp_path / "run_report.json")},
+        },
     )
     pdf_path = Path("test_data") / "sample_test.pdf"
     artifact = run_convert(str(pdf_path), spec)
     out_file = tmp_path / "out.jsonl"
+    report_file = tmp_path / "run_report.json"
     assert out_file.exists()
+    assert report_file.exists()
     assert artifact.meta.get("input") == str(pdf_path)

--- a/tests/bootstrap/test_run_report.py
+++ b/tests/bootstrap/test_run_report.py
@@ -1,9 +1,24 @@
+from __future__ import annotations
+
+import json
 from pathlib import Path
 
-import pytest
+import pdf_chunker.adapters.io_pdf as io_pdf
+from pdf_chunker.config import PipelineSpec
+from pdf_chunker.core_new import run_convert
 
 
-@pytest.mark.xfail(reason="run_report emission is implemented in later stories", strict=True)
-def test_run_report_placeholder():
-    # Placeholder: will assert existence when Story E2 adds run_report.json
-    assert Path("run_report.json").exists()
+def test_run_report_emitted(tmp_path, monkeypatch):
+    def fake_read(path, exclude_pages=None):
+        return {"type": "page_blocks", "source_path": path, "pages": []}
+
+    monkeypatch.setattr(io_pdf, "read", fake_read)
+    spec = PipelineSpec(
+        pipeline=["pdf_parse"],
+        options={"run_report": {"output_path": str(tmp_path / "run_report.json")}},
+    )
+    pdf_path = Path("test_data") / "sample_test.pdf"
+    run_convert(str(pdf_path), spec)
+    report_file = tmp_path / "run_report.json"
+    data = json.loads(report_file.read_text())
+    assert set(data) == {"timings", "metrics", "warnings"}


### PR DESCRIPTION
## Summary
- build run report from timings and metrics and write to configurable path
- verify run report emission through bootstrap tests

## Testing
- `nox -s lint typecheck tests`


------
https://chatgpt.com/codex/tasks/task_e_68a127717c2c8325b334174e14f191f9