### PR TITLE
chore: add PyYAML typings and update mypy config

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,4 @@
 [mypy]
-ignore_missing_imports = True
 files = pdf_chunker/
 python_version = 3.11
 strict_optional = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -124,6 +124,7 @@ toolz==1.0.0
 tqdm==4.67.1
 transformers==4.52.4
 typeguard==4.4.4
+types-PyYAML==6.0.12.20250822
 typer==0.16.1
 typing-inspection==0.4.1
 typing_extensions==4.14.0


### PR DESCRIPTION
## Summary
- add types-PyYAML to requirements for YAML typing
- enable missing import checks in mypy

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` (fails: env_utils_test.py::test_use_pymupdf4llm[None-True], footer_artifact_test.py::test_bullet_footer_removed, heading_detection_test.py::TestHeadingDetectPass::test_pass_adds_heading_metadata, newline_cleanup_test.py::TestNewlineCleanup::test_merge_break_in_quoted_headline, newline_cleanup_test.py::TestNewlineCleanup::test_merge_break_in_quoted_title, parity/pipeline_parity_test.py::test_new_matches_legacy, pass_options_propagation_test.py::test_run_passes_respects_spec_options, process_document_override_test.py::test_callable_overrides, property_based_text_test.py::test_clean_text_idempotent, sample_local_pdf_list_test.py::test_sample_local_pdf_lists_have_newlines, semantic_chunking_test.py::test_limits_and_metrics, semantic_chunking_test.py::test_parameter_propagation, split_semantic_pass_test.py::test_enforces_limits_and_structure, splitter_transform_test.py::test_splitter_size_and_overlap)

------
https://chatgpt.com/codex/tasks/task_e_68ae22e093c08325a384e9e0f10f5a8d