### PR TITLE
fix(adapter): align io_pdf options and page ordering with legacy

### DIFF
--- a/pdf_chunker/cli.py
+++ b/pdf_chunker/cli.py
@@ -17,18 +17,21 @@ def _cli_overrides(
     chunk_size: int | None,
     overlap: int | None,
     enrich: bool,
+    exclude_pages: str | None,
 ) -> dict[str, dict[str, Any]]:
     split_opts = {
         k: v for k, v in {"chunk_size": chunk_size, "overlap": overlap}.items() if v is not None
     }
     emit_opts = {"output_path": str(out)} if out else {}
     enrich_opts = {"enabled": True} if enrich else {}
+    parse_opts = {"exclude_pages": exclude_pages} if exclude_pages else {}
     return {
         k: v
         for k, v in {
             "split_semantic": split_opts,
             "emit_jsonl": emit_opts,
             "ai_enrich": enrich_opts,
+            "pdf_parse": parse_opts,
         }.items()
         if v
     }
@@ -54,10 +57,14 @@ def convert(
     chunk_size: int | None = typer.Option(None, "--chunk-size"),
     overlap: int | None = typer.Option(None, "--overlap"),
     enrich: bool = typer.Option(False, "--enrich/--no-enrich"),
+    exclude_pages: str | None = typer.Option(None, "--exclude-pages"),
     spec: str = "pipeline.yaml",
 ):
     """Run the configured pipeline on ``input_path``."""
-    s = load_spec(spec, overrides=_cli_overrides(out, chunk_size, overlap, enrich))
+    s = load_spec(
+        spec,
+        overrides=_cli_overrides(out, chunk_size, overlap, enrich, exclude_pages),
+    )
     s = _enrich_spec(s) if enrich else s
     run_convert(_input_artifact(str(input_path)), s)
     typer.echo("convert: OK")

--- a/tests/io_pdf_adapter_test.py
+++ b/tests/io_pdf_adapter_test.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 pytest.importorskip("fitz")
@@ -7,10 +8,30 @@ from pdf_chunker.adapters.io_pdf import read
 
 def test_read_returns_page_blocks():
     doc = read("test_data/sample_test.pdf")
+    pages = [p["page"] for p in doc["pages"]]
     assert doc["type"] == "page_blocks"
-    assert doc["pages"] and doc["pages"][0]["page"] == 1
+    assert pages == sorted(pages)
 
 
 def test_exclude_pages_list():
     doc = read("test_data/sample_test.pdf", exclude_pages=[1])
     assert all(p["page"] != 1 for p in doc["pages"])
+
+
+def test_use_pymupdf4llm_env(monkeypatch):
+    captured = {}
+
+    def fake_extract(path, exclude):
+        captured["env"] = os.getenv("PDF_CHUNKER_USE_PYMUPDF4LLM")
+        return [{"source": {"page": 1, "index": 0}}]
+
+    monkeypatch.setenv("PDF_CHUNKER_USE_PYMUPDF4LLM", "0")
+    monkeypatch.setattr(
+        "pdf_chunker.pdf_parsing.extract_text_blocks_from_pdf", fake_extract
+    )
+
+    read("test_data/sample_test.pdf", use_pymupdf4llm=True)
+
+    assert captured["env"] == "1"
+    assert os.getenv("PDF_CHUNKER_USE_PYMUPDF4LLM") == "0"
+


### PR DESCRIPTION
## Summary
- sort PDF blocks deterministically before grouping by page
- pipe exclude-pages and PyMuPDF4LLM flags directly into the adapter
- expose `--exclude-pages` flag via `pdf_chunker convert` CLI

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: tests/parity/test_e2e_parity.py::test_e2e_parity_flags[--exclude-pages 1] - FileNotFoundError: [Errno 2] No such file or directory: 'pdf_chunker')*

------
https://chatgpt.com/codex/tasks/task_e_68a88ee15f908325aef2ac179bd5c166