### PR TITLE
Propagate heading and list metadata to chunk meta

### DIFF
--- a/pdf_chunker/passes/split_semantic.py
+++ b/pdf_chunker/passes/split_semantic.py
@@ -119,18 +119,15 @@ def _merge_headings(
         yield pending
 
 
-def _list_meta(block: Block) -> dict[str, str]:
-    return (
-        {"list_kind": block["list_kind"]}
-        if block.get("type") == "list_item" and block.get("list_kind")
-        else {}
-    )
-
-
 def _chunk_meta(page: int, block: Block, source: str | None) -> dict[str, Any]:
     base = {k: v for k, v in {"page": page, "source": source}.items() if v is not None}
+    attrs = {
+        k: block[k]
+        for k in ("is_heading", "heading_level", "list_kind")
+        if block.get(k) is not None and (k != "list_kind" or block.get("type") == "list_item")
+    }
     block_meta = block.get("meta") if isinstance(block.get("meta"), dict) else {}
-    return {**base, **block_meta, **_list_meta(block)}
+    return {**base, **attrs, **block_meta}
 
 
 def _chunk_items(doc: Doc, split_fn: SplitFn) -> Iterator[Chunk]:

--- a/tests/metadata_propagation_test.py
+++ b/tests/metadata_propagation_test.py
@@ -1,0 +1,34 @@
+import sys
+
+sys.path.insert(0, ".")
+
+from pdf_chunker.framework import Artifact
+from pdf_chunker.passes.heading_detect import heading_detect
+from pdf_chunker.passes.list_detect import list_detect
+from pdf_chunker.passes.split_semantic import split_semantic
+
+
+def test_metadata_propagation() -> None:
+    doc = {
+        "type": "page_blocks",
+        "source_path": "src.pdf",
+        "pages": [
+            {"page": 1, "blocks": [{"text": "1. first"}]},
+            {"page": 2, "blocks": [{"text": "Chapter One"}]},
+        ],
+    }
+    doc["pages"] = [
+        {**p, "blocks": heading_detect(Artifact(payload=p["blocks"])).payload} for p in doc["pages"]
+    ]
+    chunks = split_semantic(list_detect(Artifact(payload=doc))).payload["items"]
+
+    list_meta = chunks[0]["meta"]
+    assert list_meta["list_kind"] == "numbered"
+    assert list_meta["page"] == 1
+    assert list_meta["source"] == "src.pdf"
+
+    heading_meta = chunks[1]["meta"]
+    assert heading_meta["is_heading"] is True
+    assert heading_meta["heading_level"] == 1
+    assert heading_meta["page"] == 2
+    assert heading_meta["source"] == "src.pdf"


### PR DESCRIPTION
## Summary
- ensure chunk metadata retains heading and list annotations alongside page and source
- cover heading/numbered-list metadata propagation end-to-end

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`
- `pytest tests/metadata_propagation_test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a68392dd108325b6e4f422802b173c