### PR TITLE
Expose EPUB read entrypoint for CLI and add regression test

### DIFF
--- a/pdf_chunker/adapters/io_epub.py
+++ b/pdf_chunker/adapters/io_epub.py
@@ -24,10 +24,7 @@ def _group_blocks(
 
     key = lambda blk: _page_key(mapping, blk)
     sorted_blocks = sorted(blocks, key=key)
-    return [
-        {"page": page, "blocks": list(group)}
-        for page, group in groupby(sorted_blocks, key)
-    ]
+    return [{"page": page, "blocks": list(group)} for page, group in groupby(sorted_blocks, key)]
 
 
 def _excluded_spines(spec: str | None, total: int, filename: str) -> set[int]:
@@ -69,6 +66,12 @@ def read_epub(path: str, spine: str | None = None) -> Dict[str, Any]:
         "source_path": abs_path,
         "pages": _group_blocks(blocks, mapping),
     }
+
+
+def read(path: str, exclude_pages: str | None = None) -> Dict[str, Any]:
+    """Compatibility wrapper exposing a standard ``read`` entrypoint."""
+
+    return read_epub(path, spine=exclude_pages)
 
 
 def describe_epub(path: str) -> Dict[str, str]:

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -21,6 +21,7 @@ Test modules validating behavior of parsing, chunking, and enrichment layers.
 - `footer_artifact_test.py`: Regression for footer and sub-footer removal and multi-page preservation
 - `artifact_block_test.py`: Numeric margin block detection conservatism
 - `scripts_cli_test.py`: CLI invocation sanity checks
+- `cli_epub_conversion_test.py`: CLI EPUB conversion parity with golden output
 - `splitter_transform_test.py`: Chunk splitting of cleaned text artifacts
 - `text_cleaning_transform_test.py`: Ligature, underscore, and hyphenation normalization
 - Duplicate detection thresholds (via `detect_duplicates.py`).

--- a/tests/golden/cli_epub_conversion_test.py
+++ b/tests/golden/cli_epub_conversion_test.py
@@ -1,0 +1,52 @@
+import base64
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def _materialize(src: Path, dst: Path) -> Path:
+    data = base64.b64decode(src.read_text())
+    target = dst / "sample.epub"
+    target.write_bytes(data)
+    return target
+
+
+def test_cli_epub_conversion(tmp_path: Path) -> None:
+    b64_path = Path("tests/golden/samples/sample.epub.b64")
+    epub_path = _materialize(b64_path, tmp_path)
+    out_file = tmp_path / "out.jsonl"
+    cmd = [
+        "python",
+        "-m",
+        "pdf_chunker.cli",
+        "convert",
+        str(epub_path),
+        "--chunk-size",
+        "1000",
+        "--overlap",
+        "0",
+        "--out",
+        str(out_file),
+    ]
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": "."},
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0
+    actual = [
+        json.loads(line)
+        for line in out_file.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    expected = [
+        json.loads(line)
+        for line in Path("tests/golden/expected/epub.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line.strip()
+    ]
+    assert actual == expected


### PR DESCRIPTION
## Summary
- add `read` wrapper to EPUB IO adapter
- cover CLI EPUB conversion with regression test
- document new test coverage

## Testing
- `black pdf_chunker/adapters/io_epub.py tests/golden/cli_epub_conversion_test.py`
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: pdf_chunker/adapters/io_pdf.py:117:1: W391 blank line at end of file)*
- `mypy pdf_chunker/` *(fails: pdf_chunker/page_utils.py:64: error: Missing type parameters for generic type "set" [type-arg])*
- `bash scripts/validate_chunks.sh tests/golden/expected/pdf.jsonl`
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: Command pytest -q tests/bootstrap tests/golden tests/parity failed with exit code 4)*

------
https://chatgpt.com/codex/tasks/task_e_68ab43bdbd34832582dc997e98bdd57b