### PR TITLE
test: guard fitz import

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import sys
 import base64
 
-import fitz
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -68,9 +67,8 @@ _CASES = (
 
 @pytest.fixture(params=_CASES, ids=("ligature", "underscore", "hyphenation"))
 def pdf_case(request):
+    fitz = pytest.importorskip("fitz")
     filename, func, expected = request.param
     pdf_bytes = base64.b64decode((_TEST_DATA / filename).read_text())
-    raw = "".join(
-        page.get_text() for page in fitz.open(stream=pdf_bytes, filetype="pdf")
-    )
+    raw = "".join(page.get_text() for page in fitz.open(stream=pdf_bytes, filetype="pdf"))
     return raw, func, expected


### PR DESCRIPTION
## Summary
- skip PDF fixtures when `fitz` is unavailable by guarding the import in `tests/conftest.py`

## Testing
- `black tests/`
- `flake8 tests/`
- `mypy pdf_chunker/` *(fails: Missing type parameters for generic type "set" in `page_utils.py:64` and others)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `nox -s lint typecheck tests` *(fails: ModuleNotFoundError: No module named 'ftfy')*


------
https://chatgpt.com/codex/tasks/task_e_68a7401039408325aabfe2ad641b5909