### PR TITLE
feat: expose heading thresholds in pass

### DIFF
--- a/tests/heading_detect_pass_test.py
+++ b/tests/heading_detect_pass_test.py
@@ -1,0 +1,22 @@
+from pdf_chunker.framework import Artifact
+from pdf_chunker.passes.heading_detect import heading_detect
+
+
+def test_heading_pass_hierarchy_and_metrics() -> None:
+    blocks = [
+        {"text": "Chapter 1"},
+        {"text": "Section 1 Overview"},
+        {"text": "Some paragraph text."},
+    ]
+    result = heading_detect(Artifact(payload=blocks, meta={}))
+
+    headings = [b for b in result.payload if b["is_heading"]]
+    assert [h["heading_level"] for h in headings] == [1, 2]
+    assert [h["heading_threshold"] for h in headings] == [3, 3]
+
+    hierarchy = result.meta["heading_hierarchy"]
+    assert [h["text"] for h in hierarchy] == ["Chapter 1", "Section 1 Overview"]
+    assert hierarchy[1]["parent"] == "Chapter 1"
+
+    metrics = result.meta["metrics"]["heading_detect"]
+    assert metrics["headings"] == 2


### PR DESCRIPTION
## Summary
- extend `heading_detect` pass to compute heuristic thresholds and expose `heading_threshold` metadata
- add regression test validating heading hierarchy and metrics

## Testing
- `nox -s lint typecheck tests`
- `mypy pdf_chunker/passes/heading_detect.py` *(fails: Missing type parameters in unrelated modules)*
- `mypy --follow-imports=skip pdf_chunker/passes/heading_detect.py`
- `pytest tests/heading_detect_pass_test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4f7e42f088325ac7c84183b57cb5b