### PR TITLE
nox: run full test suite and mark EPUB CLI test optional

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,10 +1,6 @@
-"""Nox sessions scoped to bootstrap code for Story A.
+"""Nox sessions for linting, type checking, and testing."""
 
-This temporary narrowing avoids legacy modules until they are
-refactored in later stories.
-"""
-
-import os
+from pathlib import Path
 
 import nox
 
@@ -21,7 +17,7 @@ def lint(session):
 @nox.session
 def typecheck(session):
     session.install("-e", ".[dev]")
-    targets = [t for t in ["pdf_chunker/__init__.py"] if os.path.exists(t)]
+    targets = [t for t in ["pdf_chunker/__init__.py"] if Path(t).exists()]
     if targets:
         session.run("mypy", "--allow-untyped-globals", *targets)
     else:
@@ -31,9 +27,5 @@ def typecheck(session):
 @nox.session
 def tests(session):
     session.install("-e", ".[dev]")
-    paths = (
-        f"tests/{suite}"
-        for suite in ("bootstrap", "golden", "parity")
-        if os.path.exists(f"tests/{suite}")
-    )
+    paths = (p.as_posix() for p in [Path("tests")] if p.exists())
     session.run("pytest", "-q", *paths)

--- a/tests/epub_cli_regression_test.py
+++ b/tests/epub_cli_regression_test.py
@@ -5,23 +5,23 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from tests.utils.materialize import materialize_base64
+
+pytest.importorskip("ebooklib")
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
 def _read_jsonl(path: Path) -> list[dict]:
     return [
-        json.loads(line)
-        for line in path.read_text(encoding="utf-8").splitlines()
-        if line.strip()
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
     ]
 
 
 def test_cli_epub_matches_golden(tmp_path: Path) -> None:
-    epub = materialize_base64(
-        Path("tests/golden/samples/sample.epub.b64"), tmp_path, "sample.epub"
-    )
+    epub = materialize_base64(Path("tests/golden/samples/sample.epub.b64"), tmp_path, "sample.epub")
     out_file = tmp_path / "out.jsonl"
     cmd = [
         "python",
@@ -47,4 +47,3 @@ def test_cli_epub_matches_golden(tmp_path: Path) -> None:
     actual = _read_jsonl(out_file)
     expected = _read_jsonl(Path("tests/golden/expected/epub.jsonl"))
     assert actual == expected
-


### PR DESCRIPTION
## Summary
- widen nox `tests` session to run the entire test tree
- ensure EPUB CLI regression test skips when `ebooklib` is unavailable

## Testing
- `python -m black noxfile.py tests/epub_cli_regression_test.py`
- `flake8 pdf_chunker/ scripts/ tests/ noxfile.py`
- `mypy pdf_chunker/` *(fails: Missing type parameters and annotations)*
- `pytest -q` *(fails: TypeError in tests/list_detection_edge_case_test.py)*
- `pytest tests/epub_cli_regression_test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ace646b2a08325b66b88dc6f10b670