### PR TITLE
Add EPUB IO adapter and basic test

### DIFF
--- a/pdf_chunker/adapters/io_epub.py
+++ b/pdf_chunker/adapters/io_epub.py
@@ -1,22 +1,15 @@
+"""EPUB IO adapter returning canonical PageBlocks."""
+
 from __future__ import annotations
 
-from functools import partial
 from itertools import groupby
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
 
-# heavy epub parsing imports deferred to runtime to avoid expensive deps
 
+def _page_key(mapping: Dict[str, int], block: Dict[str, Any]) -> int:
+    """Resolve spine index for grouping."""
 
-def _spine_map(path: str) -> Dict[str, int]:
-    """Map spine locations to their 1-based indices."""
-    from pdf_chunker.epub_parsing import list_epub_spines
-
-    return {item["filename"]: item["index"] for item in list_epub_spines(path)}
-
-
-def _spine_key(block: Dict[str, Any], mapping: Dict[str, int]) -> int:
-    """Spine index for grouping; defaults to 0 when missing."""
     location = block.get("source", {}).get("location", "")
     return mapping.get(location, 0)
 
@@ -24,26 +17,49 @@ def _spine_key(block: Dict[str, Any], mapping: Dict[str, int]) -> int:
 def _group_blocks(
     blocks: Iterable[Dict[str, Any]], mapping: Dict[str, int]
 ) -> List[Dict[str, Any]]:
-    """Group blocks by spine index in ascending order."""
-    key = partial(_spine_key, mapping=mapping)
-    sorted_blocks = sorted(blocks, key=key)
+    """Group blocks by computed spine index."""
+
+    key = lambda blk: _page_key(mapping, blk)
     return [
         {"page": page, "blocks": list(group)}
-        for page, group in groupby(sorted_blocks, key)
+        for page, group in groupby(sorted(blocks, key=key), key)
     ]
 
 
-def _extract_blocks(path: str, exclude_spines: str | None) -> List[Dict[str, Any]]:
-    from pdf_chunker.epub_parsing import extract_text_blocks_from_epub
+def _excluded_spines(spec: str | None, total: int, filename: str) -> set[int]:
+    """Parse and validate spine exclusion specification."""
 
-    return extract_text_blocks_from_epub(path, exclude_spines=exclude_spines)
+    if not spec:
+        return set()
+    try:
+        from pdf_chunker.page_utils import parse_page_ranges, validate_page_exclusions
+
+        return validate_page_exclusions(parse_page_ranges(spec), total, filename)
+    except ValueError:
+        return set()
 
 
-def read(path: str, exclude_pages: str | None = None) -> Dict[str, Any]:
-    """Return a page_blocks document for the given EPUB."""
-    abs_path = str(Path(path))
-    blocks = _extract_blocks(abs_path, exclude_pages)
-    mapping = _spine_map(abs_path)
+def read_epub(path: str, spine: str | None = None) -> Dict[str, Any]:
+    """Load an EPUB file and emit grouped PageBlocks."""
+
+    import ebooklib
+    from ebooklib import epub
+    from pdf_chunker.epub_parsing import process_epub_item
+
+    abs_path = str(Path(path).resolve())
+    book = epub.read_epub(abs_path)
+    filename = Path(abs_path).name
+    spine_items = list(book.get_items_of_type(ebooklib.ITEM_DOCUMENT))
+    mapping = {item.get_name(): idx for idx, item in enumerate(spine_items, 1)}
+    excluded = _excluded_spines(spine, len(spine_items), filename)
+
+    blocks = [
+        block
+        for idx, item in enumerate(spine_items, 1)
+        if idx not in excluded
+        for block in process_epub_item(item, filename)
+    ]
+
     return {
         "type": "page_blocks",
         "source_path": abs_path,
@@ -53,13 +69,5 @@ def read(path: str, exclude_pages: str | None = None) -> Dict[str, Any]:
 
 def describe_epub(path: str) -> Dict[str, str]:
     """Return a lightweight descriptor for an EPUB file."""
-    return {
-        "type": "epub_document",
-        "source_path": str(Path(path).resolve()),
-    }
 
-
-def read_epub(path: str, spine: str | None = None) -> Dict[str, Any]:
-    """Compatibility wrapper around :func:`read`."""
-    return read(path, exclude_pages=spine)
-
+    return {"type": "epub_document", "source_path": str(Path(path).resolve())}

--- a/tests/io_epub_adapter_test.py
+++ b/tests/io_epub_adapter_test.py
@@ -1,0 +1,52 @@
+"""Tests for the EPUB IO adapter."""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+def _create_minimal_epub(path: Path) -> Path:
+    container = (
+        "<?xml version='1.0' encoding='UTF-8'?>"
+        "<container version='1.0' xmlns='urn:oasis:names:tc:opendocument:xmlns:container'>"
+        "<rootfiles><rootfile full-path='OEBPS/content.opf'"
+        " media-type='application/oebps-package+xml'/></rootfiles></container>"
+    )
+    content_opf = (
+        "<?xml version='1.0' encoding='UTF-8'?>"
+        "<package version='3.0' xmlns='http://www.idpf.org/2007/opf'"
+        " unique-identifier='uid'>"
+        "<metadata xmlns:dc='http://purl.org/dc/elements/1.1/'>"
+        "<dc:identifier id='uid'>1</dc:identifier></metadata>"
+        "<manifest><item id='chap' href='chapter.xhtml'"
+        " media-type='application/xhtml+xml'/></manifest>"
+        "<spine><itemref idref='chap'/></spine></package>"
+    )
+    chapter = (
+        "<?xml version='1.0' encoding='UTF-8'?>"
+        "<html xmlns='http://www.w3.org/1999/xhtml'><body><p>Hello world</p>"
+        "</body></html>"
+    )
+    with zipfile.ZipFile(path, "w") as epub:
+        epub.writestr("mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED)
+        epub.writestr("META-INF/container.xml", container)
+        epub.writestr("OEBPS/content.opf", content_opf)
+        epub.writestr("OEBPS/chapter.xhtml", chapter)
+    return path
+
+
+pytest.importorskip("ebooklib")
+
+
+def test_read_epub_adapter(tmp_path: Path) -> None:
+    from pdf_chunker.adapters.io_epub import read_epub
+
+    epub_path = _create_minimal_epub(tmp_path / "sample.epub")
+    doc = read_epub(str(epub_path))
+    assert doc["type"] == "page_blocks"
+    pages = doc["pages"]
+    assert len(pages) == 1
+    assert pages[0]["blocks"][0]["text"] == "Hello world"


### PR DESCRIPTION
## Summary
- implement `read_epub` adapter that reads EPUB files into PageBlocks
- add minimal adapter test creating an in-memory EPUB

## Testing
- `black pdf_chunker/adapters/io_epub.py tests/io_epub_adapter_test.py`
- `flake8 pdf_chunker/adapters/io_epub.py tests/io_epub_adapter_test.py`
- `mypy pdf_chunker/` *(fails: Need type annotation for "merged")*
- `bash scripts/validate_chunks.sh output_chunks.json` *(fails: No chunks found)*
- `nox -s lint typecheck tests`
- `pytest tests/io_epub_adapter_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4e5b28e2c8325b183f7ce22962886