### PR TITLE
feat: add jsonl write adapter

### DIFF
--- a/pdf_chunker/adapters/emit_jsonl.py
+++ b/pdf_chunker/adapters/emit_jsonl.py
@@ -24,21 +24,15 @@ def _write(path: str, lines: Iterable[str]) -> None:
         f.writelines(f"{line}\n" for line in lines)
 
 
-def write(rows: Iterable[dict[str, Any]], options: dict[str, Any]) -> None:
-    """Write ``rows`` to JSONL when ``output_path`` is configured."""
-    out_path = options.get("output_path")
-    if not out_path:
+def write(rows: Iterable[dict[str, Any]], path: str | None) -> None:
+    """Write ``rows`` to JSONL at ``path`` when provided."""
+    if not path:
         return
-    _write(out_path, _serialize(rows))
+    _write(path, _serialize(rows))
 
 
 def maybe_write(
     artifact: Artifact, options: dict[str, Any], timings: dict[str, float] | None = None
 ) -> None:
     """Write artifact payload to JSONL if ``output_path`` is specified."""
-    out_path = options.get("output_path")
-    if not out_path:
-        return
-
-    lines = _serialize(_rows(artifact.payload))
-    _write(out_path, lines)
+    write(_rows(artifact.payload), options.get("output_path"))

--- a/pdf_chunker/cli.py
+++ b/pdf_chunker/cli.py
@@ -34,7 +34,7 @@ def convert(
     """Run the configured pipeline on ``input_path``."""
     s = load_spec(spec, overrides=_cli_overrides(out, chunk_size, overlap))
     rows = run_convert(input_path, s)
-    emit_jsonl.write(rows, s.options.get("emit_jsonl", {}))
+    emit_jsonl.write(rows, s.options.get("emit_jsonl", {}).get("output_path"))
     typer.echo("convert: OK")
 
 

--- a/tests/bootstrap/test_emit_jsonl_adapter.py
+++ b/tests/bootstrap/test_emit_jsonl_adapter.py
@@ -1,0 +1,11 @@
+import json
+
+from pdf_chunker.adapters import emit_jsonl
+
+
+def test_write(tmp_path):
+    rows = [{"a": 1}, {"b": 2}]
+    out = tmp_path / "rows.jsonl"
+    emit_jsonl.write(rows, str(out))
+    with out.open() as f:
+        assert [json.loads(line) for line in f.read().splitlines()] == rows


### PR DESCRIPTION
## Summary
- add `write(rows, path)` for JSONL emission
- exercise JSONL adapter with bootstrap test

## Testing
- `nox -s lint typecheck tests`


------
https://chatgpt.com/codex/tasks/task_e_68a4ef6ebb90832594978da160a7ce4f