### PR TITLE
feat(adapters): add EPUB adapter (describe_epub + read_epub stub)

### DIFF
--- a/pdf_chunker/adapters/__init__.py
+++ b/pdf_chunker/adapters/__init__.py
@@ -5,4 +5,7 @@ try:  # pragma: no cover - optional dependency
 except ModuleNotFoundError:  # pragma: no cover
     io_epub = None  # type: ignore
 
+from .io_epub import describe_epub, read_epub  # noqa: F401
+
 __all__ = ["emit_jsonl", "io_epub", "io_pdf"]
+__all__ += ["describe_epub", "read_epub"]

--- a/pdf_chunker/adapters/io_epub.py
+++ b/pdf_chunker/adapters/io_epub.py
@@ -5,14 +5,13 @@ from itertools import groupby
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
 
-from pdf_chunker.epub_parsing import (
-    extract_text_blocks_from_epub,
-    list_epub_spines,
-)
+# heavy epub parsing imports deferred to runtime to avoid expensive deps
 
 
 def _spine_map(path: str) -> Dict[str, int]:
     """Map spine locations to their 1-based indices."""
+    from pdf_chunker.epub_parsing import list_epub_spines
+
     return {item["filename"]: item["index"] for item in list_epub_spines(path)}
 
 
@@ -22,14 +21,21 @@ def _spine_key(block: Dict[str, Any], mapping: Dict[str, int]) -> int:
     return mapping.get(location, 0)
 
 
-def _group_blocks(blocks: Iterable[Dict[str, Any]], mapping: Dict[str, int]) -> List[Dict[str, Any]]:
+def _group_blocks(
+    blocks: Iterable[Dict[str, Any]], mapping: Dict[str, int]
+) -> List[Dict[str, Any]]:
     """Group blocks by spine index in ascending order."""
     key = partial(_spine_key, mapping=mapping)
     sorted_blocks = sorted(blocks, key=key)
-    return [{"page": page, "blocks": list(group)} for page, group in groupby(sorted_blocks, key)]
+    return [
+        {"page": page, "blocks": list(group)}
+        for page, group in groupby(sorted_blocks, key)
+    ]
 
 
 def _extract_blocks(path: str, exclude_spines: str | None) -> List[Dict[str, Any]]:
+    from pdf_chunker.epub_parsing import extract_text_blocks_from_epub
+
     return extract_text_blocks_from_epub(path, exclude_spines=exclude_spines)
 
 
@@ -43,3 +49,17 @@ def read(path: str, exclude_pages: str | None = None) -> Dict[str, Any]:
         "source_path": abs_path,
         "pages": _group_blocks(blocks, mapping),
     }
+
+
+def describe_epub(path: str) -> Dict[str, str]:
+    """Return a lightweight descriptor for an EPUB file."""
+    return {
+        "type": "epub_document",
+        "source_path": str(Path(path).resolve()),
+    }
+
+
+def read_epub(path: str, spine: str | None = None) -> Dict[str, Any]:
+    """Compatibility wrapper around :func:`read`."""
+    return read(path, exclude_pages=spine)
+


### PR DESCRIPTION
## Summary
- expose lightweight describe_epub utility for EPUB sources
- re-export existing EPUB reader as read_epub and defer heavy imports
- surface EPUB helpers directly from adapters package

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68a22aaf902c8325a24cef03ae4ce9e7