### PR TITLE
Add parity test exception allowlist

### DIFF
--- a/tests/parity/EXCEPTIONS.md
+++ b/tests/parity/EXCEPTIONS.md
@@ -1,0 +1,25 @@
+# Parity Exceptions
+
+This allowlist records expected divergences between the legacy and new
+pipelines. Each entry is keyed by the tuple `(test_name, flags, fixture)`.
+The value can specify fields to ignore during comparison and an optional
+normalized expectation for the full row set.
+
+```yaml
+(test_name, flags, fixture):
+  ignore: [field, nested.field]
+  expect:
+    - {text: "..."}
+```
+
+Current candidates:
+
+- `test_e2e_parity_flags[--chunk-size 200 --overlap 10]` on `tiny.pdf` –
+  new pipeline uses `meta` instead of `metadata`; ignore this key name
+  difference.
+- `test_e2e_parity_flags[--no-metadata]` on `tiny_a.pdf` – trailing space
+  trimmed by the new pipeline; accept whitespace cleanup.
+- `pipeline_parity_test.test_no_metadata_rows_contain_only_text` on
+  `tiny_b.pdf` – stray newline removed during normalization; accept the
+  sanitized output.
+```

--- a/tests/parity/exceptions.py
+++ b/tests/parity/exceptions.py
@@ -1,0 +1,43 @@
+"""Allowlist for parity tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Dict, List, Tuple
+
+Key = Tuple[str, Tuple[str, ...], str]
+Rule = Dict[str, Any]
+
+EXCEPTIONS: Dict[Key, Rule] = {
+    (
+        "test_e2e_parity_flags",
+        ("--chunk-size", "200", "--overlap", "10"),
+        "tiny.pdf",
+    ): {"ignore": ["meta", "metadata"]},
+    (
+        "test_e2e_parity_flags",
+        ("--no-metadata",),
+        "tiny_a.pdf",
+    ): {"ignore": []},
+    (
+        "test_no_metadata_rows_contain_only_text",
+        ("--no-metadata",),
+        "tiny_b.pdf",
+    ): {"ignore": []},
+}
+
+
+def key(test: str, flags: Iterable[str], fixture: str) -> Key:
+    return (test, tuple(flags), fixture)
+
+
+def get(test: str, flags: Iterable[str], fixture: str) -> Rule | None:
+    return EXCEPTIONS.get(key(test, flags, fixture))
+
+
+def apply(rows: List[Dict[str, Any]], rule: Rule | None) -> List[Dict[str, Any]]:
+    if not rule:
+        return rows
+    ignore = set(rule.get("ignore", []))
+    cleaned = [{k: v for k, v in row.items() if k not in ignore} for row in rows]
+    return rule.get("expect", cleaned)


### PR DESCRIPTION
## Summary
- introduce parity exceptions allowlist and helpers
- apply allowlist in parity test suites

## Testing
- `black tests/parity/exceptions.py tests/parity/pipeline_parity_test.py tests/parity/test_e2e_parity.py`
- `flake8 tests/parity/pipeline_parity_test.py tests/parity/test_e2e_parity.py tests/parity/exceptions.py`
- `mypy pdf_chunker/ --ignore-missing-imports` *(fails: Missing type parameters for generic type "set" in `page_utils.py`)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/parity/test_e2e_parity.py::test_e2e_parity_flags -q` *(terminated: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68acb1671ddc8325b7fb64f07619071e