### PR TITLE
feat: skip metadata construction when disabled

### DIFF
--- a/pdf_chunker/core_new.py
+++ b/pdf_chunker/core_new.py
@@ -70,7 +70,11 @@ def _time_step(
         a, timings = acc
         p = registry()[step]
         step_opts = opts.get(step, {})
-        p = p.__class__(**step_opts) if step_opts else p
+        if step_opts:
+            try:
+                p = p.__class__(**step_opts)
+            except TypeError:
+                p = p
         t0 = time.time()
         a = p(a)
         return a, {**timings, step: time.time() - t0}

--- a/tests/core_new_warnings_test.py
+++ b/tests/core_new_warnings_test.py
@@ -12,10 +12,17 @@ def test_collect_warnings_flags_known_issues() -> None:
         pipeline=[],
         options={"pdf_parse": {"exclude_pages": "1", "engine": "pymupdf4llm"}},
     )
-    warnings = _collect_warnings(Artifact(payload=payload, meta={}), spec)
+    warnings = _collect_warnings(Artifact(payload=payload, meta={}), spec, generate_metadata=True)
     assert set(warnings) == {
         "footnote_anchors",
         "page_exclusion_noop",
         "metadata_gaps",
         "underscore_loss",
     }
+
+
+def test_collect_warnings_ignores_metadata_when_disabled() -> None:
+    payload = [{"text": "plain"}]
+    spec = PipelineSpec(options={"split_semantic": {"generate_metadata": False}})
+    warnings = _collect_warnings(Artifact(payload=payload, meta={}), spec, generate_metadata=False)
+    assert "metadata_gaps" not in warnings


### PR DESCRIPTION
## Summary
- avoid building chunk metadata in split_semantic when generate_metadata is false
- ignore unsupported pass options during pipeline execution
- test warning collection with metadata disabled

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `pytest tests/core_new_warnings_test.py tests/pass_options_propagation_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa7204b2f483259d15ac181bd521f5