### PR TITLE
Add CLI smoke test

### DIFF
--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""E2E tests package enabling discovery."""

--- a/tests/e2e/test_cli_smoke.py
+++ b/tests/e2e/test_cli_smoke.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import base64
+import subprocess
+from pathlib import Path
+from shutil import which
+
+import pytest
+
+# Skip if heavy PDF dependency or CLI is missing
+pytest.importorskip("fitz")
+if which("pdf_chunker") is None:
+    pytest.skip("pdf_chunker CLI not installed", allow_module_level=True)
+
+
+def _materialize_sample_pdf() -> Path:
+    """Ensure the sample PDF exists by decoding its base64 form."""
+    samples_dir = Path("tests/golden/samples")
+    pdf_path = samples_dir / "sample.pdf"
+    if not pdf_path.exists():
+        b64_path = samples_dir / "sample.pdf.b64"
+        pdf_path.write_bytes(base64.b64decode(b64_path.read_text()))
+    return pdf_path
+
+
+def test_cli_smoke() -> None:
+    pdf_path = _materialize_sample_pdf()
+    out_path = Path("tmp.jsonl")
+    if out_path.exists():
+        out_path.unlink()
+    result = subprocess.run(
+        [
+            "pdf_chunker",
+            "convert",
+            str(pdf_path),
+            "--out",
+            str(out_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    try:
+        assert result.returncode == 0
+        assert out_path.exists()
+    finally:
+        out_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- add e2e smoke test for `pdf_chunker convert` CLI
- ensure tests/e2e package is discoverable

## Testing
- `black tests/e2e/test_cli_smoke.py`
- `flake8 tests/e2e/test_cli_smoke.py`
- `mypy pdf_chunker/ | tail -n 5`
- `pytest tests/e2e/test_cli_smoke.py`
- `nox -s lint typecheck tests`


------
https://chatgpt.com/codex/tasks/task_e_68a532c66ea08325ae6e648f73565d27