### PR TITLE
Expand Nox test session to golden and parity suites

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -31,4 +31,9 @@ def typecheck(session):
 @nox.session
 def tests(session):
     session.install("-e", ".[dev]")
-    session.run("pytest", "-q", "tests/bootstrap", "--confcutdir=tests/bootstrap")
+    paths = (
+        f"tests/{suite}"
+        for suite in ("bootstrap", "golden", "parity")
+        if os.path.exists(f"tests/{suite}")
+    )
+    session.run("pytest", "-q", *paths)


### PR DESCRIPTION
## Summary
- run golden and parity tests in the Nox `tests` session using a generator expression

## Testing
- `nox -R -s lint`
- `nox -R -s typecheck`
- `nox -R -s tests` *(fails: ModuleNotFoundError: No module named 'pkg_resources')*

------
https://chatgpt.com/codex/tasks/task_e_68a71dc316c883258b17b3b453f98b8c