### PR TITLE
Use deterministic language metadata

### DIFF
--- a/pdf_chunker/epub_parsing.py
+++ b/pdf_chunker/epub_parsing.py
@@ -8,7 +8,7 @@ from bs4 import BeautifulSoup
 from typing import Dict, List, TypedDict
 from .text_cleaning import clean_paragraph
 from .heading_detection import _detect_heading_fallback
-from .extraction_fallbacks import _detect_language
+from .extraction_fallbacks import default_language
 
 
 class TextBlock(TypedDict):
@@ -57,7 +57,7 @@ def _element_to_block(element, filename: str, item_name: str) -> TextBlock | Non
     return {
         "type": block_type,
         "text": block_text,
-        "language": _detect_language(block_text),
+        "language": default_language(),
         "source": {"filename": filename, "location": item_name},
     }
 

--- a/pdf_chunker/extraction_fallbacks.py
+++ b/pdf_chunker/extraction_fallbacks.py
@@ -3,8 +3,6 @@ import re
 import sys
 from subprocess import TimeoutExpired
 
-from langdetect import LangDetectException, detect
-
 try:
     from pdfminer.high_level import extract_text
     from pdfminer.layout import LAParams
@@ -17,12 +15,9 @@ from .page_artifacts import remove_page_artifact_lines
 from .text_cleaning import clean_text
 
 
-def _detect_language(text: str) -> str:
-    """Detects language of a text block, defaults to 'un' (unknown) on failure."""
-    try:
-        return detect(text)
-    except LangDetectException:
-        return "un"
+def default_language() -> str:
+    """Return the deterministic default language code."""
+    return "en"
 
 
 def _assess_text_quality(text: str) -> dict:
@@ -84,7 +79,7 @@ def _text_to_blocks(text: str, filepath: str, method: str) -> list[dict]:
         {
             "type": "heading" if _is_heading(t) else "paragraph",
             "text": t,
-            "language": _detect_language(t),
+            "language": default_language(),
             "source": {"filename": os.path.basename(filepath), "method": method},
         }
         for t in (clean_text(p) for p in text.split("\n\n"))

--- a/project_response_with_snippets.md
+++ b/project_response_with_snippets.md
@@ -19,7 +19,7 @@ structured.append(
     {
         "type": block_type,
         "text": block_text,
-        "language": _detect_language(block_text),
+        "language": default_language(),
         "source": {"filename": filename, "page": page_num, "location": None},
         "bbox": b[:4],
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
   "wordfreq>=3.1.1",
   "haystack-ai>=2.15.1",
   "textstat>=0.7.7",
-  "langdetect>=1.0.9",
   "PyMuPDF>=1.26.3",
   "python-dotenv>=1.1.1",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,6 @@ langchain==0.3.26
 langchain-core==0.3.71
 langchain-text-splitters==0.3.8
 langcodes==3.5.0
-langdetect==1.0.9
 langsmith==0.4.8
 language_data==1.3.0
 lazy-imports==0.3.1
@@ -135,7 +134,6 @@ ftfy
 pymupdf4llm
 reportlab
 lxml
-langdetect
 textstat
 wcwidth==0.2.13
 wordfreq==3.1.1


### PR DESCRIPTION
## Summary
- replace nondeterministic langdetect usage with a pure `default_language()` helper returning `"en"`
- wire default language through PDF and EPUB parsers and structured block builder
- drop unused langdetect dependency from project configuration

## Testing
- `flake8 pdf_chunker/epub_parsing.py pdf_chunker/extraction_fallbacks.py pdf_chunker/pdf_parsing.py`
- `mypy pdf_chunker/` *(fails: "_load" does not return a value)*
- `bash scripts/validate_chunks.sh output_chunks.json` *(fails: No chunks found in 'output_chunks.json')*
- `pytest -q tests/parity/pipeline_parity_test.py::test_new_matches_legacy -q`
- `pytest -q tests/parity/test_e2e_parity.py -k e2e_parity_flags -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac74b452dc83258ff59665c62fcf96