### PR TITLE
feat(pass): capture fallback reason and score

### DIFF
--- a/tests/extraction_fallback_pass_test.py
+++ b/tests/extraction_fallback_pass_test.py
@@ -4,7 +4,7 @@ from pdf_chunker.passes.extraction_fallback import extraction_fallback
 
 def test_extraction_fallback_records_metrics(monkeypatch):
     def fake_extract(path: str, reason: str | None):
-        return [{"text": "hello"}]
+        return ([{"text": "hello"}], {"reason": reason, "score": 0.5})
 
     monkeypatch.setattr("pdf_chunker.passes.extraction_fallback._extract", fake_extract)
 
@@ -13,5 +13,4 @@ def test_extraction_fallback_records_metrics(monkeypatch):
 
     assert artifact.meta == {"fallback_reason": "low_quality"}
     metrics = result.meta["metrics"]["extraction_fallback"]
-    assert metrics["reason"] == "low_quality"
-    assert metrics["score"] > 0
+    assert metrics == {"reason": "low_quality", "score": 0.5}


### PR DESCRIPTION
## Summary
- capture fallback reason and quality score from extraction adapters
- verify extraction_fallback pass records metrics in metadata

## Testing
- `nox -s lint typecheck tests`
- `black pdf_chunker/passes/extraction_fallback.py tests/extraction_fallback_pass_test.py`
- `flake8 pdf_chunker/passes/extraction_fallback.py tests/extraction_fallback_pass_test.py`
- `mypy --follow-imports=skip --ignore-missing-imports pdf_chunker/passes/extraction_fallback.py`
- `pytest tests/extraction_fallback_pass_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4abc05a04832594ea89d1f46ee324