### PR TITLE
Add EPUB extraction dispatcher and regression test

### DIFF
--- a/pdf_chunker/core.py
+++ b/pdf_chunker/core.py
@@ -240,7 +240,7 @@ def process_document(
     exclude_pages: str | None = None,
     min_chunk_size: int | None = None,
     enable_dialogue_detection: bool = True,
-    extractor: Extractor = parsing.extract_structured_text,
+    extractor: Extractor | None = None,
     chunker: Chunker = chunk_text,
     enricher: Enricher = utils_format_chunks_with_metadata,
 ) -> list[dict]:
@@ -271,8 +271,8 @@ def process_document(
 
     excluded_pages = parse_exclusions(exclude_pages)
     path = Path(filepath)
-    # EPUB extractor interprets exclude_pages as spine indices
-    blocks = extractor(path, exclude_pages)
+    extractor = extractor or parsing.extract_structured_text
+    blocks = extractor(path, exclude_pages=exclude_pages)
     filtered_blocks = filter_blocks(blocks, excluded_pages)
     haystack_chunks = chunker(
         filtered_blocks,

--- a/pdf_chunker/parsing.py
+++ b/pdf_chunker/parsing.py
@@ -30,7 +30,11 @@ DISPATCH: dict[str, Extractor] = {
 
 
 def extract_structured_text(path: Path | str, exclude_pages: str | None = None) -> list[dict]:
-    """Select the proper extractor based on file suffix."""
+    """Return text blocks from a PDF or EPUB file.
+
+    The extractor is chosen solely by the file's suffix, keeping the function
+    free of side effects and external state.
+    """
 
     p = Path(path)
     try:

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility helpers for tests."""
+
+from .materialize import materialize_base64
+
+__all__ = ["materialize_base64"]
+

--- a/tests/utils/materialize.py
+++ b/tests/utils/materialize.py
@@ -1,0 +1,19 @@
+"""Helpers for materializing encoded fixtures."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+
+def materialize_base64(src: Path, dst_dir: Path, filename: str) -> Path:
+    """Decode a base64-encoded file into *dst_dir* with *filename*.
+
+    Returns the path to the materialized file.
+    """
+
+    data = base64.b64decode(src.read_text())
+    target = dst_dir / filename
+    target.write_bytes(data)
+    return target
+


### PR DESCRIPTION
## Summary
- Dispatch structured text extraction based on file type to support EPUBs
- Introduce utility for materializing base64 fixtures and apply in CLI tests
- Add regression test verifying EPUB CLI output against golden data

## Testing
- `nox -s lint typecheck tests` *(fails: tests/bootstrap/test_run_convert_adapter.py::test_run_convert_writes_jsonl, tests/golden/test_conversion.py::test_conversion[epub-b64_path1], tests/golden/test_conversion_epub_cli.py::test_conversion_epub_cli, tests/parity/pipeline_parity_test.py::test_new_matches_legacy, tests/parity/test_e2e_parity.py::test_e2e_parity_flags[base], tests/parity/test_e2e_parity_flags[--chunk-size 200], tests/parity/test_e2e_parity_flags[--overlap 10], tests/parity/test_e2e_parity_flags[--chunk-size 200 --overlap 10])`


------
https://chatgpt.com/codex/tasks/task_e_68ab76a859988325817980f5f863786c