### PR TITLE
feat: apply block-level text cleaning

### DIFF
--- a/pdf_chunker/passes/text_clean.py
+++ b/pdf_chunker/passes/text_clean.py
@@ -1,29 +1,45 @@
 from __future__ import annotations
 
+from typing import Any, Dict
+
 from pdf_chunker.framework import Artifact, register
 
 
-def clean_text(text: str) -> str:
-    """Pure text normalization wrapper.
+def _clean_block(block: Dict[str, Any]) -> Dict[str, Any]:
+    from pdf_chunker import text_cleaning
 
-    Uses the heavy text_cleaning implementation only when invoked to keep
-    import times lean.
-    """
-    from pdf_chunker.text_cleaning import _clean_text_impl
+    return {**block, "text": text_cleaning.clean_text(block.get("text", ""))}
 
-    return _clean_text_impl(text)
+
+def _clean_page(page: Dict[str, Any]) -> Dict[str, Any]:
+    blocks = (_clean_block(b) for b in page.get("blocks", []))
+    return {**page, "blocks": list(blocks)}
+
+
+def _clean_doc(doc: Dict[str, Any]) -> Dict[str, Any]:
+    pages = (_clean_page(p) for p in doc.get("pages", []))
+    return {**doc, "pages": list(pages)}
 
 
 class _TextCleanPass:
     name = "text_clean"
-    input_type = str
-    output_type = str
+    input_type = object
+    output_type = object
 
     def __call__(self, a: Artifact) -> Artifact:
-        result = clean_text(a.payload)
+        payload = a.payload
+        if isinstance(payload, str):
+            from pdf_chunker.text_cleaning import _clean_text_impl
+
+            cleaned = _clean_text_impl(payload)
+        elif isinstance(payload, dict) and payload.get("type") == "page_blocks":
+            cleaned = _clean_doc(payload)
+        else:
+            return a
+
         meta = dict(a.meta or {})
-        meta.setdefault("metrics", {}).setdefault("text_clean", {})["normalized"] = True
-        return Artifact(payload=result, meta=meta)
+        meta.setdefault("metrics", {})["normalized"] = True
+        return Artifact(payload=cleaned, meta=meta)
 
 
 text_clean = register(_TextCleanPass())

--- a/tests/bootstrap/test_pass_purity.py
+++ b/tests/bootstrap/test_pass_purity.py
@@ -1,10 +1,10 @@
-from pathlib import Path
 import re
+from pathlib import Path
 
 DISALLOWED = re.compile(r"\b(fitz|subprocess|requests|litellm|PyPDF)\b")
+
 
 def test_pass_modules_have_no_io_imports():
     for p in Path("pdf_chunker/passes").glob("*.py"):
         text = p.read_text(encoding="utf-8")
         assert not DISALLOWED.search(text), f"Disallowed import in {p}"
-

--- a/tests/text_cleaning_transform_test.py
+++ b/tests/text_cleaning_transform_test.py
@@ -1,3 +1,16 @@
+from pdf_chunker.framework import Artifact
+from pdf_chunker.passes.text_clean import text_clean
+
+
 def test_text_cleaning_transform(pdf_case):
     raw, func, expected = pdf_case
     assert func(raw).rstrip() == expected
+
+
+def test_text_clean_pass_normalizes_blocks(pdf_case):
+    raw, _, expected = pdf_case
+    doc = {"type": "page_blocks", "pages": [{"page": 1, "blocks": [{"text": raw}]}]}
+    result = text_clean(Artifact(payload=doc))
+    cleaned = result.payload["pages"][0]["blocks"][0]["text"].rstrip()
+    assert cleaned == expected
+    assert result.meta["metrics"]["normalized"] is True


### PR DESCRIPTION
## Summary
- clean each page block via `text_cleaning.clean_text` using generator expressions
- flag normalized metrics during text cleaning pass
- exercise block-level cleaning in tests

## Testing
- `nox -s lint typecheck tests`
- `python -m pdf_chunker.cli inspect`

------
https://chatgpt.com/codex/tasks/task_e_68a48e7bc2488325b55050398940dc2c