### PR TITLE
fix(parse): add comma continuation rule for same-page merges

### DIFF
--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -110,6 +110,11 @@ def _is_common_sentence_starter(word: str) -> bool:
     return word in COMMON_SENTENCE_STARTERS
 
 
+def _is_comma_uppercase_continuation(curr_text: str, next_text: str) -> bool:
+    """Detect comma-ended blocks followed by uppercase-starting text."""
+    return curr_text.endswith(",") and next_text[:1].isupper()
+
+
 def _is_indented_continuation(curr: dict, nxt: dict) -> bool:
     curr_bbox = curr.get("bbox")
     next_bbox = nxt.get("bbox")
@@ -201,6 +206,8 @@ def _is_same_page_continuation(
         return False
     if curr_text.endswith((".", "!", "?", ":", ";")):
         return False
+    if _is_comma_uppercase_continuation(curr_text, next_text):
+        return True
     first_word = next_text.split()[0]
     return next_text[0].islower() or _is_common_sentence_starter(first_word)
 

--- a/tests/cross_page_sentence_test.py
+++ b/tests/cross_page_sentence_test.py
@@ -66,3 +66,16 @@ def test_cross_page_does_not_merge_entire_document():
     merged = merge_continuation_blocks(blocks)
     assert len(merged) == 2
     assert merged[1]["text"].startswith("New paragraph")
+
+
+def test_comma_same_page_continuation():
+    blocks = [
+        {"text": "Chapters may end with a teaser,", "source": {"page": 1}},
+        {
+            "text": "However more follows on the same page.",
+            "source": {"page": 1},
+        },
+    ]
+    merged = merge_continuation_blocks(blocks)
+    assert len(merged) == 1
+    assert "teaser, However" in merged[0]["text"]


### PR DESCRIPTION
## Summary
- treat comma-ended blocks followed by uppercase text as same-page continuations
- test merging when a page block ending with a comma continues with an uppercase word

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: parity and golden tests mismatched)*
- `pytest tests/cross_page_sentence_test.py::test_comma_same_page_continuation -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8aecf6278832583111eca1dfd9e0f