### PR TITLE
Add mypy configuration

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+ignore_missing_imports = True
+files = pdf_chunker/
+


### PR DESCRIPTION
## Summary
- configure mypy to ignore missing imports and check only `pdf_chunker`

## Testing
- `black --check pdf_chunker/ scripts/ tests/` *(fails: would reformat many files)*
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: numerous style errors)*
- `mypy pdf_chunker/` *(fails: Found 49 errors in 16 files)*
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0b5d53088325aa78a1bf80711106