### PR TITLE
Thread metadata flag through chunk processing

### DIFF
--- a/pdf_chunker/core.py
+++ b/pdf_chunker/core.py
@@ -322,9 +322,8 @@ def process_document(
         Document(content=text, id=f"chunk_{i}")
         for i, text in enumerate(haystack_chunks)
     ]
-    final_chunks = enricher(
-        haystack_documents,
-        filtered_blocks,
+    enricher_fn = partial(
+        enricher,
         generate_metadata=generate_metadata,
         perform_ai_enrichment=perform_ai_enrichment,
         enrichment_fn=enrichment_fn,
@@ -332,4 +331,5 @@ def process_document(
         min_chunk_size=min_chunk_size,
         enable_dialogue_detection=enable_dialogue_detection,
     )
+    final_chunks = enricher_fn(haystack_documents, filtered_blocks)
     return validate_chunks(final_chunks, exclude_pages, generate_metadata)


### PR DESCRIPTION
## Summary
- forward `generate_metadata` from `process_document` to chunk processing via a curried enrichment function
- short-circuit `process_chunk` and skip character map construction when metadata generation is disabled

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: W391 etc.)*
- `flake8 pdf_chunker/core.py pdf_chunker/utils.py`
- `mypy pdf_chunker/` *(fails: Missing type parameters)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: parity tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1ab49f608325b55e39d4f3361cb5