### PR TITLE
fix(io): create output directories in JSONL writer

### DIFF
--- a/pdf_chunker/adapters/emit_jsonl.py
+++ b/pdf_chunker/adapters/emit_jsonl.py
@@ -46,7 +46,9 @@ def _serialize(rows: Iterable[dict[str, Any]]) -> Iterator[str]:
 
 def _write(path: str, lines: Iterable[str]) -> None:
     """Write ``lines`` to ``path`` with trailing newlines."""
-    with Path(path).open("w", encoding="utf-8") as f:
+    path_obj = Path(path)
+    path_obj.parent.mkdir(parents=True, exist_ok=True)
+    with path_obj.open("w", encoding="utf-8") as f:
         f.writelines(f"{line}\n" for line in lines)
 
 

--- a/tests/bootstrap/test_emit_jsonl_adapter.py
+++ b/tests/bootstrap/test_emit_jsonl_adapter.py
@@ -9,3 +9,12 @@ def test_write(tmp_path):
     emit_jsonl.write(rows, str(out))
     with out.open() as f:
         assert [json.loads(line) for line in f.read().splitlines()] == rows
+
+
+def test_write_creates_parent_directory(tmp_path):
+    rows = [{"a": 1}, {"b": 2}]
+    out = tmp_path / "nested" / "rows.jsonl"
+    emit_jsonl.write(rows, str(out))
+    assert out.parent.is_dir()
+    with out.open() as f:
+        assert [json.loads(line) for line in f.read().splitlines()] == rows


### PR DESCRIPTION
## Summary
- ensure JSONL writer creates parent directories before writing
- test JSONL writer creates missing directories and outputs rows

## Testing
- `black pdf_chunker/adapters/emit_jsonl.py tests/bootstrap/test_emit_jsonl_adapter.py`
- `flake8 pdf_chunker/adapters/emit_jsonl.py tests/bootstrap/test_emit_jsonl_adapter.py`
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: E704 multiple statements...)*
- `mypy pdf_chunker/` *(fails: Missing type parameters for generic types...)*
- `bash scripts/validate_chunks.sh tests/golden/expected/epub.jsonl`
- `pytest tests/golden/test_conversion_epub_cli.py::test_conversion_epub_cli -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: .../out.jsonl)*
- `nox -s lint typecheck tests` *(fails: Command pytest -q tests/bootstrap tests/golden tests/parity failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68abbe624e508325995e1675f5be04a7