### PR TITLE
feat(core): enforce pipeline invariants

### DIFF
--- a/pdf_chunker/core_new.py
+++ b/pdf_chunker/core_new.py
@@ -49,8 +49,12 @@ def _ensure_pdf_epub_separation(steps: Sequence[str], ext: str) -> None:
 def _enforce_invariants(spec: PipelineSpec, *, input_path: str) -> list[str]:
     """Return validated steps while enforcing order and media-type invariants."""
     steps = list(spec.pipeline)
-    _ensure_clean_precedes_split(steps)
-    _ensure_pdf_epub_separation(steps, Path(input_path).suffix.lower())
+    ext = Path(input_path).suffix.lower()
+    validators = (
+        _ensure_clean_precedes_split,
+        lambda s: _ensure_pdf_epub_separation(s, ext),
+    )
+    tuple(v(steps) for v in validators)
     return _pass_steps(spec)
 
 

--- a/tests/bootstrap/test_invariants.py
+++ b/tests/bootstrap/test_invariants.py
@@ -1,0 +1,32 @@
+from collections.abc import Callable
+from functools import reduce
+
+import pytest
+
+from pdf_chunker.config import PipelineSpec
+from pdf_chunker.core_new import _enforce_invariants
+
+
+def _add(step: str) -> Callable[[PipelineSpec], PipelineSpec]:
+    return lambda spec: PipelineSpec(pipeline=[*spec.pipeline, step])
+
+
+def _build_pipeline(*steps: str) -> PipelineSpec:
+    return reduce(lambda spec, s: _add(s)(spec), steps, PipelineSpec(pipeline=[]))
+
+
+def test_valid_pipeline() -> None:
+    spec = _build_pipeline("pdf_parse", "text_clean", "split_semantic")
+    _enforce_invariants(spec, input_path="dummy.pdf")
+
+
+def test_split_requires_clean() -> None:
+    spec = _build_pipeline("split_semantic", "text_clean")
+    with pytest.raises(ValueError):
+        _enforce_invariants(spec, input_path="dummy.pdf")
+
+
+def test_media_mixing_rejected() -> None:
+    spec = _build_pipeline("pdf_parse", "epub_parse")
+    with pytest.raises(ValueError):
+        _enforce_invariants(spec, input_path="dummy.pdf")


### PR DESCRIPTION
## Summary
- ensure pipeline checks enforce text cleaning before splitting and disallow mixing PDF/EPUB passes
- add bootstrap tests covering valid and invalid pipeline compositions

## Testing
- `nox -s lint typecheck tests`

------
https://chatgpt.com/codex/tasks/task_e_68a4c9b42b4483259dbf2ada63484452