### PR TITLE
feat: add parity runner

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -11,6 +11,7 @@ Please, keep this file up-to-date with the latest code structure. If you notice 
 - `validate_chunks.sh`: Semantic and size checks.
 - `detect_duplicates.py`: Overlap/duplicate analysis.
 - `_apply.sh`: Batch orchestration.
+- `parity.py`: Run legacy and new pipelines for comparison.
 
 ## AI Agent Guidance
 - Delegate core logic to library modules.

--- a/scripts/parity.py
+++ b/scripts/parity.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from contextlib import redirect_stdout
+from functools import partial
+from pathlib import Path
+from subprocess import run
+from typing import Callable
+from unittest.mock import patch
+
+from scripts import chunk_pdf
+
+
+def _run_legacy(pdf: Path, out_path: Path) -> Path:
+    argv = ["chunk_pdf.py", str(pdf)]
+    with out_path.open("w", encoding="utf-8") as f, redirect_stdout(f), patch.object(
+        sys, "argv", argv
+    ):
+        chunk_pdf.main()
+    return out_path
+
+
+def _run_new(pdf: Path, out_path: Path) -> Path:
+    run(["pdf_chunker", "convert", str(pdf), "--out", str(out_path)], check=True)
+    return out_path
+
+
+def run_parity(pdf: Path, tmpdir: Path) -> tuple[Path, Path]:
+    tmpdir.mkdir(parents=True, exist_ok=True)
+    runners: tuple[Callable[[], Path], ...] = (
+        partial(_run_legacy, pdf, tmpdir / "legacy.jsonl"),
+        partial(_run_new, pdf, tmpdir / "new.jsonl"),
+    )
+    return tuple(map(lambda fn: fn(), runners))  # type: ignore[return-value]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run legacy and new pipelines")
+    parser.add_argument("pdf", type=Path)
+    parser.add_argument("tmpdir", type=Path)
+    args = parser.parse_args()
+    legacy, new = run_parity(args.pdf, args.tmpdir)
+    for p in (legacy, new):
+        print(p)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/parity.py` to run legacy and new pipelines side by side
- document parity helper in scripts AGENTS

## Testing
- `nox -s lint typecheck tests`
- `pytest tests/bootstrap --confcutdir=tests/bootstrap`


------
https://chatgpt.com/codex/tasks/task_e_68a5ce043f3083258bd19ec45c79ae7f