### PR TITLE
feat: add extraction fallback metrics

### DIFF
--- a/pdf_chunker/passes/extraction_fallback.py
+++ b/pdf_chunker/passes/extraction_fallback.py
@@ -8,10 +8,14 @@ Block = dict[str, Any]
 
 
 def _blocks_doc(blocks: list[Block], source: str) -> dict[str, Any]:
+    """Package ``blocks`` with their originating ``source`` path."""
+
     return {"type": "blocks", "blocks": blocks, "source_path": source}
 
 
 def _score(blocks: list[Block]) -> float:
+    """Calculate a quality score for ``blocks`` using text assessment."""
+
     from pdf_chunker.extraction_fallbacks import _assess_text_quality
 
     text = "\n".join(b.get("text", "") for b in blocks)
@@ -19,11 +23,15 @@ def _score(blocks: list[Block]) -> float:
 
 
 def _metrics(reason: str | None, blocks: list[Block]) -> dict[str, Any]:
-    metrics: dict[str, Any] = {"score": _score(blocks)}
+    """Return fallback metrics combining ``reason`` and quality ``score``."""
+
+    metrics = {"score": _score(blocks)}
     return metrics if reason is None else {**metrics, "reason": reason}
 
 
 def _extract(path: str, reason: str | None) -> tuple[list[Block], dict[str, Any]]:
+    """Run fallback extraction for ``path`` and compute metrics."""
+
     from pdf_chunker.extraction_fallbacks import execute_fallback_extraction
 
     blocks = execute_fallback_extraction(path, fallback_reason=reason)

--- a/tests/extraction_fallback_pass_test.py
+++ b/tests/extraction_fallback_pass_test.py
@@ -2,15 +2,24 @@ from pdf_chunker.framework import Artifact
 from pdf_chunker.passes.extraction_fallback import extraction_fallback
 
 
-def test_extraction_fallback_records_metrics(monkeypatch):
-    def fake_extract(path: str, reason: str | None):
-        return ([{"text": "hello"}], {"reason": reason, "score": 0.5})
-
-    monkeypatch.setattr("pdf_chunker.passes.extraction_fallback._extract", fake_extract)
+def test_extraction_fallback_records_reason_and_score(monkeypatch):
+    monkeypatch.setattr(
+        "pdf_chunker.extraction_fallbacks.execute_fallback_extraction",
+        lambda path, fallback_reason=None: [{"text": "hello"}],
+    )
+    monkeypatch.setattr(
+        "pdf_chunker.extraction_fallbacks._assess_text_quality",
+        lambda text: {"quality_score": 0.5},
+    )
 
     artifact = Artifact(payload={"source_path": "dummy"}, meta={"fallback_reason": "low_quality"})
     result = extraction_fallback(artifact)
 
     assert artifact.meta == {"fallback_reason": "low_quality"}
+    assert result.payload == {
+        "type": "blocks",
+        "blocks": [{"text": "hello"}],
+        "source_path": "dummy",
+    }
     metrics = result.meta["metrics"]["extraction_fallback"]
     assert metrics == {"reason": "low_quality", "score": 0.5}


### PR DESCRIPTION
## Summary
- compute quality score and optional fallback reason for extraction fallback
- merge fallback metrics into artifact meta
- test metric propagation

## Testing
- `nox -s lint typecheck tests`


------
https://chatgpt.com/codex/tasks/task_e_68a51f25cd408325b8b7495de6636388