### PR TITLE
fix(clean): port legacy hyphen and quote repairs

### DIFF
--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -645,6 +645,14 @@ def _clean_text_impl(text: str) -> str:
     text = fix_hyphenated_linebreaks(text)
     logger.debug(f"After fix_hyphenated_linebreaks: {_preview(text)}")
 
+    logger.debug("Calling normalize_quotes")
+    text = normalize_quotes(text)
+    logger.debug(f"After normalize_quotes: {_preview(text)}")
+
+    logger.debug("Calling remove_control_characters")
+    text = remove_control_characters(text)
+    logger.debug(f"After remove_control_characters: {_preview(text)}")
+
     logger.debug("Calling _fix_double_newlines")
     text = _fix_double_newlines(text)
     logger.debug(f"After _fix_double_newlines: {_preview(text)}")

--- a/tests/text_cleaning_transform_test.py
+++ b/tests/text_cleaning_transform_test.py
@@ -34,3 +34,13 @@ def test_clean_paragraph_cleans_bullet_fragments():
 def test_clean_paragraph_removes_underscore_wrapping():
     text = "This is __bold__ and _italics_"
     assert clean_paragraph(text) == "This is bold and italics"
+
+
+def test_quotes_and_control_chars():
+    text = "Here\u202d are “quotes”\u202c"
+    expected = 'Here are "quotes"'
+    assert clean_paragraph(text) == expected
+
+    doc = {"type": "page_blocks", "pages": [{"page": 1, "blocks": [{"text": text}]}]}
+    cleaned = text_clean(Artifact(payload=doc)).payload["pages"][0]["blocks"][0]["text"]
+    assert cleaned == expected


### PR DESCRIPTION
## Summary
- ensure `_clean_text_impl` normalizes smart quotes and strips control characters
- test quote normalization and control-character removal

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: FILES DIFFER in tests/golden/test_conversion.py::test_conversion[epub-b64_path1], parity tests fail)*
- `pytest tests/hyphenation_test.py tests/text_cleaning_transform_test.py::test_quotes_and_control_chars`

------
https://chatgpt.com/codex/tasks/task_e_68a8970d56b883259799729f5bfeed55