### PR TITLE
feat(passes): add emit_jsonl pass

### DIFF
--- a/pdf_chunker/passes/__init__.py
+++ b/pdf_chunker/passes/__init__.py
@@ -1,4 +1,5 @@
 from .ai_enrich import ai_enrich  # noqa: F401
+from .emit_jsonl import emit_jsonl  # noqa: F401
 from .extraction_fallback import extraction_fallback  # noqa: F401
 from .heading_detect import heading_detect  # noqa: F401
 from .list_detect import list_detect  # noqa: F401

--- a/pdf_chunker/passes/emit_jsonl.py
+++ b/pdf_chunker/passes/emit_jsonl.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from pdf_chunker.framework import Artifact, register
+
+Row = Dict[str, Any]
+Doc = Dict[str, Any]
+
+
+def _row(item: Dict[str, Any]) -> Row:
+    return {"text": item.get("text", ""), "meta": item.get("meta", {})}
+
+
+def _rows(doc: Doc) -> List[Row]:
+    return [_row(i) for i in doc.get("items", []) if i.get("text")]
+
+
+def _update_meta(meta: Dict[str, Any] | None, count: int) -> Dict[str, Any]:
+    base = dict(meta or {})
+    base.setdefault("metrics", {}).setdefault("emit_jsonl", {})["rows"] = count
+    return base
+
+
+class _EmitJsonlPass:
+    name = "emit_jsonl"
+    input_type = dict
+    output_type = list
+
+    def __call__(self, a: Artifact) -> Artifact:
+        doc = a.payload if isinstance(a.payload, dict) else {}
+        rows = _rows(doc) if doc.get("type") == "chunks" else []
+        meta = _update_meta(a.meta, len(rows))
+        return Artifact(payload=rows, meta=meta)
+
+
+emit_jsonl = register(_EmitJsonlPass())


### PR DESCRIPTION
## Summary
- add pure emit_jsonl pass to convert chunk dicts into JSONL-ready rows and track row metrics
- expose emit_jsonl via passes package

## Testing
- `python -m pdf_chunker.cli inspect`
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68a209043bf48325bf8718a2daa803d7