### PR TITLE
Preserve language metadata in semantic splitter

### DIFF
--- a/pdf_chunker/passes/split_semantic.py
+++ b/pdf_chunker/passes/split_semantic.py
@@ -137,10 +137,10 @@ def build_chunk_with_meta(
     text: str, block: Block, page: int, filename: str | None, index: int
 ) -> Chunk:
     """Return chunk payload enriched with metadata."""
-
-    meta = _build_metadata(text, _with_source(block, page, filename), index, {})
-    meta["language"] = "en"
-    return {"text": text, "meta": meta}
+    return {
+        "text": text,
+        "meta": _build_metadata(text, _with_source(block, page, filename), index, {}),
+    }
 
 
 def _chunk_items(doc: Doc, split_fn: SplitFn, generate_metadata: bool = True) -> Iterator[Chunk]:


### PR DESCRIPTION
## Summary
- stop overwriting detected language when building chunk metadata
- keep `build_chunk_with_meta` purely functional by returning new chunk mapping

## Testing
- `black pdf_chunker/passes/split_semantic.py`
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: W391, E704, etc. in unrelated files)*
- `mypy pdf_chunker/` *(fails: missing type params, missing stubs, etc.)*
- `bash scripts/validate_chunks.sh /tmp/out.jsonl`
- `pytest tests/parity/test_e2e_parity.py::test_e2e_parity_flags[base]` *(fails: AssertionError: parity mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9622ce0883259aec76179c769489