### PR TITLE
refactor: functional pipeline update

### DIFF
--- a/pdf_chunker/cli.py
+++ b/pdf_chunker/cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import typer
 
@@ -17,7 +17,7 @@ def _cli_overrides(
     chunk_size: int | None,
     overlap: int | None,
     enrich: bool,
-) -> Dict[str, Dict[str, Any]]:
+) -> dict[str, dict[str, Any]]:
     split_opts = {
         k: v for k, v in {"chunk_size": chunk_size, "overlap": overlap}.items() if v is not None
     }
@@ -46,11 +46,12 @@ def convert(
     """Run the configured pipeline on ``input_path``."""
     s = load_spec(spec, overrides=_cli_overrides(out, chunk_size, overlap, enrich))
     if enrich:
-        s["pipeline"] = [
+        pipeline = [
             step
-            for p in s["pipeline"]
+            for p in s.pipeline
             for step in (["ai_enrich", "emit_jsonl"] if p == "emit_jsonl" else [p])
         ]
+        s = s.model_copy(update={"pipeline": pipeline})
     run_convert(_input_artifact(input_path), s)
     typer.echo("convert: OK")
 


### PR DESCRIPTION
## Summary
- refactor CLI pipeline enrichment to use functional `model_copy` instead of dict mutation

## Testing
- `nox -s lint`  
- `nox -s typecheck`  
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'haystack')*

------
https://chatgpt.com/codex/tasks/task_e_68a732ce76f08325b339678279dcdeb0