### PR TITLE
fix: guard AI enrichment imports

### DIFF
--- a/pdf_chunker/ai_enrichment.py
+++ b/pdf_chunker/ai_enrichment.py
@@ -3,18 +3,13 @@
 The original logic now lives in :mod:`pdf_chunker.passes.ai_enrich`
 (for pure classification) and :mod:`pdf_chunker.adapters.ai_enrich`
 (for LLM and file I/O). This module re-exports those functions to
-maintain compatibility.
+maintain compatibility while avoiding heavy dependencies at import time.
 """
 
 import os
 import sys
+from typing import Callable
 
-from pdf_chunker.adapters.ai_enrich import (
-    _load_tag_configs,
-    init_llm,
-    _process_chunk_for_file,
-    _process_jsonl_file,
-)
 from pdf_chunker.passes.ai_enrich import classify_chunk_utterance
 
 __all__ = [
@@ -24,6 +19,47 @@ __all__ = [
     "_process_chunk_for_file",
     "_process_jsonl_file",
 ]
+
+
+def _load_tag_configs(config_dir: str = "config/tags") -> dict:
+    from pdf_chunker.adapters.ai_enrich import _load_tag_configs as impl
+
+    return impl(config_dir=config_dir)
+
+
+def init_llm(api_key: str | None = None) -> Callable[[str], str]:
+    from pdf_chunker.adapters.ai_enrich import init_llm as impl
+
+    return impl(api_key=api_key)
+
+
+def _process_chunk_for_file(
+    chunk: dict,
+    *,
+    tag_configs: dict,
+    completion_fn: Callable[[str], str],
+) -> dict:
+    from pdf_chunker.adapters.ai_enrich import _process_chunk_for_file as impl
+
+    return impl(chunk, tag_configs=tag_configs, completion_fn=completion_fn)
+
+
+def _process_jsonl_file(
+    input_path: str,
+    output_path: str,
+    completion_fn: Callable[[str], str],
+    tag_configs: dict | None = None,
+    max_workers: int = 10,
+) -> None:
+    from pdf_chunker.adapters.ai_enrich import _process_jsonl_file as impl
+
+    return impl(
+        input_path,
+        output_path,
+        completion_fn,
+        tag_configs=tag_configs,
+        max_workers=max_workers,
+    )
 
 
 def main() -> None:

--- a/pdf_chunker/core.py
+++ b/pdf_chunker/core.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 from typing import Callable, Iterable, List, Sequence, Set
 from functools import partial
 
-from haystack.dataclasses import Document
-
-from .ai_enrichment import init_llm, classify_chunk_utterance, _load_tag_configs
+from .ai_enrichment import classify_chunk_utterance
 from .splitter import semantic_chunker
 from .utils import format_chunks_with_metadata as utils_format_chunks_with_metadata
 
@@ -253,6 +251,8 @@ def setup_enrichment(
     if not perform_ai_enrichment:
         return False, None
     try:
+        from .ai_enrichment import init_llm, _load_tag_configs
+
         completion_fn = init_llm()
         tag_configs = _load_tag_configs()
         return True, partial(
@@ -316,6 +316,8 @@ def process_document(
         min_chunk_size=min_chunk_size,
         enable_dialogue_detection=enable_dialogue_detection,
     )
+    from haystack.dataclasses import Document
+
     haystack_documents = [
         Document(content=text, id=f"chunk_{i}")
         for i, text in enumerate(haystack_chunks)


### PR DESCRIPTION
## Summary
- Defer heavy AI dependencies by lazily importing LLM init and tag config loading
- Delay Haystack `Document` import until document processing
- Shim `pdf_chunker.ai_enrichment` with lazy wrappers to avoid Litellm/Haystack requirements when enrichment disabled

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: test_conversion[epub-b64_path1]; multiple parity tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a9266f705c8325be15e1835a6f3c52