### PR TITLE
Respect pass-specific options

### DIFF
--- a/tests/pass_options_propagation_test.py
+++ b/tests/pass_options_propagation_test.py
@@ -1,0 +1,31 @@
+from pdf_chunker.core_new import _run_passes
+from pdf_chunker.framework import Artifact
+
+
+def _doc(text: str) -> dict:
+    return {
+        "type": "page_blocks",
+        "source_path": "src.pdf",
+        "pages": [{"page": 1, "blocks": [{"text": text}]}],
+    }
+
+
+def test_run_passes_respects_spec_options(monkeypatch) -> None:
+    captured: dict[str, tuple[int, int, int]] = {}
+
+    def fake_semantic_chunker(
+        text: str, chunk_size: int, overlap: int, *, min_chunk_size: int
+    ) -> list[str]:
+        captured["args"] = (chunk_size, overlap, min_chunk_size)
+        return [text[:5], text[5:]]
+
+    monkeypatch.setattr("pdf_chunker.splitter.semantic_chunker", fake_semantic_chunker)
+
+    opts = {"split_semantic": {"chunk_size": 5, "overlap": 0, "generate_metadata": False}}
+    art = Artifact(payload=_doc("hello world"))
+    out, _ = _run_passes(["split_semantic"], art, opts)
+    items = out.payload["items"]
+
+    assert captured["args"] == (5, 0, 8)
+    assert len(items) == 2
+    assert all("meta" not in item for item in items)


### PR DESCRIPTION
## Summary
- propagate PipelineSpec options to each pass invocation
- allow split_semantic to honor chunk_size, overlap, and metadata generation flags
- cover option propagation with a regression test

## Testing
- `black --check pdf_chunker/ scripts/ tests/` *(fails: would reformat several files)*
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: blank line at EOF and other style errors)*
- `flake8 pdf_chunker/core_new.py pdf_chunker/passes/split_semantic.py tests/pass_options_propagation_test.py`
- `mypy pdf_chunker/` *(fails: missing type params and stub errors)*
- `bash scripts/validate_chunks.sh` *(fails: output_chunks_pdf.jsonl not found)*
- `pytest tests/` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6f9984908325b0e9e4f7e7e8bc58