### PR TITLE
fix bullet char union in list detection test

### DIFF
--- a/tests/list_detection_edge_case_test.py
+++ b/tests/list_detection_edge_case_test.py
@@ -20,7 +20,13 @@ text_strategy = st.text(
 )
 bullet_char_strategy = st.sampled_from(list(BULLET_CHARS) + ["-"])
 
-bullet_start_chars = BULLET_CHARS | {"-"}
+bullet_start_chars = set(BULLET_CHARS) | {"-"}
+
+
+def test_bullet_char_union() -> None:
+    expected = set(BULLET_CHARS) | {"-"}
+    assert bullet_start_chars == expected
+
 
 non_bullet_strategy = text_strategy.filter(
     lambda s: s and not any(s.startswith(ch) for ch in bullet_start_chars)
@@ -32,7 +38,11 @@ non_number_strategy = text_strategy.filter(lambda s: not s[0].isdigit())
 def bullet_pairs(draw):
     bullet = draw(bullet_char_strategy)
     prefix, first, second = draw(st.tuples(text_strategy, text_strategy, text_strategy))
-    bullet_line = lambda b, txt: f"{('- ' if b == '-' else b + ' ')}{txt}"
+
+    def bullet_line(b: str, txt: str) -> str:
+        marker = "- " if b == "-" else f"{b} "
+        return f"{marker}{txt}"
+
     curr = draw(
         st.one_of(
             st.just(bullet_line(bullet, first)),
@@ -64,7 +74,10 @@ def numbered_pairs(draw):
     n1, n2 = draw(st.tuples(number_strategy, number_strategy))
     delim = draw(delim_strategy)
     prefix, first, second = draw(st.tuples(text_strategy, text_strategy, text_strategy))
-    num_line = lambda n, txt: f"{n}{delim} {txt}"
+
+    def num_line(n: int, txt: str) -> str:
+        return f"{n}{delim} {txt}"
+
     curr = draw(
         st.one_of(
             st.just(num_line(n1, first)),


### PR DESCRIPTION
## Summary
- fix bullet char union to avoid TypeError
- add regression test and replace lambdas with local functions in list detection edge case test

## Testing
- `black tests/list_detection_edge_case_test.py`
- `flake8 tests/list_detection_edge_case_test.py`
- `mypy pdf_chunker/` *(fails: Incompatible return value type in list_detect, missing yaml stubs, and other typing errors)*
- `bash scripts/validate_chunks.sh`
- `pytest tests/list_detection_edge_case_test.py::test_bullet_char_union -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1dff4ea483258e67a35851401ed9