### PR TITLE
fix(cli): resolve pipeline spec relative to package

### DIFF
--- a/pdf_chunker/cli.py
+++ b/pdf_chunker/cli.py
@@ -11,6 +11,13 @@ import typer
 
 from pdf_chunker.config import PipelineSpec, load_spec
 
+
+def _resolve_spec_path(path: str | Path) -> Path:
+    """Resolve pipeline spec relative to this package if not found."""
+    candidate = Path(path)
+    return candidate if candidate.exists() else Path(__file__).resolve().parent / candidate
+
+
 app = typer.Typer(add_completion=False, no_args_is_help=True)
 
 
@@ -112,10 +119,8 @@ def convert(
     """Run the configured pipeline on ``input_path``."""
     _input_artifact, run_convert, _ = _core_helpers(enrich)
     s = load_spec(
-        spec,
-        overrides=_cli_overrides(
-            out, chunk_size, overlap, enrich, exclude_pages, no_metadata
-        ),
+        _resolve_spec_path(spec),
+        overrides=_cli_overrides(out, chunk_size, overlap, enrich, exclude_pages, no_metadata),
     )
     s = _enrich_spec(s) if enrich else s
     run_convert(_input_artifact(str(input_path), s), s)


### PR DESCRIPTION
## Summary
- ensure CLI resolves pipeline spec relative to package when not found

## Testing
- `black --check pdf_chunker/cli.py`
- `black --check pdf_chunker/ scripts/ tests/` *(fails: would reformat many files)*
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: W391, E704, W504, E741)*
- `mypy pdf_chunker/cli.py` *(fails: interrupted)*
- `bash scripts/validate_chunks.sh` *(fails: file not found)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/golden/test_conversion_epub_cli.py::test_conversion_epub_cli -q` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_68ab9445d98c8325a876d8ec42f14f3f