### PR TITLE
Refactor protocol and remove trailing blanks

### DIFF
--- a/pdf_chunker/adapters/io_pdf.py
+++ b/pdf_chunker/adapters/io_pdf.py
@@ -29,7 +29,10 @@ def _sorted_blocks(blocks: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
         block
         for _, block in sorted(
             enumerate(blocks),
-            key=lambda t: (_page_key(t[1]), t[1].get("source", {}).get("index", t[0])),
+            key=lambda t: (
+                _page_key(t[1]),
+                t[1].get("source", {}).get("index", t[0]),
+            ),
         )
     ]
 
@@ -39,14 +42,17 @@ def _group_blocks(blocks: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
 
     key = _page_key
     sorted_blocks = _sorted_blocks(blocks)
-    return [{"page": page, "blocks": list(group)} for page, group in groupby(sorted_blocks, key)]
+    grouped = groupby(sorted_blocks, key)
+    return [{"page": p, "blocks": list(g)} for p, g in grouped]
 
 
 def _excluded(pages: Sequence[int] | str | None) -> set[int]:
     """Parse ``pages`` spec into a set of page numbers."""
     if pages is None or pages == "":
         return set()
-    return parse_page_ranges(pages) if isinstance(pages, str) else {int(p) for p in pages}
+    if isinstance(pages, str):
+        return parse_page_ranges(pages)
+    return {int(p) for p in pages}
 
 
 def _format_exclusions(pages: Sequence[int] | str | None) -> str | None:
@@ -89,7 +95,8 @@ def _primary_blocks(
 
 
 def _fallback_blocks(
-    path: str, exclude_pages: Sequence[int] | str | None
+    path: str,
+    exclude_pages: Sequence[int] | str | None,
 ) -> list[dict[str, Any]]:
     """Invoke subprocess-based fallback extraction strategies."""
 
@@ -113,17 +120,20 @@ def read(
     blocks = _primary_blocks(abs_path, sorted(excluded), use_pymupdf4llm)
     if not blocks:
         blocks = _fallback_blocks(abs_path, sorted(excluded))
-    filtered = [
-        b
-        for b in blocks
-        if b.get("source", {}).get("page") not in excluded
-    ]
+    filtered = [b for b in blocks if b.get("source", {}).get("page") not in excluded]
     pages = [p for p in _group_blocks(filtered) if p["page"] not in excluded]
     return {"type": "page_blocks", "source_path": abs_path, "pages": pages}
 
 
-def run_pdftotext(cmd: Sequence[str], timeout: int | None = None) -> CompletedProcess[str]:
+def run_pdftotext(
+    cmd: Sequence[str],
+    timeout: int | None = None,
+) -> CompletedProcess[str]:
     """Execute ``pdftotext`` and capture its output."""
 
-    return run(cmd, capture_output=True, text=True, timeout=timeout or _PDFTOTEXT_TIMEOUT)
-
+    return run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout or _PDFTOTEXT_TIMEOUT,
+    )

--- a/pdf_chunker/framework.py
+++ b/pdf_chunker/framework.py
@@ -19,7 +19,9 @@ class Pass(Protocol):
     input_type: Type
     output_type: Type
 
-    def __call__(self, a: Artifact) -> Artifact: ...
+    def __call__(self, a: Artifact) -> Artifact:
+        """Execute the pass."""
+        ...
 
 
 _REGISTRY: Mapping[str, Pass] = MappingProxyType({})

--- a/pdf_chunker/list_detection.py
+++ b/pdf_chunker/list_detection.py
@@ -35,4 +35,3 @@ __all__ = [
     "is_numbered_continuation",
     "_last_non_empty_line",
 ]
-


### PR DESCRIPTION
## Summary
- expand Pass protocol's __call__ into a proper multi-line method
- tidy io_pdf helpers with comprehensions and clearer conditionals
- drop stray trailing blanks in adapters and list shims

## Testing
- `flake8 pdf_chunker/adapters/io_pdf.py pdf_chunker/list_detection.py pdf_chunker/framework.py`


------
https://chatgpt.com/codex/tasks/task_e_68adf68e6fd88325a4dfbd65440a5b94