### PR TITLE
feat(cli): drive convert through adapter-based pipeline

### DIFF
--- a/pdf_chunker/cli.py
+++ b/pdf_chunker/cli.py
@@ -1,20 +1,49 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import typer
 
+from pdf_chunker.adapters import emit_jsonl, io_pdf
 from pdf_chunker.config import load_spec
-from pdf_chunker.core_new import run_convert, run_inspect
+from pdf_chunker.core_new import (
+    assemble_report,
+    run_convert,
+    run_inspect,
+    write_run_report,
+)
+from pdf_chunker.framework import Artifact
 
 app = typer.Typer(add_completion=False, no_args_is_help=True)
+
+
+def _adapter_for(path: str):
+    """Return IO adapter for ``path`` based on its extension."""
+    ext = Path(path).suffix.lower()
+    if ext == ".epub":
+        from pdf_chunker.adapters import io_epub
+
+        return io_epub
+    return io_pdf
+
+
+def _initial_artifact(path: str) -> Artifact:
+    """Load ``path`` via adapter and wrap in an ``Artifact``."""
+    adapter = _adapter_for(path)
+    payload = adapter.read(path)
+    return Artifact(payload=payload, meta={"metrics": {}, "input": path})
 
 
 @app.command()
 def convert(input_path: str, spec: str = "pipeline.yaml"):
     """Run the configured pipeline on ``input_path``."""
     s = load_spec(spec)
-    _ = run_convert(input_path, s)
+    a = _initial_artifact(input_path)
+    a, timings = run_convert(a, s)
+    emit_jsonl.maybe_write(a, s.options.get("emit_jsonl", {}), timings)
+    report = assemble_report(timings, a.meta or {})
+    write_run_report(s, report)
     typer.echo("convert: OK")
 
 

--- a/tests/bootstrap/test_run_report.py
+++ b/tests/bootstrap/test_run_report.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 import pdf_chunker.adapters.io_pdf as io_pdf
 from pdf_chunker.config import PipelineSpec
-from pdf_chunker.core_new import run_convert
+from pdf_chunker.core_new import assemble_report, run_convert, write_run_report
+from pdf_chunker.framework import Artifact
 
 
 def test_run_report_emitted(tmp_path, monkeypatch):
@@ -18,7 +19,11 @@ def test_run_report_emitted(tmp_path, monkeypatch):
         options={"run_report": {"output_path": str(tmp_path / "run_report.json")}},
     )
     pdf_path = Path("test_data") / "sample_test.pdf"
-    run_convert(str(pdf_path), spec)
+    payload = io_pdf.read(str(pdf_path))
+    artifact = Artifact(payload=payload, meta={"metrics": {}, "input": str(pdf_path)})
+    artifact, timings = run_convert(artifact, spec)
+    report = assemble_report(timings, artifact.meta or {})
+    write_run_report(spec, report)
     report_file = tmp_path / "run_report.json"
     data = json.loads(report_file.read_text())
     assert set(data) == {"timings", "metrics", "warnings"}


### PR DESCRIPTION
## Summary
- route CLI convert through adapter-selected IO and report emission
- refactor pipeline runner to be side-effect free

## Testing
- `nox -s lint typecheck tests`


------
https://chatgpt.com/codex/tasks/task_e_68a23d59f2648325a8e6809318ad28fd