### PR TITLE
RH1 – Emit run_report.json via CLI

### DIFF
--- a/pdf_chunker/cli.py
+++ b/pdf_chunker/cli.py
@@ -6,9 +6,8 @@ from typing import Any, Dict
 
 import typer
 
-from pdf_chunker.adapters import emit_jsonl
 from pdf_chunker.config import load_spec
-from pdf_chunker.core_new import convert as run_convert, run_inspect
+from pdf_chunker.core_new import _input_artifact, run_convert, run_inspect
 
 app = typer.Typer(add_completion=False, no_args_is_help=True)
 
@@ -30,11 +29,10 @@ def convert(
     chunk_size: int | None = typer.Option(None, "--chunk-size"),
     overlap: int | None = typer.Option(None, "--overlap"),
     spec: str = "pipeline.yaml",
-):
+): 
     """Run the configured pipeline on ``input_path``."""
     s = load_spec(spec, overrides=_cli_overrides(out, chunk_size, overlap))
-    rows = run_convert(input_path, s)
-    emit_jsonl.write(rows, s.options.get("emit_jsonl", {}).get("output_path"))
+    run_convert(_input_artifact(input_path), s)
     typer.echo("convert: OK")
 
 

--- a/tests/scripts_cli_test.py
+++ b/tests/scripts_cli_test.py
@@ -35,6 +35,7 @@ def test_convert_cli_writes_jsonl(tmp_path: Path) -> None:
         capture_output=True,
         text=True,
         env={**os.environ, "PYTHONPATH": "."},
+        cwd=tmp_path,
     )
     assert result.returncode == 0
     rows = [
@@ -43,3 +44,5 @@ def test_convert_cli_writes_jsonl(tmp_path: Path) -> None:
         if line.strip()
     ]
     assert rows
+    report = json.loads((tmp_path / "run_report.json").read_text())
+    assert {"timings", "metrics", "warnings"} <= report.keys()


### PR DESCRIPTION
## Summary
- Load input artifacts in the CLI and delegate conversion to `core_new.run_convert`
- Persist step metrics via `run_report.json`
- Assert the report file exists and includes timings, metrics, and warnings

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68a645f622b8832589c6603e03fd80c4