### PR TITLE
feat(core): add convert helper and CLI wiring

### DIFF
--- a/pdf_chunker/adapters/emit_jsonl.py
+++ b/pdf_chunker/adapters/emit_jsonl.py
@@ -24,6 +24,14 @@ def _write(path: str, lines: Iterable[str]) -> None:
         f.writelines(f"{line}\n" for line in lines)
 
 
+def write(rows: Iterable[dict[str, Any]], options: dict[str, Any]) -> None:
+    """Write ``rows`` to JSONL when ``output_path`` is configured."""
+    out_path = options.get("output_path")
+    if not out_path:
+        return
+    _write(out_path, _serialize(rows))
+
+
 def maybe_write(
     artifact: Artifact, options: dict[str, Any], timings: dict[str, float] | None = None
 ) -> None:


### PR DESCRIPTION
## Summary
- add `convert` helper to run pure passes based on input adapter
- wire CLI to use new convert and JSONL writer
- expose `emit_jsonl.write` for persisting rows

## Testing
- `nox -s lint typecheck tests`

------
https://chatgpt.com/codex/tasks/task_e_68a4c706e1f88325af3775ee4b46c146