### PR TITLE
style: format CLI and split pass

### DIFF
--- a/pdf_chunker/cli.py
+++ b/pdf_chunker/cli.py
@@ -51,7 +51,7 @@ def _safe(func: Callable[[], None]) -> None:
         func()
     except Exception as exc:  # pragma: no cover - exercised in CLI tests
         _exit_with_error(exc)
-        
+
 
 def _run_convert(
     input_path: Path,
@@ -103,9 +103,7 @@ def _core_helpers(
     sys.modules.setdefault("pdf_chunker.adapters", pkg)
 
     def _load(name: str) -> None:
-        spec = ilu.spec_from_file_location(
-            f"pdf_chunker.adapters.{name}", base / f"{name}.py"
-        )
+        spec = ilu.spec_from_file_location(f"pdf_chunker.adapters.{name}", base / f"{name}.py")
         if not spec or not spec.loader:
             raise ImportError(f"Cannot load adapter module: {name}")
         module = ilu.module_from_spec(spec)

--- a/pdf_chunker/epub_parsing.py
+++ b/pdf_chunker/epub_parsing.py
@@ -72,21 +72,21 @@ def process_epub_item(item: epub.EpubHtml, filename: str) -> List[TextBlock]:
     body_tag = cast(Tag, body)
 
     item_name = item.get_name()
-    elements = body_tag.find_all([
-        "p",
-        "li",
-        "h1",
-        "h2",
-        "h3",
-        "h4",
-        "h5",
-        "h6",
-    ])
+    elements = body_tag.find_all(
+        [
+            "p",
+            "li",
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
+        ]
+    )
     return [
         block
-        for block in (
-            _element_to_block(element, filename, item_name) for element in elements
-        )
+        for block in (_element_to_block(element, filename, item_name) for element in elements)
         if block
         and not (
             item_name == "nav.xhtml"

--- a/pdf_chunker/heading_detection.py
+++ b/pdf_chunker/heading_detection.py
@@ -44,11 +44,7 @@ def _detect_heading_fallback(text: str) -> bool:
         return True
 
     # Text that starts with common heading patterns
-    if (
-        _has_heading_starter(words)
-        and len(words) <= 8
-        and not text.endswith(TRAILING_PUNCTUATION)
-    ):
+    if _has_heading_starter(words) and len(words) <= 8 and not text.endswith(TRAILING_PUNCTUATION):
         return True
 
     # Text that's mostly numbers (like "1.2.3 Some Topic")
@@ -105,9 +101,7 @@ def detect_headings_from_font_analysis(
     """Extract heading information using traditional font-based analysis."""
 
     def _is_heading(text: str, block_type: str) -> bool:
-        declared_heading = block_type == "heading" and not text.endswith(
-            TRAILING_PUNCTUATION
-        )
+        declared_heading = block_type == "heading" and not text.endswith(TRAILING_PUNCTUATION)
         return declared_heading or _detect_heading_fallback(text)
 
     def _make_heading(i: int, block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -203,9 +197,7 @@ def detect_headings_hybrid(
             block.get("metadata", {}).get("text_enhanced_with_pymupdf4llm", False)
             for block in blocks
         )
-        extraction_method = (
-            "pymupdf4llm_enhanced" if has_pymupdf4llm_enhancement else "traditional"
-        )
+        extraction_method = "pymupdf4llm_enhanced" if has_pymupdf4llm_enhancement else "traditional"
 
     # For PyMuPDF4LLM-enhanced extraction, use traditional font-based analysis
     # since PyMuPDF4LLM is only used for text cleaning in the simplified approach
@@ -308,9 +300,7 @@ def validate_heading_consistency(
 
     # Calculate consistency metrics
     total_unique_headings = len(pymupdf4llm_texts | traditional_texts)
-    overlap_ratio = (
-        len(common_headings) / total_unique_headings if total_unique_headings > 0 else 0
-    )
+    overlap_ratio = len(common_headings) / total_unique_headings if total_unique_headings > 0 else 0
 
     return {
         "total_pymupdf4llm_headings": len(pymupdf4llm_headings),

--- a/pdf_chunker/passes/split_semantic.py
+++ b/pdf_chunker/passes/split_semantic.py
@@ -199,7 +199,9 @@ def _resolve_opts(meta: Mapping[str, Any] | None, base: _SplitSemanticPass) -> t
 class _SplitSemanticPass:
     name: str = field(default="split_semantic", init=False)
     input_type: type = field(default=dict, init=False)  # expects {"type": "page_blocks"}
-    output_type: type = field(default=dict, init=False)  # returns {"type": "chunks", "items": [...]}
+    output_type: type = field(
+        default=dict, init=False
+    )  # returns {"type": "chunks", "items": [...]}
     chunk_size: int = 400
     overlap: int = 50
     min_chunk_size: int | None = None


### PR DESCRIPTION
## Summary
- auto-format CLI module and simplify adapter loader invocation
- apply Black formatting to semantic split pass dataclass fields

## Testing
- `black --check pdf_chunker/cli.py pdf_chunker/passes/split_semantic.py`
- `flake8 pdf_chunker/cli.py pdf_chunker/passes/split_semantic.py` *(fails: line too long)*
- `mypy --no-error-summary pdf_chunker/cli.py pdf_chunker/passes/split_semantic.py` *(fails: missing stubs, unused ignores, arg-type)*
- `bash scripts/validate_chunks.sh`
- `pytest -q tests/list_detection_edge_case_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68add03c5f188325b7ff095ca0958fac