### PR TITLE
refactor(passes): adapt clean_text into text_clean pass

### DIFF
--- a/pdf_chunker/passes/text_clean.py
+++ b/pdf_chunker/passes/text_clean.py
@@ -1,41 +1,29 @@
 from __future__ import annotations
 
-from typing import Any, Dict
-
 from pdf_chunker.framework import Artifact, register
 
 
-def _clean_text(text: str) -> str:
-    from pdf_chunker.text_cleaning import clean_text  # local import avoids heavy deps at import time
+def clean_text(text: str) -> str:
+    """Pure text normalization wrapper.
 
-    return clean_text(text)
+    Uses the heavy text_cleaning implementation only when invoked to keep
+    import times lean.
+    """
+    from pdf_chunker.text_cleaning import _clean_text_impl
 
-
-def _clean_block(block: Dict[str, Any]) -> Dict[str, Any]:
-    return {**block, "text": _clean_text(block.get("text", ""))}
-
-
-def _clean_page(page: Dict[str, Any]) -> Dict[str, Any]:
-    return {**page, "blocks": [_clean_block(b) for b in page.get("blocks", [])]}
-
-
-def _clean_page_blocks(doc: Dict[str, Any]) -> Dict[str, Any]:
-    if doc.get("type") != "page_blocks":
-        return doc
-    return {**doc, "pages": [_clean_page(p) for p in doc.get("pages", [])]}
+    return _clean_text_impl(text)
 
 
 class _TextCleanPass:
     name = "text_clean"
-    input_type = dict  # expects {"type": "page_blocks", ...}
-    output_type = dict
+    input_type = str
+    output_type = str
 
     def __call__(self, a: Artifact) -> Artifact:
-        doc = a.payload
-        out = _clean_page_blocks(doc) if isinstance(doc, dict) else doc
+        result = clean_text(a.payload)
         meta = dict(a.meta or {})
         meta.setdefault("metrics", {}).setdefault("text_clean", {})["normalized"] = True
-        return Artifact(payload=out, meta=meta)
+        return Artifact(payload=result, meta=meta)
 
 
 text_clean = register(_TextCleanPass())

--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -567,7 +567,7 @@ def clean_paragraph(paragraph: str) -> str:
     )
 
 
-def clean_text(text: str) -> str:
+def _clean_text_impl(text: str) -> str:
     """
     Cleans multi-paragraph text, preserving paragraph breaks,
     using clean_paragraph() for each paragraph.
@@ -656,6 +656,14 @@ def clean_text(text: str) -> str:
 
     logger.debug(f"Final clean_text result preview: {_preview(result)}")
     return result
+
+
+def clean_text(text: str) -> str:
+    """Shim maintaining legacy API while delegating to the text_clean pass."""
+    from pdf_chunker.framework import Artifact
+    from pdf_chunker.passes import text_clean as _text_clean
+
+    return _text_clean(Artifact(payload=text)).payload
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- expose text cleaning as a pure `text_clean` pass working on string artifacts
- delegate `text_cleaning.clean_text` to the new pass for backward compatibility

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68a24a08fdf083259baba7a2b50dba16