### PR TITLE
chore(docs): auto-update AGENTS responsibilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,21 @@ This `AGENTS.md` suite provides comprehensive guidance to OpenAI Codex and other
 
 ---
 
+## Pass Responsibilities
+
+<!-- responsibilities-start -->
+| Pass | Module | Responsibility |
+| --- | --- | --- |
+| `ai_enrich` | `pdf_chunker.passes.ai_enrich` |  |
+| `emit_jsonl` | `pdf_chunker.passes.emit_jsonl` |  |
+| `extraction_fallback` | `pdf_chunker.passes.extraction_fallback` |  |
+| `heading_detect` | `pdf_chunker.passes.heading_detect` |  |
+| `list_detect` | `pdf_chunker.passes.list_detect` | List detection pass. |
+| `pdf_parse` | `pdf_chunker.passes.pdf_parse` | Extract PDF blocks while remaining side-effect free. |
+| `split_semantic` | `pdf_chunker.passes.split_semantic` | Split ``page_blocks`` into canonical ``chunks``. |
+| `text_clean` | `pdf_chunker.passes.text_clean` |  |
+<!-- responsibilities-end -->
+
 ## Project Structure for OpenAI Codex Navigation
 
 The codebase follows a modular structure rooted in Unix philosophy (single responsibility, composability via interface boundaries):

--- a/scripts/update_agents_md.py
+++ b/scripts/update_agents_md.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import argparse
+import inspect
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from pdf_chunker.framework import registry
+import pdf_chunker.passes  # ensure registration side effects
+
+START_MARK = "<!-- responsibilities-start -->"
+END_MARK = "<!-- responsibilities-end -->"
+
+
+def _pass_rows() -> Iterable[Tuple[str, str, str]]:
+    reg = registry()
+    doc = lambda o: inspect.getdoc(o) or inspect.getdoc(inspect.getmodule(o)) or ""
+    first = lambda s: s.splitlines()[0] if s else ""
+    return sorted((name, obj.__class__.__module__, first(doc(obj))) for name, obj in reg.items())
+
+
+def _format_table(rows: Iterable[Tuple[str, str, str]]) -> str:
+    header = "| Pass | Module | Responsibility |\n| --- | --- | --- |\n"
+    body = "\n".join(f"| `{n}` | `{m}` | {d} |" for n, m, d in rows)
+    return f"{header}{body}\n"
+
+
+def _inject_table(text: str, table: str) -> str:
+    before, _, rest = text.partition(START_MARK)
+    _, _, after = rest.partition(END_MARK)
+    return f"{before}{START_MARK}\n{table}{END_MARK}{after}"
+
+
+def main(path: Path) -> None:
+    updated = _inject_table(path.read_text(), _format_table(_pass_rows()))
+    path.write_text(updated)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Regenerate responsibilities table in AGENTS.md")
+    parser.add_argument(
+        "--agents-path",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "AGENTS.md",
+        help="Path to AGENTS.md to update",
+    )
+    main(parser.parse_args().agents_path)


### PR DESCRIPTION
## Summary
- add `scripts/update_agents_md.py` to rebuild the Pass Responsibilities table from the registered pipeline passes
- document pass responsibilities in `AGENTS.md` via an auto-generated fenced section

## Testing
- `nox -s lint typecheck tests`


------
https://chatgpt.com/codex/tasks/task_e_68a3998a4e548325b9ddd1b793d932d9