### PR TITLE
fix(split): merge headings with following content

### DIFF
--- a/tests/heading_merge_rule_test.py
+++ b/tests/heading_merge_rule_test.py
@@ -31,3 +31,12 @@ def test_heading_followed_by_list_item():
     ]
     chunks = _run(blocks)
     assert [c["text"] for c in chunks] == ["Intro\nBullet"]
+
+
+def test_terminal_heading_discarded():
+    blocks = [
+        {"text": "Body", "type": "paragraph"},
+        {"text": "Lonely", "type": "heading"},
+    ]
+    chunks = _run(blocks)
+    assert [c["text"] for c in chunks] == ["Body"]


### PR DESCRIPTION
## Summary
- refine semantic splitting by merging consecutive headings into the following block and skipping orphaned headings
- cover heading merge edge case with a test for terminal headings

## Testing
- `nox -s lint` *(pass)*
- `nox -s typecheck` *(pass)*
- `nox -s tests` *(fail: parity tests and golden conversion mismatches)*
- `pytest tests/heading_merge_rule_test.py` *(pass)*

------
https://chatgpt.com/codex/tasks/task_e_68a8935303448325b9752efb0e8b5fdd