### PR TITLE
feat: record parity diff on mismatch

### DIFF
--- a/scripts/parity.py
+++ b/scripts/parity.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from contextlib import redirect_stdout
 from functools import partial
 from pathlib import Path
 from subprocess import run
-from typing import Callable, Sequence
+from typing import Any, Callable, Mapping, Sequence
 from unittest.mock import patch
+import difflib
 
 from scripts import chunk_pdf
 
@@ -38,21 +40,65 @@ def _run_new(pdf: Path, out_path: Path, flags: Sequence[str] = ()) -> Path:
     return out_path
 
 
-def run_parity(pdf: Path, tmpdir: Path, flags: Sequence[str] = ()) -> tuple[Path, Path]:
+VOLATILE_FIELDS = frozenset({"timings"})
+
+
+def _load_rows(path: Path) -> list[Mapping[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+def _normalize(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        k: v.strip() if isinstance(v, str) else v
+        for k, v in sorted(row.items())
+        if k not in VOLATILE_FIELDS
+    }
+
+
+def _canonical_lines(path: Path) -> list[str]:
+    return [
+        json.dumps(_normalize(r), sort_keys=True)
+        for r in _load_rows(path)
+    ]
+
+
+def _write_diff(name: str, legacy: Path, new: Path, diffdir: Path) -> None:
+    diffdir.mkdir(parents=True, exist_ok=True)
+    diff = difflib.unified_diff(
+        _canonical_lines(legacy),
+        _canonical_lines(new),
+        fromfile="legacy",
+        tofile="new",
+        lineterm="",
+    )
+    (diffdir / f"{name}.diff").write_text("\n".join(diff), encoding="utf-8")
+
+
+def run_parity(
+    pdf: Path,
+    tmpdir: Path,
+    flags: Sequence[str] = (),
+    diffdir: Path | None = None,
+) -> tuple[Path, Path]:
     tmpdir.mkdir(parents=True, exist_ok=True)
     runners: tuple[Callable[[], Path], ...] = (
         partial(_run_legacy, pdf, tmpdir / "legacy.jsonl", flags),
         partial(_run_new, pdf, tmpdir / "new.jsonl", flags),
     )
-    return tuple(map(lambda fn: fn(), runners))  # type: ignore[return-value]
+    legacy, new = tuple(fn() for fn in runners)
+    if diffdir:
+        _write_diff(pdf.stem, legacy, new, diffdir)
+    return legacy, new
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run legacy and new pipelines")
     parser.add_argument("pdf", type=Path)
     parser.add_argument("tmpdir", type=Path)
+    parser.add_argument("--diffdir", type=Path)
     args = parser.parse_args()
-    legacy, new = run_parity(args.pdf, args.tmpdir)
+    legacy, new = run_parity(args.pdf, args.tmpdir, diffdir=args.diffdir)
     for p in (legacy, new):
         print(p)
 

--- a/tests/parity/pipeline_parity_test.py
+++ b/tests/parity/pipeline_parity_test.py
@@ -6,6 +6,8 @@ from scripts.parity import run_parity
 from tests.parity.normalize import canonical_rows
 
 SAMPLES = Path("tests/golden/samples")
+ARTIFACTS = Path("artifacts/parity")
+ARTIFACTS.mkdir(parents=True, exist_ok=True)
 
 
 def _pdfs() -> list[Path]:
@@ -20,7 +22,7 @@ def _rows(path: Path) -> list[dict]:
 
 
 def _equal(pdf: Path, tmp: Path) -> bool:
-    legacy, new = run_parity(pdf, tmp)
+    legacy, new = run_parity(pdf, tmp, diffdir=ARTIFACTS)
     return _rows(legacy) == _rows(new)
 
 


### PR DESCRIPTION
## Summary
- support optional diff artifact generation in parity runner
- store parity diff artifacts for failing parity tests

## Testing
- `nox -s lint typecheck tests`

------
https://chatgpt.com/codex/tasks/task_e_68a606884f508325b2f015c37faebd69