### PR TITLE
Wrap LLM tagging into ai_enrich pass with adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,10 @@ pdf_chunker/
 │   ├── __init__.py                # Package initializer
 │   ├── adapters/
 │   │   ├── __init__.py
+│   │   ├── ai_enrich.py           # LLM completion & tag config loading
 │   │   ├── io_pdf.py
 │   │   └── io_epub.py
-│   ├── ai_enrichment.py           # AI Pass: classification and YAML-based tagging
+│   ├── ai_enrichment.py           # Shim delegating to ai_enrich pass and adapter
 │   ├── core.py                    # Orchestrates the three-pass pipeline
 │   ├── env_utils.py               # Environment flag helpers
 │   ├── epub_parsing.py            # EPUB extraction with spine exclusion support

--- a/pdf_chunker/AGENTS.md
+++ b/pdf_chunker/AGENTS.md
@@ -15,7 +15,7 @@ Please, keep this file up-to-date with the latest code structure. If you notice 
 - `page_utils.py`: Page range parsing/filtering.
 - `epub_parsing.py`: Spine discovery and exclusion.
 - `splitter.py`: Enforces chunk boundaries and semantic cohesion.
-- `ai_enrichment.py`: Applies YAML-based tags.
+- `ai_enrichment.py`: Legacy shim delegating to pass/adapter.
 - `utils.py`: Metadata mapping and helper functions.
 - `env_utils.py`: Environment flag helpers.
 - `page_artifacts.py`: Header/footer detection utilities.

--- a/pdf_chunker/adapters/__init__.py
+++ b/pdf_chunker/adapters/__init__.py
@@ -1,4 +1,4 @@
-from . import emit_jsonl, io_pdf
+from . import ai_enrich, emit_jsonl, io_pdf
 
 try:  # pragma: no cover - optional dependency
     from . import io_epub  # type: ignore
@@ -7,5 +7,5 @@ except ModuleNotFoundError:  # pragma: no cover
 
 from .io_epub import describe_epub, read_epub  # noqa: F401
 
-__all__ = ["emit_jsonl", "io_epub", "io_pdf"]
+__all__ = ["ai_enrich", "emit_jsonl", "io_epub", "io_pdf"]
 __all__ += ["describe_epub", "read_epub"]

--- a/pdf_chunker/adapters/ai_enrich.py
+++ b/pdf_chunker/adapters/ai_enrich.py
@@ -1,0 +1,114 @@
+import json
+import os
+from pathlib import Path
+from typing import Callable
+
+from concurrent.futures import ThreadPoolExecutor
+from functools import reduce
+
+import yaml
+
+from pdf_chunker.passes.ai_enrich import classify_chunk_utterance
+
+
+def _load_tag_configs(config_dir: str = "config/tags") -> dict:
+    """Merge YAML tag configurations into a single dictionary."""
+    config_path = Path(config_dir)
+    if not config_path.is_absolute():
+        config_path = Path(__file__).resolve().parent.parent / config_path
+    if not config_path.exists():
+        return {}
+
+    def load_yaml(path: Path) -> dict:
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                data = yaml.safe_load(handle) or {}
+                return {k: v for k, v in data.items() if isinstance(v, list)}
+        except FileNotFoundError:
+            return {}
+
+    def merge_dicts(acc: dict, nxt: dict) -> dict:
+        return {key: acc.get(key, []) + nxt.get(key, []) for key in set(acc) | set(nxt)}
+
+    merged = reduce(
+        merge_dicts,
+        map(load_yaml, config_path.glob("*.yaml")),
+        {},
+    )
+
+    return {
+        k: sorted({tag.strip().lower() for tag in v if isinstance(tag, str)})
+        for k, v in merged.items()
+    }
+
+
+def init_llm(api_key: str | None = None) -> Callable[[str], str]:
+    """Return a completion function configured with an API key."""
+    from dotenv import load_dotenv  # lazy import
+
+    load_dotenv()
+    key = api_key or os.environ.get("OPENAI_API_KEY")
+    if not key:
+        raise ValueError("OPENAI_API_KEY not found in .env file or environment.")
+    try:
+        import litellm  # type: ignore
+    except Exception as exc:  # pragma: no cover
+        raise ImportError("litellm is required for init_llm") from exc
+
+    def completion(prompt: str) -> str:
+        response = litellm.completion(  # type: ignore[union-attr]
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.0,
+            max_tokens=100,
+            api_key=key,
+        )
+        return response.choices[0].message.content
+
+    return completion
+
+
+def _process_chunk_for_file(
+    chunk: dict,
+    *,
+    tag_configs: dict,
+    completion_fn: Callable[[str], str],
+) -> dict:
+    """Helper to wrap utterance classification and tagging for file processing."""
+    result = classify_chunk_utterance(
+        chunk.get("text", ""), tag_configs=tag_configs, completion_fn=completion_fn
+    )
+    chunk = {
+        **chunk,
+        "utterance_type": result["classification"],
+        "tags": result["tags"],
+    }
+    meta = {**chunk.get("metadata", {}), "utterance_type": result["classification"], "tags": result["tags"]}
+    return {**chunk, "metadata": meta}
+
+
+def _process_jsonl_file(
+    input_path: str,
+    output_path: str,
+    completion_fn: Callable[[str], str],
+    tag_configs: dict | None = None,
+    max_workers: int = 10,
+) -> None:
+    """Read ``input_path`` JSONL, classify chunks, and write to ``output_path``."""
+    tag_configs = tag_configs or _load_tag_configs()
+    with (
+        open(input_path, "r", encoding="utf-8") as infile,
+        open(output_path, "w", encoding="utf-8") as outfile,
+    ):
+        chunks = [json.loads(line) for line in infile]
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            results = list(
+                ex.map(
+                    lambda c: _process_chunk_for_file(
+                        c, tag_configs=tag_configs, completion_fn=completion_fn
+                    ),
+                    chunks,
+                )
+            )
+        for chunk in results:
+            outfile.write(json.dumps(chunk) + "\n")

