### PR TITLE
refactor: annotate reducer accumulators

### DIFF
--- a/pdf_chunker/config.py
+++ b/pdf_chunker/config.py
@@ -73,11 +73,11 @@ def load_spec(
     """Load YAML + env/CLI overrides into a validated PipelineSpec."""
     data = _read_yaml(path)
     opts = data.get("options", {})
-    merged = reduce(
-        _merge_options,
-        filter(None, [opts, _env_overrides(), overrides]),
-        {},
+    sources: Iterable[Dict[str, Dict[str, Any]]] = (
+        d for d in (opts, _env_overrides(), overrides) if d
     )
+    acc: Dict[str, Dict[str, Any]] = {}
+    merged = reduce(_merge_options, sources, acc)
     pipeline = data.get("pipeline", [])
     _warn_unknown_options(pipeline, merged)
     if merged:

--- a/pdf_chunker/core_new.py
+++ b/pdf_chunker/core_new.py
@@ -91,7 +91,8 @@ def _run_passes(spec: PipelineSpec, a: Artifact) -> tuple[Artifact, dict[str, fl
     """Run pipeline passes declared in ``spec`` capturing per-pass timings."""
     chain = (registry()[s] for s in spec.pipeline)
     passes = [configure_pass(p, spec.options.get(p.name, {})) for p in chain]
-    a, timings = reduce(_time_step, passes, (a, {}))
+    acc: tuple[Artifact, dict[str, float]] = (a, {})
+    a, timings = reduce(_time_step, passes, acc)
     return a, timings
 
 


### PR DESCRIPTION
## Summary
- type reducer accumulators in `config.load_spec` and `_run_passes`

## Testing
- `black pdf_chunker/config.py pdf_chunker/core_new.py`
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: line length, unused imports, missing stubs, etc.)*
- `mypy pdf_chunker/` *(fails: missing stubs and type errors in unrelated modules)*
- `pytest tests/` *(fails: ModuleNotFoundError: typer)*
- `bash scripts/validate_chunks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ae6ca8f0e8832591492bcb25570123