### PR TITLE
refactor(passes): wrap fallback extraction

### DIFF
--- a/pdf_chunker/adapters/io_pdf.py
+++ b/pdf_chunker/adapters/io_pdf.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from itertools import groupby
 from pathlib import Path
+from subprocess import CompletedProcess, run
 from typing import Any
 
 
@@ -33,3 +34,8 @@ def read(path: str, exclude_pages: str | None = None) -> dict[str, Any]:
         "source_path": abs_path,
         "pages": _group_blocks(blocks),
     }
+
+
+def run_pdftotext(cmd: Sequence[str], timeout: int = 60) -> CompletedProcess[str]:
+    """Execute ``pdftotext`` and capture its output."""
+    return run(cmd, capture_output=True, text=True, timeout=timeout)

--- a/pdf_chunker/passes/extraction_fallback.py
+++ b/pdf_chunker/passes/extraction_fallback.py
@@ -1,28 +1,30 @@
-from typing import Any, Dict, List
+from __future__ import annotations
+
+from typing import Any
 
 from pdf_chunker.framework import Artifact, register
 
-Block = Dict[str, Any]
+Block = dict[str, Any]
 
 
-def _blocks_doc(blocks: List[Block], source: str) -> Dict[str, Any]:
+def _blocks_doc(blocks: list[Block], source: str) -> dict[str, Any]:
     return {"type": "blocks", "blocks": blocks, "source_path": source}
 
 
-def _score(blocks: List[Block]) -> float:
+def _score(blocks: list[Block]) -> float:
     from pdf_chunker.extraction_fallbacks import _assess_text_quality
 
     text = "\n".join(b.get("text", "") for b in blocks)
     return _assess_text_quality(text).get("quality_score", 0.0)
 
 
-def _extract(path: str, reason: str | None) -> List[Block]:
+def _extract(path: str, reason: str | None) -> list[Block]:
     from pdf_chunker.extraction_fallbacks import execute_fallback_extraction
 
     return execute_fallback_extraction(path, fallback_reason=reason)
 
 
-def _meta(meta: Dict[str, Any] | None, reason: str | None, score: float) -> Dict[str, Any]:
+def _meta(meta: dict[str, Any] | None, reason: str | None, score: float) -> dict[str, Any]:
     metrics = (meta or {}).get("metrics", {})
     fallback = metrics.get("extraction_fallback", {})
     update = {"score": score, **({"reason": reason} if reason else {})}


### PR DESCRIPTION
## Summary
- isolate `pdftotext` subprocess handling inside `io_pdf.run_pdftotext`
- route `_extract_with_pdftotext` through the new adapter and clean up imports
- ensure `extraction_fallback` pass registers `execute_fallback_extraction`

### API Stability
- `execute_fallback_extraction` retains its signature in `pdf_chunker/extraction_fallbacks.py`; callers use the same interface while subprocess work now lives in `io_pdf.run_pdftotext`
- `extraction_fallback` remains registered as a pass under the same name

## Testing
- `nox -s lint`  
- `nox -s typecheck`  
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68a284c1d8488325a73012f290e0fcaf