### PR TITLE
feat(metrics): log fallback reasons and scores

### DIFF
--- a/pdf_chunker/passes/__init__.py
+++ b/pdf_chunker/passes/__init__.py
@@ -1,8 +1,30 @@
-from .ai_enrich import ai_enrich  # noqa: F401
-from .emit_jsonl import emit_jsonl  # noqa: F401
-from .extraction_fallback import extraction_fallback  # noqa: F401
-from .heading_detect import heading_detect  # noqa: F401
-from .list_detect import list_detect  # noqa: F401
-from .pdf_parse import pdf_parse  # noqa: F401
-from .split_semantic import split_semantic  # noqa: F401
-from .text_clean import text_clean  # noqa: F401
+"""Lazy pass accessors that avoid shadowing submodules."""
+
+from importlib import import_module
+from typing import Any
+
+_PASS_MODULES = [
+    "ai_enrich",
+    "emit_jsonl",
+    "extraction_fallback",
+    "heading_detect",
+    "list_detect",
+    "pdf_parse",
+    "split_semantic",
+    "text_clean",
+]
+
+# Import submodules for registration side effects without polluting the package
+# namespace. This keeps ``pdf_chunker.passes.<module>`` importable while ensuring
+# each pass registers itself with the framework.
+for _mod in _PASS_MODULES:  # pragma: no cover - import side effects only
+    import_module(f".{_mod}", __name__)
+
+__all__ = list(_PASS_MODULES)
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - simple delegation
+    if name in __all__:
+        module = import_module(f".{name}", __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/pdf_chunker/passes/extraction_fallback.py
+++ b/pdf_chunker/passes/extraction_fallback.py
@@ -25,13 +25,13 @@ def _extract(path: str, reason: str | None) -> list[Block]:
 
 
 def _meta(meta: dict[str, Any] | None, reason: str | None, score: float) -> dict[str, Any]:
+    """Return a new meta dict with fallback metrics merged immutably."""
+
     metrics = (meta or {}).get("metrics", {})
-    fallback = metrics.get("extraction_fallback", {})
-    update = {"score": score, **({"reason": reason} if reason else {})}
-    return {
-        **(meta or {}),
-        "metrics": {"extraction_fallback": {**fallback, **update}, **metrics},
-    }
+    fallback = {**metrics.get("extraction_fallback", {}), "score": score}
+    if reason:
+        fallback["reason"] = reason
+    return {**(meta or {}), "metrics": {**metrics, "extraction_fallback": fallback}}
 
 
 class _ExtractionFallbackPass:


### PR DESCRIPTION
## Summary
- capture extraction fallback reason and quality score immutably in artifact metrics
- load pass modules lazily to preserve module importability while keeping pass registry intact

## Testing
- `nox -s lint typecheck tests`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/extraction_fallback_pass_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68a338f186888325b872bdd15ea0bf2e