### PR TITLE
feat: extend paragraph cleanup helpers

### DIFF
--- a/tests/text_cleaning_transform_test.py
+++ b/tests/text_cleaning_transform_test.py
@@ -1,5 +1,6 @@
 from pdf_chunker.framework import Artifact
 from pdf_chunker.passes.text_clean import text_clean
+from pdf_chunker.text_cleaning import clean_paragraph
 
 
 def test_text_cleaning_transform(pdf_case):
@@ -14,3 +15,22 @@ def test_text_clean_pass_normalizes_blocks(pdf_case):
     cleaned = result.payload["pages"][0]["blocks"][0]["text"].rstrip()
     assert cleaned == expected
     assert result.meta["metrics"]["normalized"] is True
+
+
+def test_clean_paragraph_rejoins_hyphenated_words():
+    assert clean_paragraph("hy-\nphen") == "hyphen"
+
+
+def test_clean_paragraph_strips_headers_and_footers():
+    text = "My Book | 1\ncontent\n1 | My Book"
+    assert clean_paragraph(text) == "content"
+
+
+def test_clean_paragraph_cleans_bullet_fragments():
+    text = "foo\n\u2022\nbar"
+    assert clean_paragraph(text) == "foo bar"
+
+
+def test_clean_paragraph_removes_underscore_wrapping():
+    text = "This is __bold__ and _italics_"
+    assert clean_paragraph(text) == "This is bold and italics"


### PR DESCRIPTION
## Summary
- add functional helpers for hyphen join, header/footer stripping, bullet cleanup, and underscore removal
- wire new helpers into `clean_paragraph`
- test each repair path in `text_cleaning_transform_test`

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68a67b0c31488325907850e08d597379