### PR TITLE
style: format epub and heading helpers

### DIFF
--- a/pdf_chunker/epub_parsing.py
+++ b/pdf_chunker/epub_parsing.py
@@ -72,21 +72,21 @@ def process_epub_item(item: epub.EpubHtml, filename: str) -> List[TextBlock]:
     body_tag = cast(Tag, body)
 
     item_name = item.get_name()
-    elements = body_tag.find_all([
-        "p",
-        "li",
-        "h1",
-        "h2",
-        "h3",
-        "h4",
-        "h5",
-        "h6",
-    ])
+    elements = body_tag.find_all(
+        [
+            "p",
+            "li",
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
+        ]
+    )
     return [
         block
-        for block in (
-            _element_to_block(element, filename, item_name) for element in elements
-        )
+        for block in (_element_to_block(element, filename, item_name) for element in elements)
         if block
         and not (
             item_name == "nav.xhtml"

--- a/pdf_chunker/heading_detection.py
+++ b/pdf_chunker/heading_detection.py
@@ -44,11 +44,7 @@ def _detect_heading_fallback(text: str) -> bool:
         return True
 
     # Text that starts with common heading patterns
-    if (
-        _has_heading_starter(words)
-        and len(words) <= 8
-        and not text.endswith(TRAILING_PUNCTUATION)
-    ):
+    if _has_heading_starter(words) and len(words) <= 8 and not text.endswith(TRAILING_PUNCTUATION):
         return True
 
     # Text that's mostly numbers (like "1.2.3 Some Topic")
@@ -105,9 +101,7 @@ def detect_headings_from_font_analysis(
     """Extract heading information using traditional font-based analysis."""
 
     def _is_heading(text: str, block_type: str) -> bool:
-        declared_heading = block_type == "heading" and not text.endswith(
-            TRAILING_PUNCTUATION
-        )
+        declared_heading = block_type == "heading" and not text.endswith(TRAILING_PUNCTUATION)
         return declared_heading or _detect_heading_fallback(text)
 
     def _make_heading(i: int, block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -203,9 +197,7 @@ def detect_headings_hybrid(
             block.get("metadata", {}).get("text_enhanced_with_pymupdf4llm", False)
             for block in blocks
         )
-        extraction_method = (
-            "pymupdf4llm_enhanced" if has_pymupdf4llm_enhancement else "traditional"
-        )
+        extraction_method = "pymupdf4llm_enhanced" if has_pymupdf4llm_enhancement else "traditional"
 
     # For PyMuPDF4LLM-enhanced extraction, use traditional font-based analysis
     # since PyMuPDF4LLM is only used for text cleaning in the simplified approach
@@ -308,9 +300,7 @@ def validate_heading_consistency(
 
     # Calculate consistency metrics
     total_unique_headings = len(pymupdf4llm_texts | traditional_texts)
-    overlap_ratio = (
-        len(common_headings) / total_unique_headings if total_unique_headings > 0 else 0
-    )
+    overlap_ratio = len(common_headings) / total_unique_headings if total_unique_headings > 0 else 0
 
     return {
         "total_pymupdf4llm_headings": len(pymupdf4llm_headings),


### PR DESCRIPTION
## Summary
- apply Black formatting to epub parsing helper
- apply Black formatting to heading detection module

## Testing
- `black --check pdf_chunker/epub_parsing.py pdf_chunker/heading_detection.py`
- `flake8 pdf_chunker/epub_parsing.py pdf_chunker/heading_detection.py` *(fails: line too long, unused import)*
- `mypy --no-error-summary pdf_chunker/epub_parsing.py pdf_chunker/heading_detection.py` *(fails: unused type ignore)*
- `bash scripts/validate_chunks.sh`
- `pytest -q tests/list_detection_edge_case_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68add03c5f188325b7ff095ca0958fac