### PR TITLE
chore: add AGENTS pass table updater

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,18 +6,18 @@ This `AGENTS.md` suite provides comprehensive guidance to OpenAI Codex and other
 
 ## Pass Responsibilities
 
-<!-- responsibilities-start -->
+<!-- BEGIN AUTO-PASSES -->
 | Pass | Module | Responsibility |
 | --- | --- | --- |
-| `ai_enrich` | `pdf_chunker.passes.ai_enrich` | Utterance classification and tag assignment. |
-| `emit_jsonl` | `pdf_chunker.passes.emit_jsonl` | Prepare chunk rows for JSONL output. |
+| `ai_enrich` | `pdf_chunker.passes.ai_enrich` |  |
+| `emit_jsonl` | `pdf_chunker.passes.emit_jsonl` |  |
 | `extraction_fallback` | `pdf_chunker.passes.extraction_fallback` |  |
 | `heading_detect` | `pdf_chunker.passes.heading_detect` |  |
 | `list_detect` | `pdf_chunker.passes.list_detect` | List detection pass. |
-| `pdf_parse` | `pdf_chunker.passes.pdf_parse` | Extract PDF blocks while remaining side-effect free. |
+| `pdf_parse` | `pdf_chunker.passes.pdf_parse` |  |
 | `split_semantic` | `pdf_chunker.passes.split_semantic` | Split ``page_blocks`` into canonical ``chunks``. |
 | `text_clean` | `pdf_chunker.passes.text_clean` |  |
-<!-- responsibilities-end -->
+<!-- END AUTO-PASSES -->
 
 ## Project Structure for OpenAI Codex Navigation
 


### PR DESCRIPTION
## Summary
- add `update_agents_md` script to regenerate the pass table in AGENTS.md
- fence AGENTS.md pass table with `<!-- BEGIN AUTO-PASSES -->` markers and refresh the content

## Testing
- `black --check pdf_chunker/ scripts/ tests/` *(fails: would reformat many files)*
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: W391, E704, W504)*
- `mypy pdf_chunker/` *(fails: many missing type parameters and stub warnings)*
- `bash scripts/validate_chunks.sh output_chunks.json` *(fails: No chunks found)*
- `nox -s lint typecheck tests`

------
https://chatgpt.com/codex/tasks/task_e_68a53648c73c8325aab2a41cf0b043e1