### PR TITLE
feat: add list detection metrics helper and tests

### DIFF
--- a/pdf_chunker/passes/list_detect.py
+++ b/pdf_chunker/passes/list_detect.py
@@ -24,9 +24,7 @@ def starts_with_bullet(text: str) -> bool:
     """Return True if ``text`` begins with a bullet marker or hyphen bullet."""
 
     stripped = text.lstrip()
-    return stripped.startswith(tuple(BULLET_CHARS)) or stripped.startswith(
-        HYPHEN_BULLET_PREFIX
-    )
+    return stripped.startswith(tuple(BULLET_CHARS)) or stripped.startswith(HYPHEN_BULLET_PREFIX)
 
 
 def _last_non_empty_line(text: str) -> str:
@@ -130,14 +128,17 @@ def _annotate_page(page: Dict[str, Any]) -> Dict[str, Any]:
     return {**page, "blocks": _annotate_blocks(page.get("blocks", []))}
 
 
-def _annotate_doc(doc: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, int]]:
-    pages = [_annotate_page(p) for p in doc.get("pages", [])]
-    blocks = [b for p in pages for b in p.get("blocks", [])]
-    counts = {
+def _count_kinds(blocks: Iterable[Block]) -> Dict[str, int]:
+    return {
         "bullet_items": sum(b.get("list_kind") == "bullet" for b in blocks),
         "numbered_items": sum(b.get("list_kind") == "numbered" for b in blocks),
     }
-    return {**doc, "pages": pages}, counts
+
+
+def _annotate_doc(doc: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, int]]:
+    pages = [_annotate_page(p) for p in doc.get("pages", [])]
+    blocks = [b for p in pages for b in p.get("blocks", [])]
+    return {**doc, "pages": pages}, _count_kinds(blocks)
 
 
 class _ListDetectPass:

--- a/tests/list_detect_pass_test.py
+++ b/tests/list_detect_pass_test.py
@@ -1,0 +1,26 @@
+from pdf_chunker.framework import Artifact
+from pdf_chunker.passes.list_detect import list_detect
+
+
+def _run(blocks):
+    doc = {"type": "page_blocks", "pages": [{"page": 1, "blocks": blocks}]}
+    result = list_detect(Artifact(payload=doc))
+    page_blocks = result.payload["pages"][0]["blocks"]
+    metrics = result.meta["metrics"]["list_detect"]
+    return page_blocks, metrics
+
+
+def test_bullet_items_annotated_and_counted():
+    blocks = [{"text": "• a"}, {"text": "• b"}, {"text": "plain"}]
+    annotated, metrics = _run(blocks)
+    assert [b.get("list_kind") for b in annotated] == ["bullet", "bullet", None]
+    assert [b.get("type") for b in annotated][:2] == ["list_item", "list_item"]
+    assert metrics == {"bullet_items": 2, "numbered_items": 0}
+
+
+def test_numbered_items_annotated_and_counted():
+    blocks = [{"text": "1. a."}, {"text": "2. b."}, {"text": "end"}]
+    annotated, metrics = _run(blocks)
+    assert [b.get("list_kind") for b in annotated] == ["numbered", "numbered", None]
+    assert [b.get("type") for b in annotated][:2] == ["list_item", "list_item"]
+    assert metrics == {"bullet_items": 0, "numbered_items": 2}


### PR DESCRIPTION
## Summary
- add `_count_kinds` helper to list detection pass and propagate metrics
- test bullet and numbered list annotation and metrics

## Testing
- `flake8 pdf_chunker/passes/list_detect.py tests/list_detect_pass_test.py`
- `mypy pdf_chunker/passes/list_detect.py` *(fails: Missing type parameters; reduce arg-type)*
- `bash scripts/validate_chunks.sh tests/golden/expected/pdf.jsonl`
- `pytest tests/list_detect_pass_test.py -q`
- `pytest tests -q` *(fails: TypeError in list_detection_edge_case_test)*
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68a4fc036c888325b3f41986f70ccb94