### PR TITLE
feat: add enrichment toggle

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -3,7 +3,6 @@ pipeline:
   - text_clean
   - heading_detect
   - split_semantic
-  - ai_enrich
   - emit_jsonl
 
 options:
@@ -16,6 +15,7 @@ options:
     target_tokens: 800
     hard_page_boundaries: false
   ai_enrich:
+    enabled: false
     tags_file: "tags.yaml"
   emit_jsonl:
     output_path: "out.jsonl"


### PR DESCRIPTION
## Summary
- add CLI --enrich/--no-enrich flag to control ai_enrich pass
- disable ai_enrich in default config

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`
- `pytest tests/bootstrap`


------
https://chatgpt.com/codex/tasks/task_e_68a6481522e88325ae1dd091e672a24c