### PR TITLE
test(enrich): cover pipeline enrichment via stub client

### DIFF
--- a/tests/ai_enrichment_test.py
+++ b/tests/ai_enrichment_test.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Any
 
 # Ensure local package path for pdf_chunker imports
 sys.path.insert(0, ".")
@@ -7,6 +8,8 @@ from pdf_chunker.adapters.ai_enrich import (
     _load_tag_configs,
     _process_chunk_for_file,
 )
+from pdf_chunker.config import PipelineSpec
+from pdf_chunker.framework import Artifact, run_pipeline
 from pdf_chunker.passes.ai_enrich import classify_chunk_utterance
 
 
@@ -14,12 +17,12 @@ def _dummy_completion(_: str) -> str:
     return "Classification: question\nTags: [Technical, unknown]"
 
 
-def test_load_tag_configs_deduplicates():
+def test_load_tag_configs_deduplicates() -> None:
     configs = _load_tag_configs()
     assert all(len(tags) == len({t for t in tags}) for tags in configs.values())
 
 
-def test_classify_chunk_utterance_filters_invalid_tags():
+def test_classify_chunk_utterance_filters_invalid_tags() -> None:
     tag_configs = {"generic": ["technical"]}
     result = classify_chunk_utterance(
         "What is AI?", tag_configs=tag_configs, completion_fn=_dummy_completion
@@ -27,7 +30,7 @@ def test_classify_chunk_utterance_filters_invalid_tags():
     assert result == {"classification": "question", "tags": ["technical"]}
 
 
-def test_process_chunk_for_file_populates_tags():
+def test_process_chunk_for_file_populates_tags() -> None:
     chunk = {"text": "What is AI?"}
     tag_configs = {"generic": ["technical"]}
     result = _process_chunk_for_file(
@@ -35,3 +38,28 @@ def test_process_chunk_for_file_populates_tags():
     )
     assert result["tags"] == ["technical"]
     assert result["metadata"]["tags"] == ["technical"]
+
+
+class _StubClient:
+    def classify_chunk_utterance(
+        self, text_chunk: str, *, tag_configs: dict[str, list[str]]
+    ) -> dict[str, Any]:
+        return {"classification": "question", "tags": ["technical"]}
+
+
+def test_pipeline_enrichment_with_stub() -> None:
+    spec = PipelineSpec(pipeline=["ai_enrich"])
+    tag_configs = {"generic": ["technical"]}
+    artifact = Artifact(
+        payload=[{"text": "What is AI?"}],
+        meta={
+            "ai_enrich": {
+                "enabled": True,
+                "client": _StubClient(),
+                "tag_configs": tag_configs,
+            }
+        },
+    )
+    result = run_pipeline(spec.pipeline, artifact)
+    assert all(c.get("utterance_type") == "question" for c in result.payload)
+    assert all(c.get("tags") == ["technical"] for c in result.payload)


### PR DESCRIPTION
## Summary
- add pipeline test verifying ai_enrich pass with stub client and tag configs

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: golden and parity tests)*
- `pytest tests/ai_enrichment_test.py::test_pipeline_enrichment_with_stub -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8b8eae694832591acf4901d4f06f3