### PR TITLE
refactor: treat exclude_pages as Optional[str] across parsing

### DIFF
--- a/pdf_chunker/adapters/io_pdf.py
+++ b/pdf_chunker/adapters/io_pdf.py
@@ -91,7 +91,7 @@ def _primary_blocks(
     with _env("PDF_CHUNKER_USE_PYMUPDF4LLM", "1" if use_pymupdf4llm else "0"):
         from pdf_chunker.pdf_parsing import extract_text_blocks_from_pdf
 
-        return extract_text_blocks_from_pdf(path, exclude)
+        return extract_text_blocks_from_pdf(path, exclude_pages=exclude)
 
 
 def _fallback_blocks(
@@ -102,7 +102,10 @@ def _fallback_blocks(
 
     from pdf_chunker.extraction_fallbacks import execute_fallback_extraction
 
-    return execute_fallback_extraction(path, _format_exclusions(exclude_pages))
+    return execute_fallback_extraction(
+        path,
+        exclude_pages=_format_exclusions(exclude_pages),
+    )
 
 
 def read(

--- a/pdf_chunker/parsing.py
+++ b/pdf_chunker/parsing.py
@@ -1,25 +1,28 @@
 # parsing.py
 #
 # Default extraction approach: Simplified PyMuPDF4LLM integration
-# - Uses traditional font-based extraction for all structural analysis (headings, blocks, metadata)
-# - Applies PyMuPDF4LLM text cleaning for superior text quality (ligatures, word joining, whitespace)
+# - Uses traditional font-based extraction for all structural analysis
+#   (headings, blocks, metadata)
+# - Applies PyMuPDF4LLM text cleaning for superior text quality
+#   (ligatures, word joining, whitespace)
 # - Maintains proven reliability while leveraging PyMuPDF4LLM's evolving capabilities
 # - Reduces complexity compared to complex hybrid approaches
 
 from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 
 from .epub_parsing import extract_text_blocks_from_epub
 from .pdf_parsing import extract_text_blocks_from_pdf
 
-Extractor = Callable[[Path, str | None], list[dict]]
+Extractor = Callable[[Path, Optional[str]], list[dict]]
 
 
-def _pdf_extractor(path: Path, exclude: str | None) -> list[dict]:
+def _pdf_extractor(path: Path, exclude: Optional[str]) -> list[dict]:
     return extract_text_blocks_from_pdf(str(path), exclude_pages=exclude)
 
 
-def _epub_extractor(path: Path, exclude: str | None) -> list[dict]:
+def _epub_extractor(path: Path, exclude: Optional[str]) -> list[dict]:
     return extract_text_blocks_from_epub(str(path), exclude_spines=exclude)
 
 
@@ -29,7 +32,7 @@ DISPATCH: dict[str, Extractor] = {
 }
 
 
-def extract_structured_text(path: Path | str, exclude_pages: str | None = None) -> list[dict]:
+def extract_structured_text(path: Path | str, exclude_pages: Optional[str] = None) -> list[dict]:
     """Return text blocks from a PDF or EPUB file.
 
     The extractor is chosen solely by the file's suffix, keeping the function

--- a/pdf_chunker/passes/extraction_fallback.py
+++ b/pdf_chunker/passes/extraction_fallback.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from pdf_chunker.framework import Artifact, register
 
@@ -22,14 +22,14 @@ def _score(blocks: list[Block]) -> float:
     return float(_assess_text_quality(text).get("quality_score", 0.0))
 
 
-def _metrics(reason: str | None, blocks: list[Block]) -> dict[str, Any]:
+def _metrics(reason: Optional[str], blocks: list[Block]) -> dict[str, Any]:
     """Return fallback metrics combining ``reason`` and quality ``score``."""
 
     metrics = {"score": _score(blocks)}
     return metrics if reason is None else {**metrics, "reason": reason}
 
 
-def _extract(path: str, reason: str | None) -> tuple[list[Block], dict[str, Any]]:
+def _extract(path: str, reason: Optional[str]) -> tuple[list[Block], dict[str, Any]]:
     """Run fallback extraction for ``path`` and compute metrics."""
 
     from pdf_chunker.extraction_fallbacks import execute_fallback_extraction
@@ -43,7 +43,10 @@ def _meta(meta: dict[str, Any] | None, metrics: dict[str, Any]) -> dict[str, Any
 
     metrics_root = (meta or {}).get("metrics", {})
     fallback = {**metrics_root.get("extraction_fallback", {}), **metrics}
-    return {**(meta or {}), "metrics": {**metrics_root, "extraction_fallback": fallback}}
+    return {
+        **(meta or {}),
+        "metrics": {**metrics_root, "extraction_fallback": fallback},
+    }
 
 
 class _ExtractionFallbackPass:

--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -5,6 +5,7 @@ import sys
 import re
 import logging
 from functools import reduce
+from typing import Optional
 
 try:
     import fitz  # PyMuPDF
@@ -611,7 +612,7 @@ def merge_continuation_blocks(blocks: List[Dict[str, Any]]) -> List[Dict[str, An
     return merged_blocks
 
 
-def extract_text_blocks_from_pdf(filepath: str, exclude_pages: str = None) -> list[dict]:
+def extract_text_blocks_from_pdf(filepath: str, exclude_pages: Optional[str] = None) -> list[dict]:
     """
     Extract structured text from a PDF using traditional extraction with optional PyMuPDF4LLM text cleaning.
 
@@ -927,7 +928,7 @@ def extract_text_blocks_from_pdf(filepath: str, exclude_pages: str = None) -> li
 _legacy_extract_text_blocks_from_pdf = extract_text_blocks_from_pdf
 
 
-def extract_text_blocks_from_pdf(filepath: str, exclude_pages: str | None = None) -> list[dict]:
+def extract_text_blocks_from_pdf(filepath: str, exclude_pages: Optional[str] = None) -> list[dict]:
     """Shim retaining the original extraction behavior."""
 
     return _legacy_extract_text_blocks_from_pdf(filepath, exclude_pages)


### PR DESCRIPTION
## Summary
- allow `exclude_pages` to be passed as `None` across PDF parsing and fallbacks
- propagate optional `fallback_reason` and exclude handling to downstream adapters

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/extraction_fallbacks.py pdf_chunker/parsing.py pdf_chunker/adapters/io_pdf.py pdf_chunker/passes/extraction_fallback.py pdf_chunker/pdf_parsing.py` *(fails: many existing style errors)*
- `mypy pdf_chunker/adapters/io_pdf.py pdf_chunker/extraction_fallbacks.py pdf_chunker/parsing.py pdf_chunker/passes/extraction_fallback.py pdf_chunker/pdf_parsing.py` *(fails: incompatible return value in list_detect, unused ignore, interrupted)*
- `bash scripts/validate_chunks.sh`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_68ae67e042c08325abeacff046925f99