### PR TITLE
feat: emit run report from run_convert

### DIFF
--- a/tests/bootstrap/test_run_report.py
+++ b/tests/bootstrap/test_run_report.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pdf_chunker.pdf_parsing as pdf_parsing
 from pdf_chunker.config import PipelineSpec
-from pdf_chunker.core_new import assemble_report, run_convert, write_run_report
+from pdf_chunker.core_new import run_convert
 from pdf_chunker.framework import Artifact
 
 
@@ -21,9 +21,8 @@ def test_run_report_emitted(tmp_path, monkeypatch):
     )
     pdf_path = Path("test_data") / "sample_test.pdf"
     artifact = Artifact(payload=str(pdf_path), meta={"metrics": {}, "input": str(pdf_path)})
-    artifact, timings = run_convert(artifact, spec)
-    report = assemble_report(timings, artifact.meta or {})
-    write_run_report(spec, report)
+    run_convert(artifact, spec)
     report_file = tmp_path / "run_report.json"
+    assert report_file.exists()
     data = json.loads(report_file.read_text())
     assert set(data) == {"timings", "metrics", "warnings"}


### PR DESCRIPTION
## Summary
- write run report via adapter at end of `run_convert`
- test run report creation

## Testing
- `nox -s lint typecheck tests`

------
https://chatgpt.com/codex/tasks/task_e_68a4d28596d48325b9e465ef4ef6609d