### PR TITLE
fix(meta): mirror legacy metadata fields in chunks

### DIFF
--- a/tests/metadata_propagation_test.py
+++ b/tests/metadata_propagation_test.py
@@ -25,8 +25,14 @@ def test_metadata_propagation() -> None:
     assert bullet_meta["list_kind"] == "bullet"
     assert bullet_meta["page"] == 1
     assert bullet_meta["source"] == "src.pdf"
+    assert bullet_meta["block_type"] == "list_item"
+    assert bullet_meta["language"] == "un"
+    assert bullet_meta["location"] is None
 
     numbered_meta = chunks[1]["meta"]
     assert numbered_meta["list_kind"] == "numbered"
     assert numbered_meta["page"] == 2
     assert numbered_meta["source"] == "src.pdf"
+    assert numbered_meta["block_type"] == "list_item"
+    assert numbered_meta["language"] == "un"
+    assert numbered_meta["location"] is None


### PR DESCRIPTION
## Summary
- replace custom metadata builder in semantic splitter with utils._build_metadata to propagate source, page, block type, language, and location
- assert block_type, language, and location in metadata propagation test

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: test_conversion, parity tests)*
- `pytest tests/metadata_propagation_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8b3c3de50832591a9dd5cdd6d5364