### PR TITLE
feat(adapters): add non-destructive describe() alongside read()

### DIFF
--- a/pdf_chunker/adapters/__init__.py
+++ b/pdf_chunker/adapters/__init__.py
@@ -1,0 +1,1 @@
+from .io_pdf import read, describe  # noqa: F401

--- a/pdf_chunker/adapters/io_pdf.py
+++ b/pdf_chunker/adapters/io_pdf.py
@@ -1,0 +1,46 @@
+"""PDF IO adapters.
+
+This module delineates the boundary for reading and describing PDF
+resources without entangling higher-level parsing logic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+
+def _normalize(path: str) -> Path:
+    """Return an absolute ``Path`` for ``path``.
+
+    This helper centralizes path normalization so both public functions
+    remain side-effect free and easy to compose.
+    """
+
+    return Path(path).expanduser().resolve()
+
+
+def read(path: str, exclude_pages: Optional[str] = None) -> bytes:
+    """Read raw bytes from ``path``.
+
+    Parameters
+    ----------
+    path:
+        PDF file location.
+    exclude_pages:
+        Unused placeholder preserving the existing call signature.
+
+    Returns
+    -------
+    bytes
+        Raw byte content of the PDF file.
+    """
+
+    return _normalize(path).read_bytes()
+
+
+def describe(path: str) -> dict[str, str]:
+    """Describe a PDF resource without inspecting its contents."""
+
+    normalized = _normalize(path)
+    return {"type": "pdf_document", "source_path": str(normalized)}


### PR DESCRIPTION
## Summary
- add dedicated PDF adapter module with describe() helper
- expose read and describe from adapters package

## Testing
- `python -m flake8 pdf_chunker/ scripts/ tests/`
- `python -m mypy pdf_chunker`
- `pytest tests`
- `nox -s lint` *(fails: FileNotFoundError: noxfile.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a21ae8610883258beb062ca6a8c142