### PR TITLE
feat(core): add known-issue warnings to report

### DIFF
--- a/tests/core_new_warnings_test.py
+++ b/tests/core_new_warnings_test.py
@@ -1,0 +1,21 @@
+from pdf_chunker.core_new import _collect_warnings
+from pdf_chunker.config import PipelineSpec
+from pdf_chunker.framework import Artifact
+
+
+def test_collect_warnings_flags_known_issues() -> None:
+    payload = [
+        {"text": "Body footnote 1", "metadata": {"chunk_id": "c1", "source": {}}},
+        {"text": "Some text", "metadata": {"chunk_id": "c2"}},
+    ]
+    spec = PipelineSpec(
+        pipeline=[],
+        options={"pdf_parse": {"exclude_pages": "1", "engine": "pymupdf4llm"}},
+    )
+    warnings = _collect_warnings(Artifact(payload=payload, meta={}), spec)
+    assert set(warnings) == {
+        "footnote_anchors",
+        "page_exclusion_noop",
+        "metadata_gaps",
+        "underscore_loss",
+    }


### PR DESCRIPTION
## Summary
- flag footnote anchors, ineffective page exclusions, missing metadata, and underscore loss in run reports
- cover warning combinations with focused unit tests

## Testing
- `nox -s lint typecheck tests`
- `pytest tests/core_new_warnings_test.py -q`
- `black pdf_chunker/core_new.py tests/core_new_warnings_test.py`
- `flake8 pdf_chunker/core_new.py tests/core_new_warnings_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68a12f39bcbc8325ba032a22e1ada073