### PR TITLE
Add golden PDF snapshot test

### DIFF
--- a/tests/golden/expected/tiny.jsonl
+++ b/tests/golden/expected/tiny.jsonl
@@ -1,0 +1,1 @@
+{"metadata": {"block_type": "paragraph", "chunk_id": "tiny.pdf_p1_c0", "importance": "medium", "language": "it", "location": null, "page": 1, "readability": {"difficulty": "college_level", "flesch_kincaid_grade": 14.690000000000001}, "source": "tiny.pdf", "utterance_type": {"classification": "disabled", "tags": []}}, "text": "Hello, PDF!"}

--- a/tests/golden/samples/tiny.pdf
+++ b/tests/golden/samples/tiny.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R>> >> >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT /F1 24 Tf 100 100 Td (Hello, PDF!) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000115 00000 n 
+0000000244 00000 n 
+0000000333 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+380
+%%EOF

--- a/tests/golden/test_golden_pdf.py
+++ b/tests/golden/test_golden_pdf.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pdf_chunker.text_cleaning as tc
+from pdf_chunker.core import process_document
+
+BASE_DIR = Path(__file__).resolve().parent
+
+
+def _jsonl(chunks: list[dict[str, object]]) -> str:
+    """Serialize chunks into stable JSONL."""
+    return "\n".join(json.dumps(c, sort_keys=True) for c in chunks)
+
+
+def test_golden_pdf(file_regression, monkeypatch) -> None:
+    monkeypatch.setattr(tc, "clean_text", lambda text: text)
+    path = BASE_DIR / "samples" / "tiny.pdf"
+    chunks = process_document(
+        str(path),
+        chunk_size=1000,
+        overlap=0,
+        generate_metadata=True,
+        ai_enrichment=False,
+    )
+    expected = BASE_DIR / "expected" / "tiny.jsonl"
+    file_regression.check(_jsonl(chunks), fullpath=expected, encoding="utf-8")


### PR DESCRIPTION
## Summary
- add tiny PDF fixture and expected JSONL snapshot
- verify PDF conversion output using regression test

## Testing
- `black tests/golden/test_golden_pdf.py`
- `flake8 tests/golden/test_golden_pdf.py`
- `nox -s lint typecheck tests`


------
https://chatgpt.com/codex/tasks/task_e_68a52a62d5f8832598f2cbb4fc56a962