### PR TITLE
split_semantic: make metadata optional

### DIFF
--- a/tests/parity/pipeline_parity_test.py
+++ b/tests/parity/pipeline_parity_test.py
@@ -28,3 +28,12 @@ def _equal(pdf: Path, tmp: Path) -> bool:
 
 def test_new_matches_legacy(tmp_path: Path) -> None:
     assert all(_equal(pdf, tmp_path / pdf.stem) for pdf in _pdfs())
+
+
+def test_no_metadata_rows_contain_only_text(tmp_path: Path) -> None:
+    for pdf in _pdfs():
+        legacy, new = sp.run_parity(
+            pdf, tmp_path / pdf.stem, flags=["--no-metadata"], diffdir=ARTIFACTS
+        )
+        for path in (legacy, new):
+            assert all(r.keys() == {"text"} for r in canonical_rows(path))


### PR DESCRIPTION
## Summary
- Refactor chunk construction into `build_chunk` helpers and gate metadata generation
- Default `language` to "en" when building metadata and omit the field entirely when disabled
- Add parity test ensuring `--no-metadata` emits text-only rows

## Testing
- `black --check pdf_chunker/ scripts/ tests/` *(fails: would reformat many files)*
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: 7 warnings/errors)*
- `mypy pdf_chunker/` *(fails: missing type annotations in multiple modules)*
- `bash scripts/validate_chunks.sh tests/golden/expected/pdf.jsonl`
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: test suite reports failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6db5283883258db7134685ff638b