### PR TITLE
fix(report): emit legacy-equivalent metrics and warnings

### DIFF
--- a/tests/scripts_cli_test.py
+++ b/tests/scripts_cli_test.py
@@ -46,3 +46,6 @@ def test_convert_cli_writes_jsonl(tmp_path: Path) -> None:
     assert rows
     report = json.loads((tmp_path / "run_report.json").read_text())
     assert {"timings", "metrics", "warnings"} <= report.keys()
+    assert report["metrics"]["page_count"] == 3
+    assert report["metrics"]["chunk_count"] == len(rows)
+    assert report["warnings"] == ["metadata_gaps"]


### PR DESCRIPTION
## Summary
- expand run-report assembly to add page and chunk totals alongside warning names
- assert new run-report fields in CLI conversion test

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: parity suite mismatches and subprocess errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c1f5bb008325acb76b2697d7d23d