### PR TITLE
feat(passes): normalize pdf parse output

### DIFF
--- a/pdf_chunker/passes/pdf_parse.py
+++ b/pdf_chunker/passes/pdf_parse.py
@@ -1,26 +1,60 @@
 from __future__ import annotations
+from collections.abc import Iterable, Mapping
+from itertools import groupby
+from typing import Any
 
-from collections.abc import Mapping
 from pdf_chunker.framework import Artifact, register
+
+Blocks = Iterable[Mapping[str, Any]]
+
+
+def _page(block: Mapping[str, Any]) -> int | None:
+    page = block.get("source", {}).get("page")
+    return page if isinstance(page, int) else None
+
+
+def _group_blocks_by_page(blocks: Blocks) -> list[dict[str, Any]]:
+    key = _page
+    seq = sorted(blocks, key=lambda b: (key(b) is None, key(b) or 0))
+    return [{"page": page, "blocks": list(group)} for page, group in groupby(seq, key=key)]
+
+
+def _to_page_blocks(blocks: Blocks, source_path: str) -> dict:
+    return {
+        "type": "page_blocks",
+        "source_path": source_path,
+        "pages": _group_blocks_by_page(blocks),
+    }
+
+
+def _meta(meta: dict[str, Any] | None, pages: int) -> dict[str, Any]:
+    base = dict(meta or {})
+    metrics = base.setdefault("metrics", {}).setdefault("pdf_parse", {})
+    metrics["pages"] = pages
+    return base
 
 
 class _PdfParsePass:
-    """Extract PDF blocks while remaining side-effect free."""
+    """Normalize blocks into ``PageBlocks`` without performing IO."""
 
     name = "pdf_parse"
-    input_type = str
-    output_type = list
+    input_type = object
+    output_type = dict
 
     def __call__(self, a: Artifact) -> Artifact:
-        from pdf_chunker import pdf_parsing as _pdf_parsing
-
-        path = str(a.payload)
-        exclude = (a.meta or {}).get("exclude_pages")
-        blocks = _pdf_parsing._legacy_extract_text_blocks_from_pdf(path, exclude)
-        pages = {b.get("source", {}).get("page") for b in blocks if isinstance(b, Mapping)}
-        metrics = {**((a.meta or {}).get("metrics", {})), "pdf_parse": {"pages": len(pages)}}
-        meta = {**(a.meta or {}), "metrics": metrics}
-        return Artifact(payload=blocks, meta=meta)
+        payload = a.payload
+        if isinstance(payload, Mapping) and payload.get("type") == "page_blocks":
+            doc = payload
+        else:
+            blocks = (
+                payload
+                if isinstance(payload, Iterable) and not isinstance(payload, (str, bytes, Mapping))
+                else []
+            )
+            source = (a.meta or {}).get("input") or "<memory>"
+            doc = _to_page_blocks(blocks, str(source))
+        meta = _meta(a.meta, len(doc.get("pages", [])))
+        return Artifact(payload=doc, meta=meta)
 
 
 pdf_parse = register(_PdfParsePass())

--- a/tests/bootstrap/test_registry_sync.py
+++ b/tests/bootstrap/test_registry_sync.py
@@ -16,5 +16,6 @@ def test_registry_expected_keys_subset():
         "split_semantic",
         "ai_enrich",
         "list_detect",
+        "emit_jsonl",
     }
     assert expected <= registry().keys()

--- a/tests/pdf_parse_pass_test.py
+++ b/tests/pdf_parse_pass_test.py
@@ -1,0 +1,23 @@
+import pdf_chunker.pdf_parsing as pdf_parsing
+import pdf_chunker.passes.pdf_parse as pdf_parse_mod
+from pdf_chunker.framework import Artifact
+
+
+def test_pdf_parse_normalizes_blocks(monkeypatch):
+    def boom(*args, **kwargs):
+        raise AssertionError("legacy extractor called")
+
+    monkeypatch.setattr(pdf_parsing, "_legacy_extract_text_blocks_from_pdf", boom)
+
+    blocks = [
+        {"source": {"page": 2}, "text": "two"},
+        {"source": {"page": None}, "text": "none"},
+        {"source": {"page": 1}, "text": "one"},
+    ]
+
+    artifact = Artifact(payload=blocks, meta={"input": "dummy.pdf"})
+    result = pdf_parse_mod.pdf_parse(artifact)
+    expected = pdf_parse_mod._to_page_blocks(blocks, "dummy.pdf")
+
+    assert result.payload == expected
+    assert result.meta["metrics"]["pdf_parse"]["pages"] == len(expected["pages"])


### PR DESCRIPTION
## Summary
- make `pdf_parse` a pure shape normalizer with no legacy extractor dependency
- update regression test to feed in-memory legacy blocks and assert canonical `PageBlocks`

## Testing
- `python -m pdf_chunker.cli inspect`
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`
- `pytest tests/pdf_parse_pass_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3e1305464832581b5d6fa04fe2a74