### PR TITLE
chore: tidy test trailing blanks

### DIFF
--- a/tests/io_pdf_adapter_test.py
+++ b/tests/io_pdf_adapter_test.py
@@ -3,7 +3,7 @@ import pytest
 
 pytest.importorskip("fitz")
 
-from pdf_chunker.adapters.io_pdf import read
+from pdf_chunker.adapters.io_pdf import read  # noqa: E402
 
 
 def test_read_returns_page_blocks():
@@ -26,12 +26,10 @@ def test_use_pymupdf4llm_env(monkeypatch):
         return [{"source": {"page": 1, "index": 0}}]
 
     monkeypatch.setenv("PDF_CHUNKER_USE_PYMUPDF4LLM", "0")
-    monkeypatch.setattr(
-        "pdf_chunker.pdf_parsing.extract_text_blocks_from_pdf", fake_extract
-    )
+    target = "pdf_chunker.pdf_parsing.extract_text_blocks_from_pdf"
+    monkeypatch.setattr(target, fake_extract)
 
     read("test_data/sample_test.pdf", use_pymupdf4llm=True)
 
     assert captured["env"] == "1"
     assert os.getenv("PDF_CHUNKER_USE_PYMUPDF4LLM") == "0"
-

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -3,4 +3,3 @@
 from .materialize import materialize_base64
 
 __all__ = ["materialize_base64"]
-

--- a/tests/utils/materialize.py
+++ b/tests/utils/materialize.py
@@ -16,4 +16,3 @@ def materialize_base64(src: Path, dst_dir: Path, filename: str) -> Path:
     target = dst_dir / filename
     target.write_bytes(data)
     return target
-


### PR DESCRIPTION
## Summary
- fix flake8 W391 issues by trimming trailing blanks in test helpers
- compress io PDF adapter test imports and monkeypatch target

## Testing
- `flake8 tests/io_pdf_adapter_test.py tests/utils/`
- `mypy pdf_chunker/` *(fails: Missing type parameters for generic type "set" and many more)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae08dbfae883259a8c5958415724ad