### PR TITLE
refactor(passes): add list_detect pass

### DIFF
--- a/pdf_chunker/passes/list_detect.py
+++ b/pdf_chunker/passes/list_detect.py
@@ -5,16 +5,99 @@ start with bullets or numbered markers, or continue such items, are marked
 as ``list_item`` with a corresponding ``list_kind``.
 """
 
+from __future__ import annotations
+
+import re
 from functools import reduce
 from typing import Any, Dict, Iterable, List, Tuple
 
 from pdf_chunker.framework import Artifact, register
-from pdf_chunker.list_detection import (
-    is_bullet_continuation,
-    is_numbered_continuation,
-    starts_with_bullet,
-    starts_with_number,
-)
+
+
+BULLET_CHARS = "*•◦▪‣·●◉○‧"
+BULLET_CHARS_ESC = re.escape(BULLET_CHARS)
+HYPHEN_BULLET_PREFIX = "- "
+NUMBERED_RE = re.compile(r"\s*\d+[.)]")
+
+
+def starts_with_bullet(text: str) -> bool:
+    """Return True if ``text`` begins with a bullet marker or hyphen bullet."""
+
+    stripped = text.lstrip()
+    return stripped.startswith(tuple(BULLET_CHARS)) or stripped.startswith(
+        HYPHEN_BULLET_PREFIX
+    )
+
+
+def _last_non_empty_line(text: str) -> str:
+    return next(
+        (line.strip() for line in reversed(text.splitlines()) if line.strip()),
+        "",
+    )
+
+
+def is_bullet_continuation(curr: str, nxt: str) -> bool:
+    """Return True when ``nxt`` continues a bullet item from ``curr``."""
+
+    last_line = _last_non_empty_line(curr)
+    return last_line.endswith(tuple(BULLET_CHARS)) and nxt[:1].islower()
+
+
+def is_bullet_fragment(curr: str, nxt: str) -> bool:
+    """Return True when ``nxt`` starts with text that continues the last bullet in ``curr``."""
+
+    last_line = _last_non_empty_line(curr)
+    return (
+        starts_with_bullet(last_line)
+        and not last_line.rstrip().endswith((".", "!", "?"))
+        and nxt[:1].islower()
+    )
+
+
+def split_bullet_fragment(text: str) -> Tuple[str, str]:
+    """Split the first line from the remainder, if any."""
+
+    if "\n" not in text:
+        return text.strip(), ""
+    first, rest = text.split("\n", 1)
+    return first.strip(), rest.lstrip()
+
+
+def is_bullet_list_pair(curr: str, nxt: str) -> bool:
+    """Return True when ``curr`` and ``nxt`` belong to the same bullet list."""
+
+    colon_bullet = curr.rstrip().endswith(":") or re.search(
+        rf":\s*(?:[{BULLET_CHARS_ESC}]|-)", curr
+    )
+    has_bullet = starts_with_bullet(curr) or any(
+        starts_with_bullet(line) for line in curr.splitlines()
+    )
+    return starts_with_bullet(nxt) and (has_bullet or colon_bullet)
+
+
+def starts_with_number(text: str) -> bool:
+    """Return True if ``text`` begins with a numbered list marker."""
+
+    return bool(NUMBERED_RE.match(text))
+
+
+def is_numbered_list_pair(curr: str, nxt: str) -> bool:
+    """Return True when ``curr`` and ``nxt`` belong to the same numbered list."""
+
+    has_number = starts_with_number(curr) or any(
+        starts_with_number(line) for line in curr.splitlines()
+    )
+    return starts_with_number(nxt) and has_number
+
+
+def is_numbered_continuation(curr: str, nxt: str) -> bool:
+    """Return True when ``nxt`` continues a numbered item from ``curr``."""
+
+    return (
+        starts_with_number(curr)
+        and not starts_with_number(nxt)
+        and not curr.rstrip().endswith((".", "!", "?"))
+    )
 
 
 Block = Dict[str, Any]


### PR DESCRIPTION
## Summary
- move list detection helpers into `passes.list_detect`
- keep `list_detection` module as backward-compatible shim

### API Stability
- functions like `starts_with_bullet` remain importable from `pdf_chunker.list_detection`
- moved implementations live in `pdf_chunker.passes.list_detect`

## Testing
- `nox -s lint typecheck tests`


------
https://chatgpt.com/codex/tasks/task_e_68a257f2eee88325856aa0306b145230