### PR TITLE
feat: write JSONL output to file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This `AGENTS.md` suite provides comprehensive guidance to OpenAI Codex and other
 | Pass | Module | Responsibility |
 | --- | --- | --- |
 | `ai_enrich` | `pdf_chunker.passes.ai_enrich` | Utterance classification and tag assignment. |
-| `emit_jsonl` | `pdf_chunker.passes.emit_jsonl` |  |
+| `emit_jsonl` | `pdf_chunker.passes.emit_jsonl` | Prepare chunk rows for JSONL output. |
 | `extraction_fallback` | `pdf_chunker.passes.extraction_fallback` |  |
 | `heading_detect` | `pdf_chunker.passes.heading_detect` |  |
 | `list_detect` | `pdf_chunker.passes.list_detect` | List detection pass. |

--- a/pdf_chunker/adapters/emit_jsonl.py
+++ b/pdf_chunker/adapters/emit_jsonl.py
@@ -19,10 +19,9 @@ def _serialize(rows: Iterable[dict[str, Any]]) -> Iterator[str]:
 
 
 def _write(path: str, lines: Iterable[str]) -> None:
-    """Write iterable of lines to ``path`` with trailing newlines."""
+    """Write ``lines`` to ``path`` with trailing newlines."""
     with Path(path).open("w", encoding="utf-8") as f:
-        for line in lines:
-            f.write(f"{line}\n")
+        f.writelines(f"{line}\n" for line in lines)
 
 
 def maybe_write(

--- a/pdf_chunker/passes/emit_jsonl.py
+++ b/pdf_chunker/passes/emit_jsonl.py
@@ -1,22 +1,22 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any
 
 from pdf_chunker.framework import Artifact, register
 
-Row = Dict[str, Any]
-Doc = Dict[str, Any]
+Row = dict[str, Any]
+Doc = dict[str, Any]
 
 
-def _row(item: Dict[str, Any]) -> Row:
+def _row(item: dict[str, Any]) -> Row:
     return {"text": item.get("text", ""), "meta": item.get("meta", {})}
 
 
-def _rows(doc: Doc) -> List[Row]:
+def _rows(doc: Doc) -> list[Row]:
     return [_row(i) for i in doc.get("items", []) if i.get("text")]
 
 
-def _update_meta(meta: Dict[str, Any] | None, count: int) -> Dict[str, Any]:
+def _update_meta(meta: dict[str, Any] | None, count: int) -> dict[str, Any]:
     base = dict(meta or {})
     base.setdefault("metrics", {}).setdefault("emit_jsonl", {})["rows"] = count
     return base

--- a/tests/bootstrap/test_run_convert_adapter.py
+++ b/tests/bootstrap/test_run_convert_adapter.py
@@ -1,31 +1,28 @@
-from pathlib import Path
+import json
 
-import pdf_chunker.pdf_parsing as pdf_parsing
 from pdf_chunker.config import PipelineSpec
 from pdf_chunker.core_new import assemble_report, run_convert, write_run_report
 from pdf_chunker.framework import Artifact
 
 
-def test_run_convert_writes_jsonl(tmp_path, monkeypatch):
-    monkeypatch.setattr(
-        pdf_parsing,
-        "_legacy_extract_text_blocks_from_pdf",
-        lambda path, exclude_pages=None: [],
-    )
+def test_run_convert_writes_jsonl(tmp_path):
     spec = PipelineSpec(
-        pipeline=["pdf_parse", "emit_jsonl"],
+        pipeline=["emit_jsonl"],
         options={
             "emit_jsonl": {"output_path": str(tmp_path / "out.jsonl")},
             "run_report": {"output_path": str(tmp_path / "run_report.json")},
         },
     )
-    pdf_path = Path("test_data") / "sample_test.pdf"
-    artifact = Artifact(payload=str(pdf_path), meta={"metrics": {}, "input": str(pdf_path)})
+    doc = {"type": "chunks", "items": [{"text": "a"}, {"text": "b"}]}
+    artifact = Artifact(payload=doc, meta={"metrics": {}, "input": "doc.pdf"})
     artifact, timings = run_convert(artifact, spec)
     report = assemble_report(timings, artifact.meta or {})
     write_run_report(spec, report)
+
     out_file = tmp_path / "out.jsonl"
+    lines = out_file.read_text(encoding="utf-8").splitlines()
+    expected = [json.dumps(r, ensure_ascii=False) for r in artifact.payload]
+    assert lines == expected
+
     report_file = tmp_path / "run_report.json"
-    assert out_file.exists()
     assert report_file.exists()
-    assert artifact.meta.get("input") == str(pdf_path)


### PR DESCRIPTION
## Summary
- emit_jsonl adapter writes JSON lines to a file when `output_path` is set
- emit_jsonl pass produces row data and updates row metrics for adapters
- test ensures JSONL file content matches emitted rows

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68a4b535de5483259d2e6da3f2ad501a