--- a/pdf_chunker/ai_enrichment.py
+++ b/pdf_chunker/ai_enrichment.py
@@ -1,205 +1,29 @@
-import json
+"""Shim module preserving public API for AI enrichment utilities.
+
+The original logic now lives in :mod:`pdf_chunker.passes.ai_enrich`
+(for pure classification) and :mod:`pdf_chunker.adapters.ai_enrich`
+(for LLM and file I/O). This module re-exports those functions to
+maintain compatibility.
+"""
+
 import os
 import sys
-from pathlib import Path
-from functools import reduce
-from typing import Callable
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
-import yaml
+from pdf_chunker.adapters.ai_enrich import (
+    _load_tag_configs,
+    init_llm,
+    _process_chunk_for_file,
+    _process_jsonl_file,
+)
+from pdf_chunker.passes.ai_enrich import classify_chunk_utterance
 
-try:  # pragma: no cover - optional dependency
-    from dotenv import load_dotenv
-except Exception:  # pragma: no cover
-
-    def load_dotenv(*_args: object, **_kwargs: object) -> bool:  # type: ignore
-        return False
-
-
-try:  # pragma: no cover - optional dependency
-    import litellm  # type: ignore
-except Exception:  # pragma: no cover
-    litellm = None
-
-# --- Configuration ---
-# This is now configured via an explicit init function
-UTTERANCE_TYPES = [
-    "definition",
-    "explanation",
-    "instruction",
-    "example",
-    "opinion",
-    "statement_of_fact",
-    "question",
-    "summary",
-    "critique",
-    "unclassified",
+__all__ = [
+    "classify_chunk_utterance",
+    "_load_tag_configs",
+    "init_llm",
+    "_process_chunk_for_file",
+    "_process_jsonl_file",
 ]
-
-
-def _load_tag_configs(config_dir: str = "config/tags") -> dict:
-    """Merge YAML tag configurations into a single dictionary."""
-    config_path = Path(config_dir)
-    if not config_path.is_absolute():
-        config_path = Path(__file__).resolve().parent.parent / config_path
-    if not config_path.exists():
-        return {}
-
-    def load_yaml(path: Path) -> dict:
-        try:
-            with path.open("r", encoding="utf-8") as handle:
-                data = yaml.safe_load(handle) or {}
-                return {k: v for k, v in data.items() if isinstance(v, list)}
-        except FileNotFoundError:
-            return {}
-
-    def merge_dicts(acc: dict, nxt: dict) -> dict:
-        return {key: acc.get(key, []) + nxt.get(key, []) for key in set(acc) | set(nxt)}
-
-    merged = reduce(
-        merge_dicts,
-        map(load_yaml, config_path.glob("*.yaml")),
-        {},
-    )
-
-    return {
-        k: sorted({tag.strip().lower() for tag in v if isinstance(tag, str)})
-        for k, v in merged.items()
-    }
-
-
-def init_llm(api_key: str | None = None) -> Callable[[str], str]:
-    """Return a completion function configured with an API key."""
-    load_dotenv()
-    key = api_key or os.environ.get("OPENAI_API_KEY")
-    if not key:
-        raise ValueError("OPENAI_API_KEY not found in .env file or environment.")
-    if litellm is None:
-        raise ImportError("litellm is required for init_llm")
-
-    def completion(prompt: str) -> str:
-        response = litellm.completion(  # type: ignore[union-attr]
-            model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": prompt}],
-            temperature=0.0,
-            max_tokens=100,
-            api_key=key,
-        )
-        return response.choices[0].message.content
-
-    return completion
-
-
-def classify_chunk_utterance(
-    text_chunk: str,
-    *,
-    tag_configs: dict,
-    completion_fn: Callable[[str], str],
-) -> dict:
-    """Classify ``text_chunk`` and assign valid tags using ``completion_fn``."""
-    if not text_chunk or not text_chunk.strip():
-        return {"classification": "unclassified", "tags": []}
-
-    available_tags_text = ""
-    if tag_configs:
-        available_tags_text = "\n\nAvailable tags by category:\n"
-        for category, tags in tag_configs.items():
-            available_tags_text += f"- {category}: {', '.join(tags)}\n"
-        available_tags_text += "\nSelect 2-4 most relevant tags from the available categories."
-
-    prompt = f"""Given the following text, classify its primary utterance type and assign relevant tags.
-
-Classification: Choose the best fit from this list: {UTTERANCE_TYPES}.
-
-{available_tags_text}
-
-Respond in this exact format:
-Classification: [chosen_type]
-Tags: [tag1, tag2, tag3]
-
-Text: "{text_chunk}"
-
-Response:"""
-
-    try:
-        response_text = completion_fn(prompt).strip()
-        classification = "unclassified"
-        tags = []
-
-        for line in response_text.split("\n"):
-            line = line.strip()
-            if line.startswith("Classification:"):
-                classification = line.split(":", 1)[1].strip().lower()
-                if classification not in UTTERANCE_TYPES:
-                    classification = "unclassified"
-            elif line.startswith("Tags:"):
-                tags_text = line.split(":", 1)[1].strip()
-                raw_tags = [
-                    tag.strip().lower()
-                    for tag in tags_text.replace("[", "").replace("]", "").split(",")
-                    if tag.strip()
-                ]
-                valid = {t.lower() for tags in tag_configs.values() for t in tags}
-                tags = [tag for tag in raw_tags if tag in valid]
-        return {"classification": classification, "tags": tags}
-    except Exception:
-        return {"classification": "error", "tags": []}
-
-
-# --- Main execution logic for standalone script ---
-
-
-def _process_chunk_for_file(
-    chunk: dict,
-    *,
-    tag_configs: dict,
-    completion_fn: Callable[[str], str],
-) -> dict:
-    """Helper to wrap utterance classification and tagging for file processing."""
-    result = classify_chunk_utterance(
-        chunk.get("text", ""), tag_configs=tag_configs, completion_fn=completion_fn
-    )
-    chunk["utterance_type"] = result["classification"]
-    chunk["tags"] = result["tags"]
-    if "metadata" not in chunk:
-        chunk["metadata"] = {}
-    chunk["metadata"]["utterance_type"] = result["classification"]
-    chunk["metadata"]["tags"] = result["tags"]
-    return chunk
-
-
-def _process_jsonl_file(
-    input_path: str,
-    output_path: str,
-    completion_fn: Callable[[str], str],
-    tag_configs: dict | None = None,
-    max_workers: int = 10,
-):
-    """Read ``input_path`` JSONL, classify chunks, and write to ``output_path``."""
-    tag_configs = tag_configs or _load_tag_configs()
-    with (
-        open(input_path, "r", encoding="utf-8") as infile,
-        open(output_path, "w", encoding="utf-8") as outfile,
-    ):
-        lines = infile.readlines()
-        chunks = [json.loads(line) for line in lines]
-
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = {
-                executor.submit(
-                    _process_chunk_for_file,
-                    chunk,
-                    tag_configs=tag_configs,
-                    completion_fn=completion_fn,
-                ): idx
-                for idx, chunk in enumerate(chunks)
-            }
-            results = [None] * len(chunks)
-            for future in as_completed(futures):
-                results[futures[future]] = future.result()
-
-        for result_chunk in results:
-            outfile.write(json.dumps(result_chunk) + "\n")
 
 
 def main() -> None:

--- a/pdf_chunker/passes/ai_enrich.py
+++ b/pdf_chunker/passes/ai_enrich.py
@@ -1,10 +1,80 @@
 from typing import Any, Callable, Dict, List
 
-from pdf_chunker.ai_enrichment import classify_chunk_utterance
 from pdf_chunker.framework import Artifact, register
 
 Chunk = Dict[str, Any]
 Chunks = List[Chunk]
+
+
+UTTERANCE_TYPES = [
+    "definition",
+    "explanation",
+    "instruction",
+    "example",
+    "opinion",
+    "statement_of_fact",
+    "question",
+    "summary",
+    "critique",
+    "unclassified",
+]
+
+
+def classify_chunk_utterance(
+    text_chunk: str,
+    *,
+    tag_configs: Dict[str, List[str]],
+    completion_fn: Callable[[str], str],
+) -> Dict[str, Any]:
+    """Classify ``text_chunk`` and assign relevant tags using ``completion_fn``."""
+    if not text_chunk or not text_chunk.strip():
+        return {"classification": "unclassified", "tags": []}
+
+    available_tags = (
+        "\n\nAvailable tags by category:\n" +
+        "".join(
+            f"- {cat}: {', '.join(tags)}\n" for cat, tags in tag_configs.items()
+        ) +
+        "\nSelect 2-4 most relevant tags from the available categories."
+        if tag_configs
+        else ""
+    )
+
+    prompt = f"""Given the following text, classify its primary utterance type and assign relevant tags.
+
+Classification: Choose the best fit from this list: {UTTERANCE_TYPES}.
+
+{available_tags}
+
+Respond in this exact format:
+Classification: [chosen_type]
+Tags: [tag1, tag2, tag3]
+
+Text: \"{text_chunk}\"
+
+Response:"""
+
+    try:
+        response_text = completion_fn(prompt).strip()
+        classification, tags = "unclassified", []
+        for line in response_text.split("\n"):
+            line = line.strip()
+            if line.startswith("Classification:"):
+                classification = line.split(":", 1)[1].strip().lower()
+                if classification not in UTTERANCE_TYPES:
+                    classification = "unclassified"
+            elif line.startswith("Tags:"):
+                tags_text = line.split(":", 1)[1].strip()
+                raw_tags = [
+                    tag.strip().lower()
+                    for tag in tags_text.replace("[", "").replace("]", "").split(",")
+                    if tag.strip()
+                ]
+                valid = {t for v in tag_configs.values() for t in v}
+                tags = [tag for tag in raw_tags if tag in valid]
+        return {"classification": classification, "tags": tags}
+    except Exception:
+        return {"classification": "error", "tags": []}
 
 
 def _classify_chunk(

--- a/tests/ai_enrichment_test.py
+++ b/tests/ai_enrichment_test.py
@@ -3,11 +3,11 @@ import sys
 # Ensure local package path for pdf_chunker imports
 sys.path.insert(0, ".")
 
-from pdf_chunker.ai_enrichment import (
+from pdf_chunker.adapters.ai_enrich import (
     _load_tag_configs,
-    classify_chunk_utterance,
     _process_chunk_for_file,
 )
+from pdf_chunker.passes.ai_enrich import classify_chunk_utterance
 
 
 def _dummy_completion(_: str) -> str:


### PR DESCRIPTION
## Summary
- extract `classify_chunk_utterance` into the `ai_enrich` pass for pure tagging
- move tag config loading and LLM completion to `adapters.ai_enrich`
- keep `ai_enrichment.py` as a shim re-exporting the pass and adapter utilities

## Testing
- `nox -s lint typecheck tests`


------
https://chatgpt.com/codex/tasks/task_e_68a28acc6b48832581d60400967eb761