### PR TITLE
feat(ai_enrich): add optional client-driven enrichment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This `AGENTS.md` suite provides comprehensive guidance to OpenAI Codex and other
 <!-- responsibilities-start -->
 | Pass | Module | Responsibility |
 | --- | --- | --- |
-| `ai_enrich` | `pdf_chunker.passes.ai_enrich` |  |
+| `ai_enrich` | `pdf_chunker.passes.ai_enrich` | Utterance classification and tag assignment. |
 | `emit_jsonl` | `pdf_chunker.passes.emit_jsonl` |  |
 | `extraction_fallback` | `pdf_chunker.passes.extraction_fallback` |  |
 | `heading_detect` | `pdf_chunker.passes.heading_detect` |  |

--- a/pdf_chunker/adapters/ai_enrich.py
+++ b/pdf_chunker/adapters/ai_enrich.py
@@ -11,6 +11,28 @@ import yaml
 from pdf_chunker.passes.ai_enrich import classify_chunk_utterance
 
 
+class Client:
+    """Simple adapter wrapping ``classify_chunk_utterance`` for the pass."""
+
+    def __init__(
+        self,
+        *,
+        completion_fn: Callable[[str], str],
+        tag_configs: dict | None = None,
+    ) -> None:
+        self._completion_fn = completion_fn
+        self._tag_configs = tag_configs or _load_tag_configs()
+
+    def classify_chunk_utterance(
+        self, text: str, *, tag_configs: dict | None = None
+    ) -> dict:
+        return classify_chunk_utterance(
+            text,
+            tag_configs=tag_configs or self._tag_configs,
+            completion_fn=self._completion_fn,
+        )
+
+
 def _load_tag_configs(config_dir: str = "config/tags") -> dict:
     """Merge YAML tag configurations into a single dictionary."""
     config_path = Path(config_dir)

--- a/tests/ai_enrich_pass_test.py
+++ b/tests/ai_enrich_pass_test.py
@@ -2,15 +2,32 @@ from pdf_chunker.framework import Artifact
 from pdf_chunker.passes.ai_enrich import ai_enrich
 
 
-def _dummy_completion(_: str) -> str:
-    return "Classification: question\nTags: [Technical]"
+class _DummyClient:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def classify_chunk_utterance(self, text: str, *, tag_configs: dict) -> dict:
+        self.calls += 1
+        return {"classification": "question", "tags": ["technical"]}
 
 
-def test_ai_enrich_pass_adds_tags():
+def test_ai_enrich_pass_disabled():
+    client = _DummyClient()
+    chunks = [{"text": "What is AI?"}]
+    meta = {"ai_enrich": {"client": client, "enabled": False}}
+    result = ai_enrich(Artifact(payload=chunks, meta=meta))
+    assert result.payload == chunks
+    assert client.calls == 0
+    assert "ai_enrich" not in (result.meta or {}).get("metrics", {})
+
+
+def test_ai_enrich_pass_enabled_enriches():
+    client = _DummyClient()
     chunks = [{"text": "What is AI?"}]
     meta = {
         "ai_enrich": {
-            "completion_fn": _dummy_completion,
+            "client": client,
+            "enabled": True,
             "tag_configs": {"generic": ["technical"]},
         }
     }
@@ -20,3 +37,4 @@ def test_ai_enrich_pass_adds_tags():
     assert enriched["tags"] == ["technical"]
     assert enriched["metadata"]["tags"] == ["technical"]
     assert result.meta["metrics"]["ai_enrich"]["chunks"] == 1
+    assert client.calls == 1


### PR DESCRIPTION
## Summary
- make AI enrichment pass client-based with enable flag
- add adapter client stub and tests for enabled/disabled modes

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`
- `pytest tests/ai_enrich_pass_test.py`
- `pytest tests/ai_enrichment_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4b0b1ad74832595677271c679ce3f