### PR TITLE
chore(core): enforce pipeline invariants

### DIFF
--- a/pdf_chunker/core_new.py
+++ b/pdf_chunker/core_new.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import re
 import time
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from functools import reduce
 from pathlib import Path
 from typing import Any
@@ -22,37 +22,35 @@ def _pass_steps(spec: PipelineSpec) -> list[str]:
     return [s for s in spec.pipeline if s in regs]
 
 
-def _indices(pred: Callable[[str], bool], steps: Sequence[str]) -> list[int]:
-    """Return indices of ``steps`` matching ``pred`` using comprehension."""
-    return [i for i, s in enumerate(steps) if pred(s)]
-
-
 def _ensure_clean_precedes_split(steps: Sequence[str]) -> None:
-    """Raise if any split step occurs before ``text_clean``."""
-    split_idx = _indices(lambda s: s.startswith("split"), steps)
-    if not split_idx:
+    """Raise descriptive error if a split pass precedes ``text_clean``."""
+    first_split = next(((s, i) for i, s in enumerate(steps) if s.startswith("split")), None)
+    if not first_split:
         return
-    clean_idx = _indices(lambda s: s == "text_clean", steps)
-    if not clean_idx or clean_idx[0] > min(split_idx):
-        raise ValueError("text_clean must precede split passes")
+    clean_index = next((i for i, s in enumerate(steps) if s == "text_clean"), None)
+    split_name, split_index = first_split
+    if clean_index is None or clean_index > split_index:
+        raise ValueError(f"{split_name} requires text_clean to run beforehand")
 
 
 def _ensure_pdf_epub_separation(steps: Sequence[str], ext: str) -> None:
-    """Ensure pipeline contains only PDF or only EPUB passes and matches ``ext``."""
+    """Validate PDF/EPUB pass separation and match to ``ext``."""
     prefixes = {s.split("_", 1)[0] for s in steps if s.startswith(("pdf_", "epub_"))}
     if len(prefixes) > 1:
-        raise ValueError("pipeline mixes PDF and EPUB passes")
+        raise ValueError(f"pipeline mixes media types: {sorted(prefixes)}")
     ext_map = {".pdf": "pdf", ".epub": "epub"}
     expected = ext_map.get(ext)
     if prefixes and expected and prefixes != {expected}:
-        raise ValueError(f"{ext} input incompatible with {next(iter(prefixes))} passes")
+        found = next(iter(prefixes))
+        raise ValueError(f"{ext} input cannot use {found} passes")
 
 
-def _enforce_invariants(spec: PipelineSpec, *, input_path: str) -> None:
-    """Validate pipeline order and media-type separation."""
+def _enforce_invariants(spec: PipelineSpec, *, input_path: str) -> list[str]:
+    """Return validated steps while enforcing order and media-type invariants."""
     steps = list(spec.pipeline)
     _ensure_clean_precedes_split(steps)
     _ensure_pdf_epub_separation(steps, Path(input_path).suffix.lower())
+    return _pass_steps(spec)
 
 
 def _time_step(acc: tuple[Artifact, dict[str, float]], step: str) -> tuple[Artifact, dict[str, float]]:
@@ -138,8 +136,7 @@ def write_run_report(spec: PipelineSpec, report: Mapping[str, Any]) -> None:
 
 def run_convert(a: Artifact, spec: PipelineSpec) -> tuple[Artifact, dict[str, float]]:
     """Run declared passes on ``a`` and return new artifact plus timings."""
-    _enforce_invariants(spec, input_path=str((a.meta or {}).get("input", "")))
-    steps = _pass_steps(spec)
+    steps = _enforce_invariants(spec, input_path=str((a.meta or {}).get("input", "")))
     a, timings = _run_passes(steps, a)
     _maybe_emit_jsonl(a, spec, timings)
     warnings = _collect_warnings(a, spec)


### PR DESCRIPTION
## Summary
- raise descriptive errors when split passes precede cleaning and when media types mix
- centralize step validation inside `_enforce_invariants`
- streamline invariant checks using generator-based helpers

## Testing
- `nox -s lint typecheck tests`

------
https://chatgpt.com/codex/tasks/task_e_68a288842fd083259dc56cd9f94c4d78