### PR TITLE
Disable enrichment for parity tests

### DIFF
--- a/tests/parity/conftest.py
+++ b/tests/parity/conftest.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from subprocess import run
+
+import pytest
+
+from scripts import parity as sp
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    os.environ.update({"PDF_CHUNKER_ENRICH": "0", "AI_ENRICH_ENABLED": "0"})
+
+
+@pytest.fixture(scope="session")
+def classify_stub() -> Callable[[str], dict[str, object]]:
+    return lambda text, *, tag_configs=None, completion_fn=None: {
+        "classification": "none",
+        "tags": [],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _patch_legacy_llm(
+    monkeypatch: pytest.MonkeyPatch, classify_stub: Callable[[str], dict[str, object]]
+) -> None:
+    try:  # pragma: no cover - legacy optional
+        import pdf_chunker.ai_enrichment as legacy
+    except Exception:
+        return
+    monkeypatch.setattr(legacy, "init_llm", lambda: classify_stub)
+    monkeypatch.setattr(legacy, "classify_chunk_utterance", classify_stub)
+
+
+@pytest.fixture(autouse=True)
+def _patch_run_new(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _run(pdf: Path, out: Path, flags: Sequence[str] = ()) -> Path:
+        run(
+            [
+                sys.executable,
+                "-m",
+                "pdf_chunker.cli",
+                "convert",
+                str(pdf),
+                *flags,
+                "--no-enrich",
+                "--out",
+                str(out),
+            ],
+            check=True,
+        )
+        return out
+
+    monkeypatch.setattr(sp, "_run_new", _run)

--- a/tests/parity/pipeline_parity_test.py
+++ b/tests/parity/pipeline_parity_test.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.parity import run_parity
+from scripts import parity as sp
 from tests.parity.normalize import canonical_rows
 
 SAMPLES = Path("tests/golden/samples")
@@ -22,7 +22,7 @@ def _rows(path: Path) -> list[dict]:
 
 
 def _equal(pdf: Path, tmp: Path) -> bool:
-    legacy, new = run_parity(pdf, tmp, diffdir=ARTIFACTS)
+    legacy, new = sp.run_parity(pdf, tmp, diffdir=ARTIFACTS)
     return _rows(legacy) == _rows(new)
 
 


### PR DESCRIPTION
## Summary
- ensure parity tests run with enrichment disabled via env flags and stubbed LLM
- route new pipeline CLI through `--no-enrich` to avoid litellm requirement

## Testing
- `python -m black tests/parity/pipeline_parity_test.py tests/parity/conftest.py`
- `flake8 tests/parity/conftest.py tests/parity/pipeline_parity_test.py`
- `python -m mypy pdf_chunker` *(fails: missing type hints / stubs, e.g. typer)*
- `pytest -q tests/parity -k e2e_parity_flags` *(fails: CalledProcessError but no ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c9db9254832594de3e8c45d9558a