### PR TITLE
style: format CLI, split pass, and initial scripts

### DIFF
--- a/pdf_chunker/cli.py
+++ b/pdf_chunker/cli.py
@@ -51,7 +51,7 @@ def _safe(func: Callable[[], None]) -> None:
         func()
     except Exception as exc:  # pragma: no cover - exercised in CLI tests
         _exit_with_error(exc)
-        
+
 
 def _run_convert(
     input_path: Path,
@@ -103,9 +103,7 @@ def _core_helpers(
     sys.modules.setdefault("pdf_chunker.adapters", pkg)
 
     def _load(name: str) -> None:
-        spec = ilu.spec_from_file_location(
-            f"pdf_chunker.adapters.{name}", base / f"{name}.py"
-        )
+        spec = ilu.spec_from_file_location(f"pdf_chunker.adapters.{name}", base / f"{name}.py")
         if not spec or not spec.loader:
             raise ImportError(f"Cannot load adapter module: {name}")
         module = ilu.module_from_spec(spec)

--- a/pdf_chunker/epub_parsing.py
+++ b/pdf_chunker/epub_parsing.py
@@ -72,21 +72,21 @@ def process_epub_item(item: epub.EpubHtml, filename: str) -> List[TextBlock]:
     body_tag = cast(Tag, body)
 
     item_name = item.get_name()
-    elements = body_tag.find_all([
-        "p",
-        "li",
-        "h1",
-        "h2",
-        "h3",
-        "h4",
-        "h5",
-        "h6",
-    ])
+    elements = body_tag.find_all(
+        [
+            "p",
+            "li",
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
+        ]
+    )
     return [
         block
-        for block in (
-            _element_to_block(element, filename, item_name) for element in elements
-        )
+        for block in (_element_to_block(element, filename, item_name) for element in elements)
         if block
         and not (
             item_name == "nav.xhtml"

--- a/pdf_chunker/heading_detection.py
+++ b/pdf_chunker/heading_detection.py
@@ -44,11 +44,7 @@ def _detect_heading_fallback(text: str) -> bool:
         return True
 
     # Text that starts with common heading patterns
-    if (
-        _has_heading_starter(words)
-        and len(words) <= 8
-        and not text.endswith(TRAILING_PUNCTUATION)
-    ):
+    if _has_heading_starter(words) and len(words) <= 8 and not text.endswith(TRAILING_PUNCTUATION):
         return True
 
     # Text that's mostly numbers (like "1.2.3 Some Topic")
@@ -105,9 +101,7 @@ def detect_headings_from_font_analysis(
     """Extract heading information using traditional font-based analysis."""
 
     def _is_heading(text: str, block_type: str) -> bool:
-        declared_heading = block_type == "heading" and not text.endswith(
-            TRAILING_PUNCTUATION
-        )
+        declared_heading = block_type == "heading" and not text.endswith(TRAILING_PUNCTUATION)
         return declared_heading or _detect_heading_fallback(text)
 
     def _make_heading(i: int, block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -203,9 +197,7 @@ def detect_headings_hybrid(
             block.get("metadata", {}).get("text_enhanced_with_pymupdf4llm", False)
             for block in blocks
         )
-        extraction_method = (
-            "pymupdf4llm_enhanced" if has_pymupdf4llm_enhancement else "traditional"
-        )
+        extraction_method = "pymupdf4llm_enhanced" if has_pymupdf4llm_enhancement else "traditional"
 
     # For PyMuPDF4LLM-enhanced extraction, use traditional font-based analysis
     # since PyMuPDF4LLM is only used for text cleaning in the simplified approach
@@ -308,9 +300,7 @@ def validate_heading_consistency(
 
     # Calculate consistency metrics
     total_unique_headings = len(pymupdf4llm_texts | traditional_texts)
-    overlap_ratio = (
-        len(common_headings) / total_unique_headings if total_unique_headings > 0 else 0
-    )
+    overlap_ratio = len(common_headings) / total_unique_headings if total_unique_headings > 0 else 0
 
     return {
         "total_pymupdf4llm_headings": len(pymupdf4llm_headings),

--- a/pdf_chunker/passes/split_semantic.py
+++ b/pdf_chunker/passes/split_semantic.py
@@ -199,7 +199,9 @@ def _resolve_opts(meta: Mapping[str, Any] | None, base: _SplitSemanticPass) -> t
 class _SplitSemanticPass:
     name: str = field(default="split_semantic", init=False)
     input_type: type = field(default=dict, init=False)  # expects {"type": "page_blocks"}
-    output_type: type = field(default=dict, init=False)  # returns {"type": "chunks", "items": [...]}
+    output_type: type = field(
+        default=dict, init=False
+    )  # returns {"type": "chunks", "items": [...]}
     chunk_size: int = 400
     overlap: int = 50
     min_chunk_size: int | None = None

--- a/scripts/benchmark_extraction.py
+++ b/scripts/benchmark_extraction.py
@@ -211,9 +211,7 @@ def extract_with_traditional_approach(pdf_file: str, **kwargs) -> List[Dict[str,
         pymupdf4llm_module.PYMUPDF4LLM_AVAILABLE = False
 
         # Use the PDF parsing function which will now use traditional methods
-        blocks = extract_text_blocks_from_pdf(
-            pdf_file, exclude_pages=kwargs.get("exclude_pages")
-        )
+        blocks = extract_text_blocks_from_pdf(pdf_file, exclude_pages=kwargs.get("exclude_pages"))
 
         return blocks
 
@@ -361,9 +359,7 @@ def compare_methods(
                 "hybrid_avg_memory_mb": hybrid_memory,
                 "traditional_avg_memory_mb": traditional_memory,
                 "memory_ratio": memory_ratio,
-                "lower_memory_method": (
-                    "hybrid" if memory_ratio < 1.0 else "traditional"
-                ),
+                "lower_memory_method": ("hybrid" if memory_ratio < 1.0 else "traditional"),
             }
 
     # Quality comparison
@@ -402,9 +398,7 @@ def compare_methods(
         "traditional_success_rate": traditional_success_rate,
         "reliability_difference": hybrid_success_rate - traditional_success_rate,
         "more_reliable_method": (
-            "hybrid"
-            if hybrid_success_rate > traditional_success_rate
-            else "traditional"
+            "hybrid" if hybrid_success_rate > traditional_success_rate else "traditional"
         ),
     }
 
@@ -423,9 +417,7 @@ def compare_methods(
     if abs(qual_comp.get("quality_difference", 0)) > 0.1:
         better = qual_comp.get("better_quality_method", "unknown")
         diff = abs(qual_comp.get("quality_difference", 0))
-        recommendations.append(
-            f"{better.title()} method has {diff:.2f} higher quality score"
-        )
+        recommendations.append(f"{better.title()} method has {diff:.2f} higher quality score")
 
     # Heading detection recommendations
     heading_comp = qual_comp.get("heading_detection", {})
@@ -472,9 +464,7 @@ def run_benchmark(
     Returns:
         Complete benchmark results
     """
-    print(
-        f"Starting benchmark with {len(pdf_files)} PDF files, {iterations} iterations each"
-    )
+    print(f"Starting benchmark with {len(pdf_files)} PDF files, {iterations} iterations each")
     print(f"PyMuPDF4LLM available: {is_pymupdf4llm_available()}")
 
     all_hybrid_metrics = []
@@ -487,9 +477,7 @@ def run_benchmark(
     }
 
     for i, pdf_file in enumerate(pdf_files):
-        print(
-            f"\nProcessing file {i + 1}/{len(pdf_files)}: {os.path.basename(pdf_file)}"
-        )
+        print(f"\nProcessing file {i + 1}/{len(pdf_files)}: {os.path.basename(pdf_file)}")
 
         if not os.path.exists(pdf_file):
             print(f"  WARNING: File not found: {pdf_file}")
@@ -577,9 +565,7 @@ def print_benchmark_summary(results: BenchmarkResults) -> None:
 
         mem_comp = perf.get("memory_comparison", {})
         if mem_comp:
-            print(
-                f"  Hybrid average memory: {mem_comp.get('hybrid_avg_memory_mb', 0):.1f} MB"
-            )
+            print(f"  Hybrid average memory: {mem_comp.get('hybrid_avg_memory_mb', 0):.1f} MB")
             print(
                 f"  Traditional average memory: {mem_comp.get('traditional_avg_memory_mb', 0):.1f} MB"
             )
@@ -592,18 +578,12 @@ def print_benchmark_summary(results: BenchmarkResults) -> None:
     if qual:
         print(f"\nQuality Comparison:")
         print(f"  Hybrid average quality: {qual.get('hybrid_avg_quality', 0):.2f}")
-        print(
-            f"  Traditional average quality: {qual.get('traditional_avg_quality', 0):.2f}"
-        )
-        print(
-            f"  Better quality method: {qual.get('better_quality_method', 'unknown').title()}"
-        )
+        print(f"  Traditional average quality: {qual.get('traditional_avg_quality', 0):.2f}")
+        print(f"  Better quality method: {qual.get('better_quality_method', 'unknown').title()}")
 
         heading = qual.get("heading_detection", {})
         if heading:
-            print(
-                f"  Hybrid average headings: {heading.get('hybrid_avg_headings', 0):.1f}"
-            )
+            print(f"  Hybrid average headings: {heading.get('hybrid_avg_headings', 0):.1f}")
             print(
                 f"  Traditional average headings: {heading.get('traditional_avg_headings', 0):.1f}"
             )
@@ -616,12 +596,8 @@ def print_benchmark_summary(results: BenchmarkResults) -> None:
     if rel:
         print(f"\nReliability Comparison:")
         print(f"  Hybrid success rate: {rel.get('hybrid_success_rate', 0):.1%}")
-        print(
-            f"  Traditional success rate: {rel.get('traditional_success_rate', 0):.1%}"
-        )
-        print(
-            f"  More reliable method: {rel.get('more_reliable_method', 'unknown').title()}"
-        )
+        print(f"  Traditional success rate: {rel.get('traditional_success_rate', 0):.1%}")
+        print(f"  More reliable method: {rel.get('more_reliable_method', 'unknown').title()}")
 
     # Recommendations
     recommendations = comparison.get("recommendations", [])
@@ -665,9 +641,7 @@ def main() -> None:
         help="Overlap size for chunking (default: 200)",
     )
     parser.add_argument("--exclude-pages", help='Pages to exclude (e.g., "1,3,5-10")')
-    parser.add_argument(
-        "--quiet", "-q", action="store_true", help="Suppress detailed output"
-    )
+    parser.add_argument("--quiet", "-q", action="store_true", help="Suppress detailed output")
 
     args = parser.parse_args()
 
@@ -703,9 +677,7 @@ def main() -> None:
         print(f"\nDetailed results saved to: {args.output}")
 
         # Exit with appropriate code based on results
-        hybrid_success = results.comparison_summary["hybrid_statistics"].get(
-            "success_rate", 0
-        )
+        hybrid_success = results.comparison_summary["hybrid_statistics"].get("success_rate", 0)
         traditional_success = results.comparison_summary["traditional_statistics"].get(
             "success_rate", 0
         )

--- a/scripts/chunk_pdf.py
+++ b/scripts/chunk_pdf.py
@@ -48,9 +48,7 @@ def main() -> None:
 
             print(f"EPUB Spine Structure ({len(spine_items)} items):")
             for item in spine_items:
-                print(
-                    f"{item['index']:3d}. {item['filename']} - {item['content_preview']}"
-                )
+                print(f"{item['index']:3d}. {item['filename']} - {item['content_preview']}")
 
             return 0
         except Exception as e:


### PR DESCRIPTION
## Summary
- auto-format CLI module and simplify adapter loader invocation
- apply Black formatting to semantic split pass dataclass fields
- reformat chunking CLI and extraction benchmark scripts for consistent style

## Testing
- `black --check pdf_chunker/cli.py pdf_chunker/passes/split_semantic.py`
- `flake8 pdf_chunker/cli.py pdf_chunker/passes/split_semantic.py` *(fails: line too long)*
- `mypy --no-error-summary pdf_chunker/cli.py pdf_chunker/passes/split_semantic.py` *(fails: missing stubs, unused ignores, arg-type)*
- `black --check scripts/chunk_pdf.py scripts/benchmark_extraction.py`
- `flake8 scripts/chunk_pdf.py scripts/benchmark_extraction.py` *(fails: line too long, imports, F541)*
- `mypy scripts/chunk_pdf.py scripts/benchmark_extraction.py` *(fails: unused ignore in heading_detection module)*
- `bash scripts/validate_chunks.sh`
- `pytest -q tests/list_detection_edge_case_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68add03c5f188325b7ff095ca0958fac