### PR TITLE
refactor(passes): align pdf_parse with PageBlocks artifact

### DIFF
--- a/pdf_chunker/passes/pdf_parse.py
+++ b/pdf_chunker/passes/pdf_parse.py
@@ -1,19 +1,36 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Mapping
+from collections.abc import Iterable, Mapping, Sequence
+from itertools import groupby
+from typing import Any
 
 from pdf_chunker.framework import Artifact, register
 
 
-def _default_doc(src: Mapping[str, Any]) -> Dict[str, Any]:
+def to_page_blocks(
+    blocks: Sequence[Mapping[str, Any]] | Iterable[Mapping[str, Any]],
+    *,
+    source_path: str = "<memory>",
+) -> dict[str, Any]:
+    """Wrap a legacy ``list[block]`` payload into a ``page_blocks`` document."""
+
+    def _page(block: Mapping[str, Any]) -> int:
+        return int(block.get("page", 1))
+
+    grouped = groupby(sorted(blocks, key=_page), _page)
+    pages = ({"page": page, "blocks": [dict(b) for b in group]} for page, group in grouped)
     return {
         "type": "page_blocks",
-        "source_path": src.get("source_path", "<memory>"),
-        "pages": [{"page": 1, "blocks": [{"text": "<stub pdf_parse>"}]}],
+        "source_path": source_path,
+        "pages": list(pages),
     }
 
 
-def _update_meta(meta: Dict[str, Any] | None, pages: int) -> Dict[str, Any]:
+def _is_page_blocks(doc: Any) -> bool:
+    return isinstance(doc, Mapping) and doc.get("type") == "page_blocks"
+
+
+def _update_meta(meta: dict[str, Any] | None, pages: int) -> dict[str, Any]:
     base = dict(meta or {})
     metrics = base.setdefault("metrics", {})
     metrics.setdefault("pdf_parse", {})["pages"] = pages
@@ -21,19 +38,25 @@ def _update_meta(meta: Dict[str, Any] | None, pages: int) -> Dict[str, Any]:
 
 
 class _PdfParsePass:
-    """
-    Minimal stub: turn any payload into a simple page_blocks dict.
-    Pure function; no side effects.
-    """
+    """Coerce block payloads into the canonical ``page_blocks`` shape."""
 
     name = "pdf_parse"
     input_type = dict
     output_type = dict
 
     def __call__(self, a: Artifact) -> Artifact:
-        src = a.payload if isinstance(a.payload, dict) else {}
-        doc = _default_doc(src)
-        meta = _update_meta(a.meta, len(doc["pages"]))
+        payload = a.payload
+        source = a.meta.get("input", "<memory>") if isinstance(a.meta, Mapping) else "<memory>"
+        doc = (
+            payload
+            if _is_page_blocks(payload)
+            else (
+                to_page_blocks(payload, source_path=source)
+                if isinstance(payload, list)
+                else to_page_blocks([], source_path=source)
+            )
+        )
+        meta = _update_meta(a.meta, len(doc.get("pages", [])))
         return Artifact(payload=doc, meta=meta)
 
 


### PR DESCRIPTION
## Summary
- refactor pdf_parse to coerce legacy block lists into canonical PageBlocks documents
- record page count metrics while passing through already-shaped inputs

## Testing
- `python -m pdf_chunker.cli inspect | head -n 40`
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`
- `pytest tests/bootstrap`


------
https://chatgpt.com/codex/tasks/task_e_68a1fec461f483259331db1af9a54ade