### PR TITLE
feat: normalize page blocks in text_clean pass

### DIFF
--- a/pdf_chunker/passes/text_clean.py
+++ b/pdf_chunker/passes/text_clean.py
@@ -6,19 +6,25 @@ from pdf_chunker.framework import Artifact, register
 
 
 def _clean_block(block: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a new block with normalized text."""
     from pdf_chunker import text_cleaning
 
-    return {**block, "text": text_cleaning.clean_text(block.get("text", ""))}
+    text = block.get("text", "")
+    return {**block, "text": text_cleaning.clean_text(text)}
 
 
-def _clean_page(page: Dict[str, Any]) -> Dict[str, Any]:
-    blocks = (_clean_block(b) for b in page.get("blocks", []))
-    return {**page, "blocks": list(blocks)}
+def _clean_page(page: Dict[str, Any]) -> tuple[Dict[str, Any], int]:
+    """Clean all blocks in ``page`` and return the block count."""
+    blocks = [_clean_block(b) for b in page.get("blocks", [])]
+    return {**page, "blocks": blocks}, len(blocks)
 
 
-def _clean_doc(doc: Dict[str, Any]) -> Dict[str, Any]:
-    pages = (_clean_page(p) for p in doc.get("pages", []))
-    return {**doc, "pages": list(pages)}
+def _clean_doc(doc: Dict[str, Any]) -> tuple[Dict[str, Any], int]:
+    """Clean document pages and aggregate block metrics."""
+    pages_with_counts = [_clean_page(p) for p in doc.get("pages", [])]
+    pages = [p for p, _ in pages_with_counts]
+    blocks = sum(c for _, c in pages_with_counts)
+    return {**doc, "pages": pages}, blocks
 
 
 class _TextCleanPass:
@@ -28,17 +34,22 @@ class _TextCleanPass:
 
     def __call__(self, a: Artifact) -> Artifact:
         payload = a.payload
+        block_count: int | None = None
+
         if isinstance(payload, str):
             from pdf_chunker.text_cleaning import _clean_text_impl
 
             cleaned = _clean_text_impl(payload)
         elif isinstance(payload, dict) and payload.get("type") == "page_blocks":
-            cleaned = _clean_doc(payload)
+            cleaned, block_count = _clean_doc(payload)
         else:
             return a
 
         meta = dict(a.meta or {})
-        meta.setdefault("metrics", {})["normalized"] = True
+        metrics = meta.setdefault("metrics", {})
+        metrics["normalized"] = True
+        if block_count is not None:
+            metrics.setdefault("text_clean", {})["blocks"] = block_count
         return Artifact(payload=cleaned, meta=meta)
 
 

--- a/tests/text_clean_pass_test.py
+++ b/tests/text_clean_pass_test.py
@@ -1,0 +1,35 @@
+from pdf_chunker.framework import Artifact
+from pdf_chunker.passes.text_clean import text_clean
+
+
+def _build_doc() -> dict:
+    return {
+        "type": "page_blocks",
+        "pages": [
+            {
+                "page": 1,
+                "blocks": [
+                    {"text": "Foo\u00A0bar"},
+                    {"text": "One-\nline"},
+                ],
+            }
+        ],
+    }
+
+
+def test_text_clean_idempotent() -> None:
+    doc = _build_doc()
+    first = text_clean(Artifact(payload=doc))
+    second = text_clean(first)
+    assert second.payload == first.payload
+    assert second.meta == first.meta
+
+
+def test_text_clean_normalizes_blocks() -> None:
+    doc = _build_doc()
+    result = text_clean(Artifact(payload=doc))
+    blocks = [b["text"] for b in result.payload["pages"][0]["blocks"]]
+    assert blocks == ["Foo bar", "Oneline"]
+    metrics = result.meta["metrics"]
+    assert metrics["normalized"] is True
+    assert metrics["text_clean"]["blocks"] == 2


### PR DESCRIPTION
## Summary
- normalize page-block text via functional comprehensions
- record block counts in text_clean metrics
- test text_clean idempotence and block-level normalization

## Testing
- `nox -s lint typecheck tests`

------
https://chatgpt.com/codex/tasks/task_e_68a4f1fdd3a883258c6118feb787e15c