### PR TITLE
fix(cli): gate ai enrichment behind --enrich flag

### DIFF
--- a/tests/bootstrap/test_ai_enrich_purity.py
+++ b/tests/bootstrap/test_ai_enrich_purity.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from pdf_chunker.cli import app
+
+
+def test_convert_no_enrich_skips_ai_import(monkeypatch, tmp_path):
+    class Blocker:
+        def find_spec(self, fullname, path, target=None):
+            if fullname == "pdf_chunker.adapters.ai_enrich":
+                raise ImportError("ai_enrich should not be imported")
+            return None
+
+    monkeypatch.setattr(sys, "meta_path", [Blocker(), *sys.meta_path])
+    out = tmp_path / "out.jsonl"
+    sample = Path(__file__).resolve().parents[1] / "golden" / "samples" / "tiny.pdf"
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["convert", str(sample), "--no-enrich", "--out", str(out)],
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()


### PR DESCRIPTION
## Summary
- defer core imports unless --enrich is used
- ensure CLI conversion with --no-enrich skips ai_enrich imports
- add regression test asserting purity when enrichment disabled

## Testing
- `black pdf_chunker/cli.py tests/bootstrap/test_ai_enrich_purity.py`
- `flake8 pdf_chunker/cli.py tests/bootstrap/test_ai_enrich_purity.py`
- `mypy pdf_chunker/cli.py` *(fails: Missing type parameters for generic type "set" and others)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/bootstrap/test_ai_enrich_purity.py`
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: multiple parity tests and conversions failed)*
- `python -m pdf_chunker.cli convert tests/golden/samples/tiny.pdf --no-enrich --out /tmp/x.jsonl`


------
https://chatgpt.com/codex/tasks/task_e_68a8d2b229548325adfdd706ae37dc65