### PR TITLE
refactor: type fallback metrics and ai_enrich config merge

### DIFF
--- a/pdf_chunker/adapters/ai_enrich.py
+++ b/pdf_chunker/adapters/ai_enrich.py
@@ -1,12 +1,12 @@
 import json
 import os
-from pathlib import Path
-from typing import Callable
-
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from functools import reduce
+from pathlib import Path
+from typing import cast
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 from pdf_chunker.passes.ai_enrich import classify_chunk_utterance
 
@@ -18,13 +18,13 @@ class Client:
         self,
         *,
         completion_fn: Callable[[str], str],
-        tag_configs: dict | None = None,
+        tag_configs: dict[str, list[str]] | None = None,
     ) -> None:
         self._completion_fn = completion_fn
-        self._tag_configs = tag_configs or _load_tag_configs()
+        self._tag_configs: dict[str, list[str]] = tag_configs or _load_tag_configs()
 
     def classify_chunk_utterance(
-        self, text: str, *, tag_configs: dict | None = None
+        self, text: str, *, tag_configs: dict[str, list[str]] | None = None
     ) -> dict:
         return classify_chunk_utterance(
             text,
@@ -33,7 +33,7 @@ class Client:
         )
 
 
-def _load_tag_configs(config_dir: str = "config/tags") -> dict:
+def _load_tag_configs(config_dir: str = "config/tags") -> dict[str, list[str]]:
     """Merge YAML tag configurations into a single dictionary."""
     config_path = Path(config_dir)
     if not config_path.is_absolute():
@@ -41,7 +41,7 @@ def _load_tag_configs(config_dir: str = "config/tags") -> dict:
     if not config_path.exists():
         return {}
 
-    def load_yaml(path: Path) -> dict:
+    def load_yaml(path: Path) -> dict[str, list[str]]:
         try:
             with path.open("r", encoding="utf-8") as handle:
                 data = yaml.safe_load(handle) or {}
@@ -49,13 +49,13 @@ def _load_tag_configs(config_dir: str = "config/tags") -> dict:
         except FileNotFoundError:
             return {}
 
-    def merge_dicts(acc: dict, nxt: dict) -> dict:
+    def merge_dicts(acc: dict[str, list[str]], nxt: dict[str, list[str]]) -> dict[str, list[str]]:
         return {key: acc.get(key, []) + nxt.get(key, []) for key in set(acc) | set(nxt)}
 
-    merged = reduce(
+    merged: dict[str, list[str]] = reduce(
         merge_dicts,
         map(load_yaml, config_path.glob("*.yaml")),
-        {},
+        cast(dict[str, list[str]], {}),
     )
 
     return {
@@ -73,12 +73,12 @@ def init_llm(api_key: str | None = None) -> Callable[[str], str]:
     if not key:
         raise ValueError("OPENAI_API_KEY not found in .env file or environment.")
     try:
-        import litellm  # type: ignore
+        import litellm
     except Exception as exc:  # pragma: no cover
         raise ImportError("litellm is required for init_llm") from exc
 
     def completion(prompt: str) -> str:
-        response = litellm.completion(  # type: ignore[union-attr]
+        response = litellm.completion(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": prompt}],
             temperature=0.0,
@@ -93,7 +93,7 @@ def init_llm(api_key: str | None = None) -> Callable[[str], str]:
 def _process_chunk_for_file(
     chunk: dict,
     *,
-    tag_configs: dict,
+    tag_configs: dict[str, list[str]],
     completion_fn: Callable[[str], str],
 ) -> dict:
     """Helper to wrap utterance classification and tagging for file processing."""
@@ -105,7 +105,11 @@ def _process_chunk_for_file(
         "utterance_type": result["classification"],
         "tags": result["tags"],
     }
-    meta = {**chunk.get("metadata", {}), "utterance_type": result["classification"], "tags": result["tags"]}
+    meta = {
+        **chunk.get("metadata", {}),
+        "utterance_type": result["classification"],
+        "tags": result["tags"],
+    }
     return {**chunk, "metadata": meta}
 
 
@@ -113,13 +117,13 @@ def _process_jsonl_file(
     input_path: str,
     output_path: str,
     completion_fn: Callable[[str], str],
-    tag_configs: dict | None = None,
+    tag_configs: dict[str, list[str]] | None = None,
     max_workers: int = 10,
 ) -> None:
     """Read ``input_path`` JSONL, classify chunks, and write to ``output_path``."""
     tag_configs = tag_configs or _load_tag_configs()
     with (
-        open(input_path, "r", encoding="utf-8") as infile,
+        open(input_path, encoding="utf-8") as infile,
         open(output_path, "w", encoding="utf-8") as outfile,
     ):
         chunks = [json.loads(line) for line in infile]

--- a/pdf_chunker/passes/extraction_fallback.py
+++ b/pdf_chunker/passes/extraction_fallback.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from pdf_chunker.framework import Artifact, register
 
@@ -22,14 +22,14 @@ def _score(blocks: list[Block]) -> float:
     return float(_assess_text_quality(text).get("quality_score", 0.0))
 
 
-def _metrics(reason: Optional[str], blocks: list[Block]) -> dict[str, Any]:
+def _metrics(reason: str | None, blocks: list[Block]) -> dict[str, float | str]:
     """Return fallback metrics combining ``reason`` and quality ``score``."""
 
-    metrics = {"score": _score(blocks)}
+    metrics: dict[str, float | str] = {"score": _score(blocks)}
     return metrics if reason is None else {**metrics, "reason": reason}
 
 
-def _extract(path: str, reason: Optional[str]) -> tuple[list[Block], dict[str, Any]]:
+def _extract(path: str, reason: str | None) -> tuple[list[Block], dict[str, Any]]:
     """Run fallback extraction for ``path`` and compute metrics."""
 
     from pdf_chunker.extraction_fallbacks import execute_fallback_extraction
@@ -38,7 +38,7 @@ def _extract(path: str, reason: Optional[str]) -> tuple[list[Block], dict[str, A
     return blocks, _metrics(reason, blocks)
 
 
-def _meta(meta: dict[str, Any] | None, metrics: dict[str, Any]) -> dict[str, Any]:
+def _meta(meta: dict[str, Any] | None, metrics: dict[str, float | str]) -> dict[str, Any]:
     """Return a new meta dict with fallback metrics merged immutably."""
 
     metrics_root = (meta or {}).get("metrics", {})


### PR DESCRIPTION
## Summary
- allow extraction_fallback metrics to include string reasons
- type ai_enrich tag config merging and remove unused ignores

## Testing
- `mypy --follow-imports=skip pdf_chunker/passes/extraction_fallback.py pdf_chunker/adapters/ai_enrich.py`
- `nox -s typecheck`
- `nox -s lint tests` (fails: tests/env_utils_test.py::test_use_pymupdf4llm[None-True], ...)


------
https://chatgpt.com/codex/tasks/task_e_68af1f506d508325af157203ff6b6a96