### PR TITLE
fix(cli/emit): handle --no-metadata without error

### DIFF
--- a/pdf_chunker/adapters/emit_jsonl.py
+++ b/pdf_chunker/adapters/emit_jsonl.py
@@ -13,6 +13,23 @@ def _rows(payload: Any) -> Iterable[dict[str, Any]]:
     return payload if isinstance(payload, list) else []
 
 
+def _maybe_drop_meta(
+    rows: Iterable[dict[str, Any]], drop: bool
+) -> Iterable[dict[str, Any]]:
+    """Optionally remove metadata, keeping legacy defaults when present."""
+
+    def _row(r: dict[str, Any]) -> dict[str, Any]:
+        text = r.get("text", "")
+        if drop:
+            return {"text": text}
+        meta = r.get("meta", {}).copy()
+        if isinstance(meta.get("utterance_type"), dict) and not meta["utterance_type"]:
+            meta["utterance_type"] = {"classification": "disabled", "tags": []}
+        return {"text": text, "meta": meta}
+
+    return (_row(r) for r in rows)
+
+
 def _serialize(rows: Iterable[dict[str, Any]]) -> Iterator[str]:
     """Serialize dictionaries to JSON lines."""
     return (json.dumps(r, ensure_ascii=False) for r in rows)
@@ -35,4 +52,5 @@ def maybe_write(
     artifact: Artifact, options: dict[str, Any], timings: dict[str, float] | None = None
 ) -> None:
     """Write artifact payload to JSONL if ``output_path`` is specified."""
-    write(_rows(artifact.payload), options.get("output_path"))
+    rows = _maybe_drop_meta(_rows(artifact.payload), options.get("drop_meta", False))
+    write(rows, options.get("output_path"))

--- a/pdf_chunker/cli.py
+++ b/pdf_chunker/cli.py
@@ -52,11 +52,19 @@ def _cli_overrides(
     overlap: int | None,
     enrich: bool,
     exclude_pages: str | None,
+    drop_meta: bool,
 ) -> dict[str, dict[str, Any]]:
     split_opts = {
         k: v for k, v in {"chunk_size": chunk_size, "overlap": overlap}.items() if v is not None
     }
-    emit_opts = {"output_path": str(out)} if out else {}
+    emit_opts = {
+        k: v
+        for k, v in {
+            "output_path": str(out) if out else None,
+            "drop_meta": True if drop_meta else None,
+        }.items()
+        if v is not None
+    }
     enrich_opts = {"enabled": True} if enrich else {}
     parse_opts = {"exclude_pages": exclude_pages} if exclude_pages else {}
     return {
@@ -92,13 +100,14 @@ def convert(
     overlap: int | None = typer.Option(None, "--overlap"),
     enrich: bool = typer.Option(False, "--enrich/--no-enrich"),
     exclude_pages: str | None = typer.Option(None, "--exclude-pages"),
+    no_metadata: bool = typer.Option(False, "--no-metadata"),
     spec: str = "pipeline.yaml",
 ):
     """Run the configured pipeline on ``input_path``."""
     _input_artifact, run_convert, _ = _core_helpers(enrich)
     s = load_spec(
         spec,
-        overrides=_cli_overrides(out, chunk_size, overlap, enrich, exclude_pages),
+        overrides=_cli_overrides(out, chunk_size, overlap, enrich, exclude_pages, no_metadata),
     )
     s = _enrich_spec(s) if enrich else s
     run_convert(_input_artifact(str(input_path)), s)


### PR DESCRIPTION
## Summary
- add `--no-metadata` CLI flag and plumb through to emit_jsonl
- drop metadata when requested and preserve legacy defaults

## Testing
- `python -m pdf_chunker.cli convert tests/golden/samples/sample.pdf --no-enrich --no-metadata --out /tmp/a.jsonl`
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: parity mismatch for --exclude-pages flags)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e972552883258ed6d098ba3af9f5