### PR TITLE
Bind emit_jsonl adapter and remove pass-side IO

### DIFF
--- a/pdf_chunker/cli.py
+++ b/pdf_chunker/cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import typer
 
-from pdf_chunker.adapters import emit_jsonl, io_pdf
+from pdf_chunker.adapters import io_pdf
 from pdf_chunker.config import load_spec
 from pdf_chunker.core_new import (
     assemble_report,
@@ -41,7 +41,6 @@ def convert(input_path: str, spec: str = "pipeline.yaml"):
     s = load_spec(spec)
     a = _initial_artifact(input_path)
     a, timings = run_convert(a, s)
-    emit_jsonl.maybe_write(a, s.options.get("emit_jsonl", {}), timings)
     report = assemble_report(timings, a.meta or {})
     write_run_report(s, report)
     typer.echo("convert: OK")

--- a/tests/bootstrap/test_run_convert_adapter.py
+++ b/tests/bootstrap/test_run_convert_adapter.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pdf_chunker.pdf_parsing as pdf_parsing
-from pdf_chunker.adapters import emit_jsonl
 from pdf_chunker.config import PipelineSpec
 from pdf_chunker.core_new import assemble_report, run_convert, write_run_report
 from pdf_chunker.framework import Artifact
@@ -23,7 +22,6 @@ def test_run_convert_writes_jsonl(tmp_path, monkeypatch):
     pdf_path = Path("test_data") / "sample_test.pdf"
     artifact = Artifact(payload=str(pdf_path), meta={"metrics": {}, "input": str(pdf_path)})
     artifact, timings = run_convert(artifact, spec)
-    emit_jsonl.maybe_write(artifact, spec.options["emit_jsonl"], timings)
     report = assemble_report(timings, artifact.meta or {})
     write_run_report(spec, report)
     out_file = tmp_path / "out.jsonl"

--- a/tests/golden/test_conversion.py
+++ b/tests/golden/test_conversion.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from pdf_chunker.adapters import emit_jsonl, io_pdf
+from pdf_chunker.adapters import io_pdf
 from pdf_chunker.config import PipelineSpec
 from pdf_chunker.core_new import assemble_report, run_convert, write_run_report
 from pdf_chunker.framework import Artifact
@@ -14,7 +14,7 @@ BASE_DIR = Path(__file__).resolve().parent
 def _spec(tmp: Path) -> PipelineSpec:
     """Return a minimal PDF pipeline spec bound to temporary paths."""
     return PipelineSpec(
-        pipeline=["pdf_parse", "text_clean", "split_semantic"],
+        pipeline=["pdf_parse", "text_clean", "split_semantic", "emit_jsonl"],
         options={
             "emit_jsonl": {"output_path": str(tmp / "out.jsonl")},
             "run_report": {"output_path": str(tmp / "report.json")},
@@ -33,7 +33,6 @@ def test_conversion(file_regression, tmp_path: Path) -> None:
     payload = io_pdf.read(str(pdf))
     artifact = Artifact(payload=payload, meta={"metrics": {}, "input": str(pdf)})
     artifact, timings = run_convert(artifact, spec)
-    emit_jsonl.maybe_write(artifact, spec.options["emit_jsonl"], timings)
     report = assemble_report(timings, artifact.meta or {})
     write_run_report(spec, report)
     jsonl = _jsonl(artifact.payload if isinstance(artifact.payload, list) else [])


### PR DESCRIPTION
## Summary
- delegate JSONL emission to `_maybe_emit_jsonl` within `run_convert`
- drop direct `emit_jsonl` writes from CLI `convert`
- update tests to exercise adapter-based output

## Testing
- `nox -s lint typecheck tests`

------
https://chatgpt.com/codex/tasks/task_e_68a254abc9c883259e6bde20c11e5d0a