### PR TITLE
feat(list-detect): propagate list metadata

### DIFF
--- a/pdf_chunker/passes/split_semantic.py
+++ b/pdf_chunker/passes/split_semantic.py
@@ -51,13 +51,18 @@ def _block_texts(doc: Doc, split_fn: SplitFn) -> Iterator[tuple[int, Block, str]
     )
 
 
+def _list_meta(block: Block) -> dict[str, str]:
+    return (
+        {"list_kind": block["list_kind"]}
+        if block.get("type") == "list_item" and block.get("list_kind")
+        else {}
+    )
+
+
 def _chunk_meta(page: int, block: Block, source: str | None) -> dict[str, Any]:
-    base = {"page": page}
-    if source is not None:
-        base["source"] = source
-    if (block_meta := block.get("meta")) and isinstance(block_meta, dict):
-        base.update(block_meta)
-    return base
+    base = {k: v for k, v in {"page": page, "source": source}.items() if v is not None}
+    block_meta = block.get("meta") if isinstance(block.get("meta"), dict) else {}
+    return {**base, **block_meta, **_list_meta(block)}
 
 
 def _chunk_items(doc: Doc, split_fn: SplitFn) -> Iterator[Chunk]:

--- a/tests/bullet_list_test.py
+++ b/tests/bullet_list_test.py
@@ -4,6 +4,8 @@ sys.path.insert(0, ".")
 
 from pdf_chunker.pdf_parsing import extract_text_blocks_from_pdf
 from pdf_chunker.chunk_validation import validate_chunks
+from pdf_chunker.framework import Artifact
+from pdf_chunker.passes.list_detect import list_detect
 
 
 def test_bullet_list_preservation():
@@ -25,3 +27,12 @@ def test_bullet_list_preservation():
     assert "•\n\n•" not in blob
     assert "\n\nswamp" not in blob
     assert "swamp\n\nFollow" in blob
+
+
+def test_bullet_items_annotated_with_list_kind():
+    doc = {
+        "type": "page_blocks",
+        "pages": [{"page": 1, "blocks": [{"text": "• item"}, {"text": "plain"}]}],
+    }
+    annotated = list_detect(Artifact(payload=doc)).payload["pages"][0]["blocks"]
+    assert [b.get("list_kind") for b in annotated] == ["bullet", None]

--- a/tests/numbered_list_chunk_test.py
+++ b/tests/numbered_list_chunk_test.py
@@ -3,6 +3,9 @@ import sys
 sys.path.insert(0, ".")
 
 from pdf_chunker.splitter import semantic_chunker
+from pdf_chunker.framework import Artifact
+from pdf_chunker.passes.list_detect import list_detect
+from pdf_chunker.passes.split_semantic import split_semantic
 
 
 def test_numbered_list_not_split_across_chunks():
@@ -18,3 +21,12 @@ def test_numbered_list_not_split_across_chunks():
     chunk = chunks[0]
     for n in range(1, 5):
         assert str(n) in chunk
+
+
+def test_list_kind_propagates_to_chunk_metadata():
+    doc = {
+        "type": "page_blocks",
+        "pages": [{"page": 1, "blocks": [{"text": "1. first"}]}],
+    }
+    items = split_semantic(list_detect(Artifact(payload=doc))).payload["items"]
+    assert items[0]["meta"]["list_kind"] == "numbered"


### PR DESCRIPTION
## Summary
- annotate page blocks with `list_kind` via new functional list detection pass
- propagate `list_kind` into chunk metadata in split_semantic
- cover bullet and numbered list propagation in tests

## Testing
- `nox -s lint typecheck tests`

------
https://chatgpt.com/codex/tasks/task_e_68a49a55e8a08325bbf06a3573766e1e