### PR TITLE
emit_jsonl omits empty meta entries

### DIFF
--- a/pdf_chunker/passes/emit_jsonl.py
+++ b/pdf_chunker/passes/emit_jsonl.py
@@ -9,7 +9,8 @@ Doc = dict[str, Any]
 
 
 def _row(item: dict[str, Any]) -> Row:
-    return {"text": item.get("text", ""), "meta": item.get("meta", {})}
+    base = {"text": item.get("text", "")}
+    return base | ({"meta": item["meta"]} if "meta" in item else {})
 
 
 def _rows(doc: Doc) -> list[Row]:

--- a/tests/parity/test_e2e_parity.py
+++ b/tests/parity/test_e2e_parity.py
@@ -8,6 +8,8 @@ import pytest
 
 from scripts.parity import run_parity
 from tests.parity.normalize import canonical_rows
+from pdf_chunker.framework import Artifact
+from pdf_chunker.passes.emit_jsonl import emit_jsonl
 
 SAMPLES = Path("tests/golden/samples")
 PDFS = sorted(SAMPLES.glob("*.pdf"))
@@ -63,3 +65,10 @@ def test_exclude_pages_yields_no_rows(tmp_path: Path, pdf: Path) -> None:
     legacy, new = run_parity(pdf, tmp_path / pdf.stem, ("--exclude-pages", "1"))
     assert list(canonical_rows(legacy)) == []
     assert list(canonical_rows(new)) == []
+
+
+def test_emit_jsonl_omits_meta_when_absent() -> None:
+    doc = {"type": "chunks", "items": [{"text": "hello"}]}
+    result = emit_jsonl(Artifact(payload=doc, meta={})).payload
+    assert result == [{"text": "hello"}]
+    assert all(row.keys() == {"text"} for row in result)


### PR DESCRIPTION
## Summary
- refactor JSONL row construction to only include `meta` when present
- cover emit_jsonl with parity test for `--no-metadata`

## Testing
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: W391, E704, W504 in existing files)*
- `flake8 pdf_chunker/passes/emit_jsonl.py tests/parity/test_e2e_parity.py`
- `black pdf_chunker/passes/emit_jsonl.py tests/parity/test_e2e_parity.py`
- `mypy pdf_chunker/passes/emit_jsonl.py`
- `bash scripts/validate_chunks.sh sample_chunks.jsonl` *(fails: mid-sentence start)*
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: ModuleNotFoundError: ebooklib)*
- `pytest tests/parity/test_e2e_parity.py::test_emit_jsonl_omits_meta_when_absent -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3b52825c832597354f63c5a56f3e