### PR TITLE
Annotate page utilities and source matcher generics

### DIFF
--- a/pdf_chunker/page_utils.py
+++ b/pdf_chunker/page_utils.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Iterable
+from collections.abc import Iterable
 
 
 def _to_int(part: str) -> int:
@@ -34,8 +34,10 @@ def parse_page_ranges(page_spec: str) -> set[int]:
 
 
 def validate_page_exclusions(
-    excluded_pages: set, total_pages: int, filename: str
-) -> set:
+    excluded_pages: set[int],
+    total_pages: int,
+    filename: str,
+) -> set[int]:
     """
     Validate page exclusions against the actual document and log warnings.
 
@@ -58,7 +60,8 @@ def validate_page_exclusions(
     if invalid_pages:
         invalid_list = sorted(invalid_pages)
         print(
-            f"Warning: Excluding pages beyond document bounds in '{filename}': {invalid_list} (document has {total_pages} pages)",
+            "Warning: Excluding pages beyond document bounds in "
+            f"'{filename}': {invalid_list} (document has {total_pages} pages)",
             file=sys.stderr,
         )
 
@@ -73,7 +76,8 @@ def validate_page_exclusions(
     # Check if all pages would be excluded
     if len(valid_exclusions) >= total_pages:
         print(
-            f"Warning: Page exclusions would exclude all pages in '{filename}'. Processing will continue with no exclusions.",
+            "Warning: Page exclusions would exclude all pages in "
+            f"'{filename}'. Processing will continue with no exclusions.",
             file=sys.stderr,
         )
         return set()

--- a/pdf_chunker/source_matchers.py
+++ b/pdf_chunker/source_matchers.py
@@ -4,16 +4,21 @@
 # for additional strategies.
 from __future__ import annotations
 
-from typing import Callable, List, Tuple
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
 
-Matcher = Callable[[str, dict, list[dict]], bool]
+Matcher = Callable[[str, Mapping[str, Any], Sequence[Mapping[str, Any]]], bool]
 
 
-def substring_match(chunk_start: str, block: dict, _blocks: list[dict]) -> bool:
+def substring_match(
+    chunk_start: str, block: Mapping[str, Any], _blocks: Sequence[Mapping[str, Any]]
+) -> bool:
     return bool(chunk_start) and chunk_start in block.get("text", "")
 
 
-def start_match(chunk_start: str, block: dict, _blocks: list[dict]) -> bool:
+def start_match(
+    chunk_start: str, block: Mapping[str, Any], _blocks: Sequence[Mapping[str, Any]]
+) -> bool:
     block_text = block.get("text", "").strip()
     if not block_text:
         return False
@@ -23,7 +28,9 @@ def start_match(chunk_start: str, block: dict, _blocks: list[dict]) -> bool:
     return lower_chunk.startswith(lower_block) or lower_block.startswith(lower_chunk)
 
 
-def fuzzy_match(chunk_start: str, block: dict, _blocks: list[dict]) -> bool:
+def fuzzy_match(
+    chunk_start: str, block: Mapping[str, Any], _blocks: Sequence[Mapping[str, Any]]
+) -> bool:
     import re
 
     def normalize(s: str) -> str:
@@ -33,12 +40,16 @@ def fuzzy_match(chunk_start: str, block: dict, _blocks: list[dict]) -> bool:
     return normalize(block_start).startswith(normalize(chunk_start)[:15])
 
 
-def overlap_match(chunk_start: str, block: dict, _blocks: list[dict]) -> bool:
+def overlap_match(
+    chunk_start: str, block: Mapping[str, Any], _blocks: Sequence[Mapping[str, Any]]
+) -> bool:
     block_text = block.get("text", "")
     return any(chunk_start[:n] in block_text for n in range(30, 10, -5))
 
 
-def header_match(chunk_start: str, block: dict, blocks: list[dict]) -> bool:
+def header_match(
+    chunk_start: str, block: Mapping[str, Any], blocks: Sequence[Mapping[str, Any]]
+) -> bool:
     return (
         block is blocks[0]
         and bool(chunk_start)
@@ -50,7 +61,7 @@ def header_match(chunk_start: str, block: dict, blocks: list[dict]) -> bool:
     )
 
 
-MATCHERS: List[Tuple[str, Matcher]] = [
+MATCHERS: list[tuple[str, Matcher]] = [
     ("substring match", substring_match),
     ("start match", start_match),
     ("fuzzy match", fuzzy_match),


### PR DESCRIPTION
## Summary
- refine page exclusion utilities with typed sets
- add explicit mapping/sequence types for source matcher predicates

## Testing
- `black pdf_chunker/page_utils.py pdf_chunker/source_matchers.py`
- `flake8 pdf_chunker/page_utils.py pdf_chunker/source_matchers.py`
- `mypy pdf_chunker/page_utils.py pdf_chunker/source_matchers.py`
- `bash scripts/validate_chunks.sh` *(fails: File 'output_chunks_pdf.jsonl' not found)*
- `pytest tests/` *(fails: ModuleNotFoundError: No module named 'typer'; TypeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ae13bffbfc83259c13ce73f08d7575