### PR TITLE
tests: add tiny pdf fixtures

### DIFF
--- a/tests/golden/samples/tiny_a.pdf
+++ b/tests/golden/samples/tiny_a.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R>> >> >>
+endobj
+4 0 obj
+<< /Length 38 >>
+stream
+BT /F1 24 Tf 100 100 Td (Tiny A) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+0000000240 00000 n
+0000000328 00000 n
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+398
+%%EOF

--- a/tests/golden/samples/tiny_b.pdf
+++ b/tests/golden/samples/tiny_b.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R>> >> >>
+endobj
+4 0 obj
+<< /Length 38 >>
+stream
+BT /F1 24 Tf 100 100 Td (Tiny B) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+0000000240 00000 n
+0000000328 00000 n
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+398
+%%EOF


### PR DESCRIPTION
## Summary
- add two minimal PDF samples to expand golden test coverage

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68a53b5c94f88325a96bd2b966fe519a