### PR TITLE
fix(parity): forward and honor --exclude-pages in adapter path

### DIFF
--- a/pdf_chunker/cli.py
+++ b/pdf_chunker/cli.py
@@ -113,10 +113,12 @@ def convert(
     _input_artifact, run_convert, _ = _core_helpers(enrich)
     s = load_spec(
         spec,
-        overrides=_cli_overrides(out, chunk_size, overlap, enrich, exclude_pages, no_metadata),
+        overrides=_cli_overrides(
+            out, chunk_size, overlap, enrich, exclude_pages, no_metadata
+        ),
     )
     s = _enrich_spec(s) if enrich else s
-    run_convert(_input_artifact(str(input_path)), s)
+    run_convert(_input_artifact(str(input_path), s), s)
     typer.echo("convert: OK")
 
 

--- a/tests/parity/test_e2e_parity.py
+++ b/tests/parity/test_e2e_parity.py
@@ -56,3 +56,10 @@ def flag_sets() -> list[tuple[str, ...]]:
 @pytest.mark.parametrize("flags", flag_sets(), ids=lambda f: " ".join(f) or "base")
 def test_e2e_parity_flags(tmp_path: Path, flags: tuple[str, ...]) -> None:
     assert all(_equal(pdf, tmp_path / f"{i}", flags) for i, pdf in enumerate(PDFS))
+
+
+@pytest.mark.parametrize("pdf", PDFS)
+def test_exclude_pages_yields_no_rows(tmp_path: Path, pdf: Path) -> None:
+    legacy, new = run_parity(pdf, tmp_path / pdf.stem, ("--exclude-pages", "1"))
+    assert list(canonical_rows(legacy)) == []
+    assert list(canonical_rows(new)) == []


### PR DESCRIPTION
## Summary
- propagate `--exclude-pages` options into the initial artifact load so PDF exclusions are respected before any pass runs
- supply pipeline options when invoking the CLI and handle cases where all pages are excluded
- ensure parity test for excluding page 1 yields zero rows for both pipelines

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: tests/golden/test_conversion.py::test_conversion[epub-b64_path1] - AssertionError: FILES DIFFER)*

------
https://chatgpt.com/codex/tasks/task_e_68aa53301c7083259ff503ac520967bf