### PR TITLE
Implement parser selection and invariant checks

### DIFF
--- a/tests/core_invariant_test.py
+++ b/tests/core_invariant_test.py
@@ -14,7 +14,6 @@ def _check(spec: PipelineSpec, path: str) -> None:
     [
         (PipelineSpec(pipeline=["split_semantic", "text_clean"]), "dummy.pdf"),
         (PipelineSpec(pipeline=["pdf_parse", "epub_parse"]), "dummy.pdf"),
-        (PipelineSpec(pipeline=["pdf_parse", "text_clean"]), "dummy.epub"),
     ],
 )
 def test_invalid_pipelines_rejected(spec: PipelineSpec, path: str) -> None:
@@ -25,3 +24,9 @@ def test_invalid_pipelines_rejected(spec: PipelineSpec, path: str) -> None:
 def test_valid_pipeline_passes() -> None:
     spec = PipelineSpec(pipeline=["pdf_parse", "text_clean", "split_semantic"])
     _check(spec, "dummy.pdf")
+
+
+def test_parse_step_replaced_for_mismatch() -> None:
+    spec = PipelineSpec(pipeline=["pdf_parse", "text_clean"])
+    steps = _enforce_invariants(spec, input_path="dummy.epub")
+    assert steps[0] == "epub_parse"


### PR DESCRIPTION
## Summary
- add `choose_parser` to map file extensions to parse steps
- use parser lookup in `_ensure_pdf_epub_separation` and `_enforce_invariants`
- extend invariant tests for parser replacement

## Testing
- `black pdf_chunker/core_new.py tests/core_invariant_test.py`
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: E704, W391, etc.)*
- `mypy pdf_chunker/` *(fails: Missing type parameters, etc.)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/` *(fails: ModuleNotFoundError: No module named 'typer')*
- `nox -s lint typecheck tests` *(fails: tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8c65ddf88325b86fc0fa732e99dc