### PR TITLE
Add flag parity regression test

### DIFF
--- a/scripts/parity.py
+++ b/scripts/parity.py
@@ -6,31 +6,43 @@ from contextlib import redirect_stdout
 from functools import partial
 from pathlib import Path
 from subprocess import run
-from typing import Callable
+from typing import Callable, Sequence
 from unittest.mock import patch
 
 from scripts import chunk_pdf
 
 
-def _run_legacy(pdf: Path, out_path: Path) -> Path:
-    argv = ["chunk_pdf.py", str(pdf)]
-    with out_path.open("w", encoding="utf-8") as f, redirect_stdout(f), patch.object(
-        sys, "argv", argv
+def _run_legacy(pdf: Path, out_path: Path, flags: Sequence[str] = ()) -> Path:
+    argv = ["chunk_pdf.py", str(pdf), *flags]
+    with (
+        out_path.open("w", encoding="utf-8") as f,
+        redirect_stdout(f),
+        patch.object(sys, "argv", argv),
     ):
         chunk_pdf.main()
     return out_path
 
 
-def _run_new(pdf: Path, out_path: Path) -> Path:
-    run(["pdf_chunker", "convert", str(pdf), "--out", str(out_path)], check=True)
+def _run_new(pdf: Path, out_path: Path, flags: Sequence[str] = ()) -> Path:
+    run(
+        [
+            "pdf_chunker",
+            "convert",
+            str(pdf),
+            *flags,
+            "--out",
+            str(out_path),
+        ],
+        check=True,
+    )
     return out_path
 
 
-def run_parity(pdf: Path, tmpdir: Path) -> tuple[Path, Path]:
+def run_parity(pdf: Path, tmpdir: Path, flags: Sequence[str] = ()) -> tuple[Path, Path]:
     tmpdir.mkdir(parents=True, exist_ok=True)
     runners: tuple[Callable[[], Path], ...] = (
-        partial(_run_legacy, pdf, tmpdir / "legacy.jsonl"),
-        partial(_run_new, pdf, tmpdir / "new.jsonl"),
+        partial(_run_legacy, pdf, tmpdir / "legacy.jsonl", flags),
+        partial(_run_new, pdf, tmpdir / "new.jsonl", flags),
     )
     return tuple(map(lambda fn: fn(), runners))  # type: ignore[return-value]
 

--- a/tests/parity/test_e2e_parity.py
+++ b/tests/parity/test_e2e_parity.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from itertools import combinations
+from pathlib import Path
+from typing import Sequence
+
+import pytest
+
+from scripts.parity import run_parity
+from tests.parity.normalize import canonical_rows
+
+SAMPLES = Path("tests/golden/samples")
+PDFS = sorted(SAMPLES.glob("*.pdf"))
+
+
+def _rows(path: Path) -> list[dict]:
+    return [
+        {"text": r.get("text", ""), "metadata": r.get("metadata") or r.get("meta")}
+        for r in canonical_rows(path)
+    ]
+
+
+def _equal(pdf: Path, tmp: Path, flags: Sequence[str]) -> bool:
+    legacy, new = run_parity(pdf, tmp, flags)
+    return _rows(legacy) == _rows(new)
+
+
+def _flag_args() -> dict[str, str | None]:
+    return {
+        "--exclude-pages": "1",
+        "--chunk-size": "200",
+        "--overlap": "10",
+        "--no-metadata": None,
+    }
+
+
+def flag_sets() -> list[tuple[str, ...]]:
+    items = list(_flag_args().items())
+    return [
+        tuple(arg for flag, val in combo for arg in ([flag, val] if val is not None else [flag]))
+        for r in range(len(items) + 1)
+        for combo in combinations(items, r)
+    ]
+
+
+@pytest.mark.parametrize("flags", flag_sets(), ids=lambda f: " ".join(f) or "base")
+def test_e2e_parity_flags(tmp_path: Path, flags: tuple[str, ...]) -> None:
+    assert all(_equal(pdf, tmp_path / f"{i}", flags) for i, pdf in enumerate(PDFS))


### PR DESCRIPTION
## Summary
- allow parity harness to pass through arbitrary CLI flags
- add e2e parity test covering flag combinations like `--exclude-pages` and `--chunk-size`

## Testing
- `black scripts/parity.py tests/parity/test_e2e_parity.py`
- `flake8 scripts/parity.py tests/parity/test_e2e_parity.py`
- `nox -s lint typecheck tests`
- `mypy pdf_chunker` *(fails: Cannot find implementation or library stub for module named "typer")*


------
https://chatgpt.com/codex/tasks/task_e_68a5f5a2a9308325a7488f4400e6ff0d