### PR TITLE
chore: format code with black

### DIFF
--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -6,6 +6,7 @@ import re
 import logging
 from functools import reduce
 from typing import Optional, Callable, Any, Tuple, Sequence
+
 try:
     import fitz  # PyMuPDF
 except Exception:

--- a/pdf_chunker/pymupdf4llm_integration.py
+++ b/pdf_chunker/pymupdf4llm_integration.py
@@ -27,9 +27,7 @@ logger = logging.getLogger(__name__)
 
 def _is_meaningful_text(text: str) -> bool:
     stripped = text.strip()
-    return bool(stripped) and (
-        len(stripped) >= 10 or any(ch.isalpha() for ch in stripped)
-    )
+    return bool(stripped) and (len(stripped) >= 10 or any(ch.isalpha() for ch in stripped))
 
 
 class PyMuPDF4LLMExtractionError(Exception):
@@ -155,9 +153,7 @@ def extract_with_pymupdf4llm(
         return cleaned_blocks, stats
 
     except ImportError:
-        logger.error(
-            "PyMuPDF4LLM not available - install with: pip install pymupdf4llm"
-        )
+        logger.error("PyMuPDF4LLM not available - install with: pip install pymupdf4llm")
         return [], {
             "enhanced": 0,
             "failed": 1,
@@ -299,9 +295,7 @@ def _clean_pymupdf4llm_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     return cleaned_block
 
 
-def _convert_markdown_to_blocks(
-    markdown_text: str, pdf_path: str
-) -> List[Dict[str, Any]]:
+def _convert_markdown_to_blocks(markdown_text: str, pdf_path: str) -> List[Dict[str, Any]]:
     """
     Convert PyMuPDF4LLM Markdown output to structured blocks.
 
@@ -320,9 +314,7 @@ def _convert_markdown_to_blocks(
 
     from .text_cleaning import collapse_single_newlines
 
-    def _build_block(
-        lines: List[str], block_type: str, **extra: Any
-    ) -> Optional[Dict[str, Any]]:
+    def _build_block(lines: List[str], block_type: str, **extra: Any) -> Optional[Dict[str, Any]]:
         text = collapse_single_newlines("\n".join(lines).strip())
         if not text:
             return None
@@ -551,9 +543,7 @@ def should_apply_pymupdf4llm_cleaning(blocks: list[dict]) -> bool:
         True if PyMuPDF4LLM cleaning should be attempted, False otherwise.
     """
     if not blocks or not isinstance(blocks, list):
-        logger.debug(
-            "should_apply_pymupdf4llm_cleaning: No blocks provided or not a list."
-        )
+        logger.debug("should_apply_pymupdf4llm_cleaning: No blocks provided or not a list.")
         return False
 
     # Heuristic: If any block shows extraction issues, recommend cleaning
@@ -688,9 +678,7 @@ def _call_pymupdf4llm_api(pdf_path: str, pages: Optional[List[int]] = None) -> s
     )
 
 
-def assess_text_cleaning_quality(
-    original_text: str, cleaned_text: str
-) -> Dict[str, Any]:
+def assess_text_cleaning_quality(original_text: str, cleaned_text: str) -> Dict[str, Any]:
     """
     Assess the quality of PyMuPDF4LLM text cleaning for simple quality validation.
 
@@ -761,9 +749,7 @@ def assess_text_cleaning_quality(
     }
 
 
-def detect_text_flow_degradation(
-    original_text: str, cleaned_text: str
-) -> Dict[str, Any]:
+def detect_text_flow_degradation(original_text: str, cleaned_text: str) -> Dict[str, Any]:
     """
     Detect if PyMuPDF4LLM cleaning has degraded text flow quality.
 
@@ -793,13 +779,9 @@ def detect_text_flow_degradation(
     original_sentences = _re4.split(r"[.!?]+", original_text)
     cleaned_sentences = _re4.split(r"[.!?]+", cleaned_text)
 
-    short_fragments = [
-        s.strip() for s in cleaned_sentences if 0 < len(s.strip().split()) <= 4
-    ]
+    short_fragments = [s.strip() for s in cleaned_sentences if 0 < len(s.strip().split()) <= 4]
     if len(short_fragments) > len(original_sentences) * 0.3:
-        issues.append(
-            f"Excessive sentence fragmentation: {len(short_fragments)} short fragments"
-        )
+        issues.append(f"Excessive sentence fragmentation: {len(short_fragments)} short fragments")
         degradation_score += 0.3
 
     contamination_patterns = [
@@ -830,9 +812,7 @@ def detect_text_flow_degradation(
             issues.append(f"Significant content loss: {length_ratio:.2f} length ratio")
             degradation_score += 0.4
         elif length_ratio > 1.5:
-            issues.append(
-                f"Unexpected content expansion: {length_ratio:.2f} length ratio"
-            )
+            issues.append(f"Unexpected content expansion: {length_ratio:.2f} length ratio")
             degradation_score += 0.2
 
     original_words = len(original_text.split())
@@ -1011,10 +991,7 @@ def is_text_already_clean(text: str) -> bool:
     has_word_joining_issues = bool(_re7.search(r"[a-z][A-Z]", text))
 
     return not (
-        has_ligatures
-        or has_excessive_spaces
-        or has_hyphenated_breaks
-        or has_word_joining_issues
+        has_ligatures or has_excessive_spaces or has_hyphenated_breaks or has_word_joining_issues
     )
 
 
@@ -1035,12 +1012,7 @@ def has_cleaning_opportunities(text: str) -> bool:
     has_hyphenated_breaks = bool(_re8.search(r"-\s*\n\s*[a-z]", text))
     has_unicode_issues = bool(_re8.search(r"[^\x00-\x7F]", text)) and not has_ligatures
 
-    return (
-        has_ligatures
-        or has_excessive_spaces
-        or has_hyphenated_breaks
-        or has_unicode_issues
-    )
+    return has_ligatures or has_excessive_spaces or has_hyphenated_breaks or has_unicode_issues
 
 
 def get_pymupdf4llm_info() -> Dict[str, Any]:
@@ -1061,9 +1033,7 @@ def get_pymupdf4llm_info() -> Dict[str, Any]:
             "available": True,
             "version": getattr(pymupdf4llm, "__version__", "Unknown"),
             "module_file": getattr(pymupdf4llm, "__file__", "Unknown"),
-            "available_attributes": [
-                attr for attr in dir(pymupdf4llm) if not attr.startswith("_")
-            ],
+            "available_attributes": [attr for attr in dir(pymupdf4llm) if not attr.startswith("_")],
         }
 
         try:
@@ -1115,9 +1085,7 @@ def apply_pymupdf4llm_fallback(
             "degraded": 0,
             "artifacts_filtered": 0,
         }
-    logger.info(
-        f"Applying fallback enhancement to {len(problematic_blocks)} problematic blocks"
-    )
+    logger.info(f"Applying fallback enhancement to {len(problematic_blocks)} problematic blocks")
 
     try:
         pymupdf4llm_blocks, _ = extract_with_pymupdf4llm(pdf_path)
@@ -1133,9 +1101,7 @@ def apply_pymupdf4llm_fallback(
         enhanced_blocks = _merge_extraction_results(
             original_blocks, pymupdf4llm_blocks, problematic_blocks
         )
-        enhanced_count = len(
-            [idx for idx in problematic_blocks if idx < len(enhanced_blocks)]
-        )
+        enhanced_count = len([idx for idx in problematic_blocks if idx < len(enhanced_blocks)])
         stats = {
             "enhanced": enhanced_count,
             "failed": 0,
@@ -1168,9 +1134,7 @@ def _merge_extraction_results(
             continue
         original_text = original_blocks[prob_idx].get("text", "")
         best_match = _find_best_matching_block(original_text, pymupdf4llm_blocks)
-        if best_match and _is_text_improvement(
-            original_text, best_match.get("text", "")
-        ):
+        if best_match and _is_text_improvement(original_text, best_match.get("text", "")):
             logger.debug(f"Replacing block {prob_idx} with PyMuPDF4LLM version")
             improved_block = original_blocks[prob_idx].copy()
             improved_block["text"] = best_match["text"]
@@ -1213,9 +1177,7 @@ def _is_text_improvement(original: str, candidate: str) -> bool:
     if candidate_glued < original_glued:
         improvements += 1
     original_sentences = original.count(".") + original.count("!") + original.count("?")
-    candidate_sentences = (
-        candidate.count(".") + candidate.count("!") + candidate.count("?")
-    )
+    candidate_sentences = candidate.count(".") + candidate.count("!") + candidate.count("?")
     if candidate_sentences > original_sentences:
         improvements += 1
     original_quote_balance = abs(original.count('"') % 2)

--- a/pdf_chunker/splitter.py
+++ b/pdf_chunker/splitter.py
@@ -8,6 +8,7 @@ try:  # Optional haystack dependency
     from haystack.components.preprocessors import (
         DocumentSplitter as _DocumentSplitter,
     )
+
     DocumentSplitter = _DocumentSplitter
 except Exception:  # pragma: no cover - dependency optional
     DocumentSplitter = None
@@ -102,9 +103,7 @@ def _is_very_short_fragment(words: List[str]) -> bool:
     return len(words) <= CHUNK_THRESHOLDS["fragment"]
 
 
-def _is_related_short_chunks(
-    current_words: List[str], next_words: List[str], current: str
-) -> bool:
+def _is_related_short_chunks(current_words: List[str], next_words: List[str], current: str) -> bool:
     """Check for adjacent related short chunks that should merge."""
     return (
         len(current_words) <= CHUNK_THRESHOLDS["related_short"]
@@ -157,11 +156,7 @@ def _merge_forward(
     if not current:
         return _merge_forward(chunks, relationships, idx + 1)
 
-    if (
-        idx < len(relationships)
-        and relationships[idx]["should_merge"]
-        and idx + 1 < len(chunks)
-    ):
+    if idx < len(relationships) and relationships[idx]["should_merge"] and idx + 1 < len(chunks):
         next_chunk = chunks[idx + 1].strip()
         rest, counter = _merge_forward(chunks, relationships, idx + 2)
         reason = relationships[idx]["merge_reason"]
@@ -236,10 +231,7 @@ def _merge_numbered_list_chunks(chunks: List[str]) -> List[str]:
                 idx += 2
                 continue
             last_line = current.rsplit("\n", 1)[-1]
-            if (
-                NUMBERED_ITEM_ANYWHERE.search(last_line)
-                and _starting_number(nxt) is None
-            ):
+            if NUMBERED_ITEM_ANYWHERE.search(last_line) and _starting_number(nxt) is None:
                 merged.append(_combine(current, nxt))
                 idx += 2
                 continue
@@ -305,9 +297,7 @@ def _merge_standalone_lists(chunks: List[str]) -> List[str]:
     merged: List[str] = []
     for chunk in chunks:
         stripped = chunk.lstrip()
-        if merged and (
-            starts_with_bullet(stripped) or _starting_number(stripped) is not None
-        ):
+        if merged and (starts_with_bullet(stripped) or _starting_number(stripped) is not None):
             merged[-1] = f"{merged[-1].rstrip()}\n{stripped}"
         else:
             merged.append(chunk.rstrip())
@@ -538,14 +528,10 @@ def _split_text_into_chunks(text: str, chunk_size: int, overlap: int) -> List[st
         logger.debug(f"RecursiveCharacterTextSplitter produced {len(chunks)} chunks")
 
         # Post-process to fix quote and heading related issues
-        fixed_chunks = _fix_heading_splitting_issues(
-            _fix_quote_splitting_issues(chunks)
-        )
+        fixed_chunks = _fix_heading_splitting_issues(_fix_quote_splitting_issues(chunks))
 
         if len(fixed_chunks) != len(chunks):
-            logger.info(
-                f"Boundary fixes applied: {len(chunks)} → {len(fixed_chunks)} chunks"
-            )
+            logger.info(f"Boundary fixes applied: {len(chunks)} → {len(fixed_chunks)} chunks")
 
         # Log potential issues with quote handling
         for i, chunk in enumerate(fixed_chunks):
@@ -566,9 +552,7 @@ def _split_text_into_chunks(text: str, chunk_size: int, overlap: int) -> List[st
                     if chunk[0].islower() and not prev_chunk.rstrip().endswith(
                         (".", "!", "?", ":", ";")
                     ):
-                        logger.debug(
-                            f"Potential continuation split between chunks {i-1} and {i}"
-                        )
+                        logger.debug(f"Potential continuation split between chunks {i-1} and {i}")
 
         return fixed_chunks
     else:
@@ -611,9 +595,7 @@ def _fix_quote_splitting_issues(chunks: List[str]) -> List[str]:
             next_chunk = chunks[i + 1]
 
             # Case 1: Current chunk ends with opening quote, next starts with content
-            if _ends_with_opening_quote(current_chunk) and _starts_with_quote_content(
-                next_chunk
-            ):
+            if _ends_with_opening_quote(current_chunk) and _starts_with_quote_content(next_chunk):
                 logger.debug(f"Fixing quote split: merging chunks {i} and {i+1}")
                 merged = current_chunk + " " + next_chunk
                 fixed_chunks.append(merged)
@@ -621,9 +603,7 @@ def _fix_quote_splitting_issues(chunks: List[str]) -> List[str]:
                 continue
 
             # Case 2: Current chunk is quote content, next starts with closing quote
-            if _is_quote_content(current_chunk) and _starts_with_closing_quote(
-                next_chunk
-            ):
+            if _is_quote_content(current_chunk) and _starts_with_closing_quote(next_chunk):
                 logger.debug(f"Fixing quote split: merging chunks {i} and {i+1}")
                 merged = current_chunk + " " + next_chunk
                 fixed_chunks.append(merged)
@@ -720,9 +700,7 @@ def _validate_chunk_integrity(chunks: List[str], original_text: str) -> List[str
     for i, chunk in enumerate(chunks):
         quote_balance = _check_quote_balance(chunk)
         if quote_balance != 0:
-            logger.warning(
-                f"Chunk {i} has unbalanced quotes (balance: {quote_balance})"
-            )
+            logger.warning(f"Chunk {i} has unbalanced quotes (balance: {quote_balance})")
 
     # Check 3: Look for obvious corruption patterns
     validated_chunks = []
@@ -757,9 +735,7 @@ def _starts_with_quote_content(text: str) -> bool:
     continuation_words = {"and", "but", "or", "so", "yet", "for", "nor"}
     first_word = text.split()[0].lower() if text.split() else ""
 
-    return (
-        text[0].islower() or first_word in continuation_words or not text[0].isupper()
-    )
+    return text[0].islower() or first_word in continuation_words or not text[0].isupper()
 
 
 def _is_quote_content(text: str) -> bool:
@@ -773,8 +749,7 @@ def _starts_with_closing_quote(text: str) -> bool:
 
     # Pattern: starts with quote followed by punctuation or attribution
     return bool(
-        re.match(r'^["\'][,.;:]', text)
-        or re.match(r'^["\'].*?(said|asked|replied)', text.lower())
+        re.match(r'^["\'][,.;:]', text) or re.match(r'^["\'].*?(said|asked|replied)', text.lower())
     )
 
 
@@ -790,9 +765,7 @@ def _is_text_reordered(chunk1: str, chunk2: str) -> bool:
     )
 
     setup_enders = [",", ":", ";", "said", "asked", "replied"]
-    chunk2_ends_setup = any(
-        chunk2.lower().rstrip().endswith(ender) for ender in setup_enders
-    )
+    chunk2_ends_setup = any(chunk2.lower().rstrip().endswith(ender) for ender in setup_enders)
 
     return chunk1_starts_continuation and chunk2_ends_setup
 
@@ -837,9 +810,7 @@ def semantic_chunker(
         1 for chunk in initial_chunks if len(chunk.split()) <= very_short_threshold
     )
 
-    logger.info(
-        f"Initial short chunks (≤{short_threshold} words): {initial_short_count}"
-    )
+    logger.info(f"Initial short chunks (≤{short_threshold} words): {initial_short_count}")
     logger.info(
         f"Initial very short chunks (≤{very_short_threshold} words): {initial_very_short_count}"
     )
@@ -848,9 +819,7 @@ def semantic_chunker(
     for i, chunk in enumerate(initial_chunks):
         word_count = len(chunk.split())
         chunk_preview = chunk[:100].replace("\n", "\\n")
-        logger.info(
-            f"Initial chunk {i}: {word_count} words, preview: '{chunk_preview}...'"
-        )
+        logger.info(f"Initial chunk {i}: {word_count} words, preview: '{chunk_preview}...'")
 
     # Apply conversational merging if enabled
     if enable_dialogue_detection and min_chunk_size is not None:
@@ -863,9 +832,7 @@ def semantic_chunker(
         logger.info("Dialogue detection disabled")
 
     # Validate chunk integrity and repair heading boundaries
-    validated_chunks = _fix_heading_splitting_issues(
-        _validate_chunk_integrity(merged_chunks, text)
-    )
+    validated_chunks = _fix_heading_splitting_issues(_validate_chunk_integrity(merged_chunks, text))
 
     # Merge numbered list items that were split across chunks
     numbered_chunks = _merge_numbered_list_chunks(validated_chunks)
@@ -875,9 +842,7 @@ def semantic_chunker(
     list_chunks = _merge_standalone_lists(bullet_chunks)
 
     # Final statistics
-    final_short_count = sum(
-        1 for chunk in list_chunks if len(chunk.split()) <= short_threshold
-    )
+    final_short_count = sum(1 for chunk in list_chunks if len(chunk.split()) <= short_threshold)
     final_very_short_count = sum(
         1 for chunk in list_chunks if len(chunk.split()) <= very_short_threshold
     )
@@ -950,6 +915,4 @@ def _attempt_chunk_repair(chunk: str) -> str:
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-    )
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")

--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -133,24 +133,26 @@ COLON_BULLET_START_RE = re.compile(rf":\s*(?=-|[{BULLET_CHARS_ESC}])")
 DOUBLE_NEWLINE_RE = re.compile(r"([A-Za-z]+)\n{2,}\s*([a-z][A-Za-z]+)")
 SPLIT_WORD_RE = re.compile(r"([A-Za-z]{2,})(?:\n|\s{2,}|\u00A0)([a-z]{2,})")
 
-STOPWORDS: frozenset[str] = frozenset({
-    "the",
-    "of",
-    "for",
-    "and",
-    "with",
-    "from",
-    "this",
-    "that",
-    "is",
-    "to",
-    "in",
-    "on",
-    "as",
-    "by",
-    "then",
-    "up",
-})
+STOPWORDS: frozenset[str] = frozenset(
+    {
+        "the",
+        "of",
+        "for",
+        "and",
+        "with",
+        "from",
+        "this",
+        "that",
+        "is",
+        "to",
+        "in",
+        "on",
+        "as",
+        "by",
+        "then",
+        "up",
+    }
+)
 
 # Footnote handling
 FOOTNOTE_BRACKETED_RE = re.compile(rf"\[\d+\](?:[{re.escape(END_PUNCT)}])?$")
@@ -170,6 +172,7 @@ HYPHEN_SPACE_RE = re.compile(rf"(\w)[{HYPHEN_CHARS_ESC}]\s+{_HYPHEN_BULLET_OPT}(
 # ---------------------------------------------------------------------------
 # Hyphenation and word glue fixes
 # ---------------------------------------------------------------------------
+
 
 def _join_hyphenated_words(text: str) -> str:
     """Merge words broken with hyphenation across line breaks."""
@@ -232,6 +235,7 @@ def _fix_split_words(text: str) -> str:
 # Quote & ligature normalization
 # ---------------------------------------------------------------------------
 
+
 def _map_smart_quotes(text: str) -> str:
     """Map smart quotes to their ASCII equivalents."""
     return "".join(SMART_QUOTES.get(ch, ch) for ch in text)
@@ -253,6 +257,7 @@ def normalize_ligatures(text: str) -> str:
 # ---------------------------------------------------------------------------
 # Newline & list handling
 # ---------------------------------------------------------------------------
+
 
 def collapse_artifact_breaks(text: str) -> str:
     """Remove unwanted breaks after ., _, etc. (e.g., systems._\nThis → systems. This)"""
@@ -304,7 +309,11 @@ def _split_inline_numbered(match: Match[str]) -> str:
     head, tail = match.groups()
     tokens = head.rstrip().split()
     last = tokens[-1] if tokens else ""
-    return match.group(0) if last.istitle() and tail.rstrip(".)").isdigit() and "\n" not in head else f"{head}\n"
+    return (
+        match.group(0)
+        if last.istitle() and tail.rstrip(".)").isdigit() and "\n" not in head
+        else f"{head}\n"
+    )
 
 
 def _apply_inline_numbered(text: str) -> str:
@@ -322,11 +331,7 @@ def insert_numbered_list_newlines(text: str) -> str:
 def _preserve_list_newlines(text: str) -> str:
     """Keep newlines that precede bullets or enumerated items."""
     placeholder = "[[LIST_BREAK]]"
-    return (
-        LIST_BREAK_RE.sub(placeholder, text)
-        .replace("\n", " ")
-        .replace(placeholder, "\n")
-    )
+    return LIST_BREAK_RE.sub(placeholder, text).replace("\n", " ").replace(placeholder, "\n")
 
 
 def collapse_single_newlines(text: str) -> str:
@@ -354,6 +359,7 @@ def collapse_single_newlines(text: str) -> str:
 # Heading/list detection & footnotes
 # ---------------------------------------------------------------------------
 
+
 def _starts_list_item(line: str) -> bool:
     return bool(re.match(rf"([{BULLET_CHARS_ESC}]|\d+[.)])\s", line))
 
@@ -375,11 +381,7 @@ def _is_probable_heading(text: str) -> bool:
         return False
 
     # Short phrases with at least one capitalized word are often headings.
-    if (
-        1 < len(words) <= 3
-        and stripped[0].isupper()
-        and not re.search(r"[.!?]$", stripped)
-    ):
+    if 1 < len(words) <= 3 and stripped[0].isupper() and not re.search(r"[.!?]$", stripped):
         return True
 
     # Quoted fragments are likely part of sentences, not headings
@@ -457,6 +459,7 @@ def _normalize_inline_footnotes(text: str) -> str:
 # Safety & whitespace utilities
 # ---------------------------------------------------------------------------
 
+
 def normalize_newlines(text: str) -> str:
     """Convert CRLF/CR and unicode separators to LF."""
     return (
@@ -489,6 +492,7 @@ def strip_underscore_wrapping(text: str) -> str:
 # ---------------------------------------------------------------------------
 # Paragraph merge logic
 # ---------------------------------------------------------------------------
+
 
 def merge_spurious_paragraph_breaks(text: str) -> str:
     parts = [p for p in PARAGRAPH_BREAK.split(text) if p.strip()]
@@ -526,6 +530,7 @@ def merge_spurious_paragraph_breaks(text: str) -> str:
 # ---------------------------------------------------------------------------
 # JSON safety helpers
 # ---------------------------------------------------------------------------
+
 
 def validate_json_safety(text: str) -> Tuple[bool, List[str]]:
     issues: List[str] = []
@@ -573,6 +578,7 @@ def apply_json_safety_fixes(text: str) -> str:
 # ---------------------------------------------------------------------------
 # Pipelines
 # ---------------------------------------------------------------------------
+
 
 def clean_paragraph(paragraph: str) -> str:
     """
@@ -631,7 +637,9 @@ def _clean_text_impl(text: str) -> str:
             else:
                 logger.debug("PyMuPDF4LLM not available, falling back to traditional")
         except Exception as e:  # noqa: BLE001 - keep behaviour identical
-            logger.debug(f"PyMuPDF4LLM cleaning failed with exception: {e}, falling back to traditional")
+            logger.debug(
+                f"PyMuPDF4LLM cleaning failed with exception: {e}, falling back to traditional"
+            )
             pass
 
     logger.debug("Using traditional text cleaning path")

--- a/pdf_chunker/text_processing.py
+++ b/pdf_chunker/text_processing.py
@@ -99,9 +99,7 @@ def _detect_text_reordering(*args: Any, **kwargs: Any) -> bool:
     return False
 
 
-def _validate_chunk_integrity(
-    chunks: List[str], original_text: str | None = None
-) -> List[str]:
+def _validate_chunk_integrity(chunks: List[str], original_text: str | None = None) -> List[str]:
     """Stub for test compatibility. Returns chunks unchanged."""
     return chunks
 

--- a/scripts/compare_text_quality.py
+++ b/scripts/compare_text_quality.py
@@ -240,16 +240,12 @@ def assess_whitespace_quality(text: str) -> Tuple[float, List[str]]:
     # Check for excessive newlines
     excessive_newlines = len(re.findall(r"\n{3,}", text))
     if excessive_newlines > 0:
-        issues.append(
-            f"Found {excessive_newlines} instances of 3+ consecutive newlines"
-        )
+        issues.append(f"Found {excessive_newlines} instances of 3+ consecutive newlines")
 
     # Check for missing spaces after punctuation
     missing_spaces = len(re.findall(r"[.!?][a-zA-Z]", text))
     if missing_spaces > 0:
-        issues.append(
-            f"Found {missing_spaces} instances of missing spaces after punctuation"
-        )
+        issues.append(f"Found {missing_spaces} instances of missing spaces after punctuation")
 
     # Check for excessive spaces
     excessive_spaces = len(re.findall(r" {3,}", text))
@@ -263,16 +259,12 @@ def assess_whitespace_quality(text: str) -> Tuple[float, List[str]]:
 
     # Check for trailing whitespace on lines
     lines = text.split("\n")
-    trailing_whitespace = sum(
-        1 for line in lines if line.endswith(" ") or line.endswith("\t")
-    )
+    trailing_whitespace = sum(1 for line in lines if line.endswith(" ") or line.endswith("\t"))
     if trailing_whitespace > len(lines) * 0.1:  # More than 10% of lines
         issues.append(f"Excessive trailing whitespace on {trailing_whitespace} lines")
 
     # Calculate score based on issues found
-    total_issues = (
-        excessive_newlines + missing_spaces + excessive_spaces + trailing_whitespace
-    )
+    total_issues = excessive_newlines + missing_spaces + excessive_spaces + trailing_whitespace
     if mixed_whitespace:
         total_issues += 1
 
@@ -363,9 +355,7 @@ def assess_header_footer_contamination(text: str) -> Tuple[float, List[str]]:
     line_counts = {}
     for line in lines:
         stripped = line.strip()
-        if (
-            stripped and len(stripped) < 50
-        ):  # Short lines more likely to be headers/footers
+        if stripped and len(stripped) < 50:  # Short lines more likely to be headers/footers
             line_counts[stripped] = line_counts.get(stripped, 0) + 1
 
     repeated_lines = [(line, count) for line, count in line_counts.items() if count > 1]
@@ -374,18 +364,14 @@ def assess_header_footer_contamination(text: str) -> Tuple[float, List[str]]:
     for line, count in repeated_lines:
         if count > 2:  # Repeated more than twice
             contamination_score += count
-            issues.append(
-                f"Repeated line '{line}' appears {count} times (likely header/footer)"
-            )
+            issues.append(f"Repeated line '{line}' appears {count} times (likely header/footer)")
 
     # Check for page numbers in text
     page_numbers = re.findall(r"\b(?:page\s+)?\d+\b", text, re.IGNORECASE)
     isolated_numbers = [num for num in page_numbers if re.match(r"^\d+$", num.strip())]
     if len(isolated_numbers) > 3:
         contamination_score += len(isolated_numbers)
-        issues.append(
-            f"Found {len(isolated_numbers)} isolated numbers (possible page numbers)"
-        )
+        issues.append(f"Found {len(isolated_numbers)} isolated numbers (possible page numbers)")
 
     # Check for common header/footer patterns
     header_footer_patterns = [
@@ -400,9 +386,7 @@ def assess_header_footer_contamination(text: str) -> Tuple[float, List[str]]:
         matches = re.findall(pattern, text, re.IGNORECASE)
         if matches:
             contamination_score += len(matches)
-            issues.append(
-                f"Header/footer pattern found: {matches[:3]}"
-            )  # Show first 3 matches
+            issues.append(f"Header/footer pattern found: {matches[:3]}")  # Show first 3 matches
 
     # Calculate score (higher is better, lower contamination)
     total_lines = len(lines)
@@ -453,9 +437,7 @@ def analyze_text_quality(
     word_score, word_issues = assess_word_joining(all_text)
     whitespace_score, whitespace_issues = assess_whitespace_quality(all_text)
     ligature_score, ligature_issues = assess_ligature_translation(all_text)
-    contamination_score, contamination_issues = assess_header_footer_contamination(
-        all_text
-    )
+    contamination_score, contamination_issues = assess_header_footer_contamination(all_text)
 
     # Calculate overall quality score (weighted average)
     weights = {
@@ -476,11 +458,7 @@ def analyze_text_quality(
 
     # Collect all issues
     all_issues = (
-        sentence_issues
-        + word_issues
-        + whitespace_issues
-        + ligature_issues
-        + contamination_issues
+        sentence_issues + word_issues + whitespace_issues + ligature_issues + contamination_issues
     )
 
     # Create sample issues with categories
@@ -500,9 +478,7 @@ def analyze_text_quality(
                     "category": category,
                     "issue": issue,
                     "severity": (
-                        "high"
-                        if category in ["Sentence Integrity", "Word Joining"]
-                        else "medium"
+                        "high" if category in ["Sentence Integrity", "Word Joining"] else "medium"
                     ),
                 }
             )
@@ -552,9 +528,7 @@ def compare_text_quality(
         "hybrid_score": hybrid_overall,
         "traditional_score": traditional_overall,
         "difference": hybrid_overall - traditional_overall,
-        "better_method": (
-            "hybrid" if hybrid_overall > traditional_overall else "traditional"
-        ),
+        "better_method": ("hybrid" if hybrid_overall > traditional_overall else "traditional"),
         "improvement_percentage": abs(hybrid_overall - traditional_overall) * 100,
     }
 
@@ -577,9 +551,7 @@ def compare_text_quality(
             "hybrid_score": hybrid_score,
             "traditional_score": traditional_score,
             "difference": hybrid_score - traditional_score,
-            "better_method": (
-                "hybrid" if hybrid_score > traditional_score else "traditional"
-            ),
+            "better_method": ("hybrid" if hybrid_score > traditional_score else "traditional"),
         }
 
     comparison["dimension_comparison"] = dimension_results
@@ -671,9 +643,7 @@ def generate_detailed_examples(
                 hybrid_text[:200] + "..." if len(hybrid_text) > 200 else hybrid_text
             ),
             "traditional_text_preview": (
-                traditional_text[:200] + "..."
-                if len(traditional_text) > 200
-                else traditional_text
+                traditional_text[:200] + "..." if len(traditional_text) > 200 else traditional_text
             ),
             "length_comparison": {
                 "hybrid_length": len(hybrid_text),
@@ -791,12 +761,8 @@ def run_text_quality_comparison(pdf_files: List[str]) -> List[QualityComparison]
 
         # Print summary
         print(f"  Hybrid overall quality: {hybrid_metrics.overall_quality_score:.2f}")
-        print(
-            f"  Traditional overall quality: {traditional_metrics.overall_quality_score:.2f}"
-        )
-        print(
-            f"  Better method: {comparison_analysis['overall_comparison']['better_method']}"
-        )
+        print(f"  Traditional overall quality: {traditional_metrics.overall_quality_score:.2f}")
+        print(f"  Better method: {comparison_analysis['overall_comparison']['better_method']}")
 
     return results
 
@@ -870,9 +836,7 @@ def print_quality_summary(results: List[QualityComparison]) -> None:
         print("=" * 80)
 
         hybrid_scores = [r.hybrid_metrics.overall_quality_score for r in results]
-        traditional_scores = [
-            r.traditional_metrics.overall_quality_score for r in results
-        ]
+        traditional_scores = [r.traditional_metrics.overall_quality_score for r in results]
 
         avg_hybrid = statistics.mean(hybrid_scores)
         avg_traditional = statistics.mean(traditional_scores)
@@ -901,9 +865,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Compare text quality between hybrid PyMuPDF4LLM and traditional PDF extraction methods"
     )
-    parser.add_argument(
-        "pdf_files", nargs="+", help="PDF files to analyze for text quality"
-    )
+    parser.add_argument("pdf_files", nargs="+", help="PDF files to analyze for text quality")
     parser.add_argument(
         "--output",
         "-o",
@@ -915,9 +877,7 @@ def main() -> None:
         action="store_true",
         help="Include detailed text examples in output",
     )
-    parser.add_argument(
-        "--quiet", "-q", action="store_true", help="Suppress detailed output"
-    )
+    parser.add_argument("--quiet", "-q", action="store_true", help="Suppress detailed output")
 
     args = parser.parse_args()
 
@@ -952,9 +912,7 @@ def main() -> None:
         # Add summary statistics
         if results:
             hybrid_scores = [r.hybrid_metrics.overall_quality_score for r in results]
-            traditional_scores = [
-                r.traditional_metrics.overall_quality_score for r in results
-            ]
+            traditional_scores = [r.traditional_metrics.overall_quality_score for r in results]
 
             output_data["summary_statistics"] = {
                 "average_hybrid_quality": statistics.mean(hybrid_scores),
@@ -962,14 +920,12 @@ def main() -> None:
                 "hybrid_wins": sum(
                     1
                     for r in results
-                    if r.comparison_analysis["overall_comparison"]["better_method"]
-                    == "hybrid"
+                    if r.comparison_analysis["overall_comparison"]["better_method"] == "hybrid"
                 ),
                 "traditional_wins": sum(
                     1
                     for r in results
-                    if r.comparison_analysis["overall_comparison"]["better_method"]
-                    == "traditional"
+                    if r.comparison_analysis["overall_comparison"]["better_method"] == "traditional"
                 ),
                 "quality_improvement": statistics.mean(hybrid_scores)
                 - statistics.mean(traditional_scores),
@@ -986,9 +942,7 @@ def main() -> None:
 
         # Exit with appropriate code based on results
         if results:
-            avg_hybrid = statistics.mean(
-                [r.hybrid_metrics.overall_quality_score for r in results]
-            )
+            avg_hybrid = statistics.mean([r.hybrid_metrics.overall_quality_score for r in results])
             avg_traditional = statistics.mean(
                 [r.traditional_metrics.overall_quality_score for r in results]
             )

--- a/scripts/detect_duplicates.py
+++ b/scripts/detect_duplicates.py
@@ -90,9 +90,7 @@ def detect_duplications(
                         "chunk_index": i,
                         "chunk_line": chunk.get("_line_number", i + 1),
                         "window_index": window_idx,
-                        "text_preview": (
-                            window[:100] + "..." if len(window) > 100 else window
-                        ),
+                        "text_preview": (window[:100] + "..." if len(window) > 100 else window),
                     }
                 )
 
@@ -101,9 +99,7 @@ def detect_duplications(
         if len(chunk_list) > 1:
             # Multiple chunks contain this window - potential duplication
             duplication = {
-                "duplicated_text": (
-                    window[:200] + "..." if len(window) > 200 else window
-                ),
+                "duplicated_text": (window[:200] + "..." if len(window) > 200 else window),
                 "word_count": len(window.split()),
                 "occurrences": [],
             }
@@ -155,9 +151,7 @@ def analyze_chunk_boundaries(chunks: List[Dict]) -> Dict:
         # Look for overlap at boundaries
         max_check = min(20, len(current_words), len(next_words))
 
-        for overlap_size in range(
-            max_check, 4, -1
-        ):  # Check from large to small overlaps
+        for overlap_size in range(max_check, 4, -1):  # Check from large to small overlaps
             current_end = " ".join(current_words[-overlap_size:])
             next_start = " ".join(next_words[:overlap_size])
 
@@ -169,9 +163,7 @@ def analyze_chunk_boundaries(chunks: List[Dict]) -> Dict:
                         "chunk1_id": current_chunk.get("metadata", {}).get(
                             "chunk_id", f"chunk_{i}"
                         ),
-                        "chunk2_id": next_chunk.get("metadata", {}).get(
-                            "chunk_id", f"chunk_{i+1}"
-                        ),
+                        "chunk2_id": next_chunk.get("metadata", {}).get("chunk_id", f"chunk_{i+1}"),
                         "overlap_words": overlap_size,
                         "overlapping_text": current_end,
                         "issue_type": "boundary_overlap",

--- a/scripts/experiment_pymupdf4llm.py
+++ b/scripts/experiment_pymupdf4llm.py
@@ -211,24 +211,16 @@ def extract_with_pymupdf4llm(
                                         md_text = result
                                     elif isinstance(result, list):
                                         if result and hasattr(result[0], "text"):
-                                            md_text = "\n".join(
-                                                [doc.text for doc in result]
-                                            )
+                                            md_text = "\n".join([doc.text for doc in result])
                                         else:
-                                            md_text = "\n".join(
-                                                [str(doc) for doc in result]
-                                            )
+                                            md_text = "\n".join([str(doc) for doc in result])
                                     else:
                                         md_text = str(result)
 
-                                    extraction_method = (
-                                        f"pymupdf4llm.{class_name}().{method_name}"
-                                    )
+                                    extraction_method = f"pymupdf4llm.{class_name}().{method_name}"
                                     break
                                 except Exception as e:
-                                    print(
-                                        f"DEBUG: {class_name}.{method_name} failed: {e}"
-                                    )
+                                    print(f"DEBUG: {class_name}.{method_name} failed: {e}")
                                     continue
 
                         if md_text is not None:
@@ -248,14 +240,10 @@ def extract_with_pymupdf4llm(
                                 method = getattr(submodule, method_name)
                                 print(f"DEBUG: Trying {submodule_name}.{method_name}")
                                 md_text = method(pdf_path)
-                                extraction_method = (
-                                    f"pymupdf4llm.{submodule_name}.{method_name}"
-                                )
+                                extraction_method = f"pymupdf4llm.{submodule_name}.{method_name}"
                                 break
                             except Exception as e:
-                                print(
-                                    f"DEBUG: {submodule_name}.{method_name} failed: {e}"
-                                )
+                                print(f"DEBUG: {submodule_name}.{method_name} failed: {e}")
                                 continue
 
                     if md_text is not None:
@@ -383,9 +371,7 @@ def calculate_comparison_metrics(
     if current.text_length > 0 and pymupdf4llm.text_length > 0:
         length_ratio = pymupdf4llm.text_length / current.text_length
         metrics["text_length_ratio"] = length_ratio
-        metrics["text_length_difference"] = (
-            pymupdf4llm.text_length - current.text_length
-        )
+        metrics["text_length_difference"] = pymupdf4llm.text_length - current.text_length
     else:
         metrics["text_length_ratio"] = 0
         metrics["text_length_difference"] = 0
@@ -394,9 +380,7 @@ def calculate_comparison_metrics(
     metrics["chunk_count_difference"] = pymupdf4llm.chunk_count - current.chunk_count
 
     # Heading detection comparison
-    metrics["heading_count_difference"] = (
-        pymupdf4llm.heading_count - current.heading_count
-    )
+    metrics["heading_count_difference"] = pymupdf4llm.heading_count - current.heading_count
 
     # Performance comparison
     if current.processing_time > 0:
@@ -434,9 +418,7 @@ def generate_recommendations(comparison: ComparisonReport) -> List[str]:
 
     # Error analysis
     if current.errors and not pymupdf4llm.errors:
-        recommendations.append(
-            "PyMuPDF4LLM shows better error handling - consider migration"
-        )
+        recommendations.append("PyMuPDF4LLM shows better error handling - consider migration")
     elif pymupdf4llm.errors and not current.errors:
         recommendations.append(
             "Current pipeline shows better error handling - keep current approach"
@@ -464,35 +446,23 @@ def generate_recommendations(comparison: ComparisonReport) -> List[str]:
 
     # Performance
     if metrics.get("speed_ratio", 0) > 2:
-        recommendations.append(
-            "PyMuPDF4LLM is significantly faster - performance benefit"
-        )
+        recommendations.append("PyMuPDF4LLM is significantly faster - performance benefit")
     elif metrics.get("speed_ratio", 0) < 0.5:
-        recommendations.append(
-            "Current pipeline is faster - PyMuPDF4LLM has performance cost"
-        )
+        recommendations.append("Current pipeline is faster - PyMuPDF4LLM has performance cost")
 
     # Heading overlap
     if metrics.get("heading_overlap_ratio", 0) < 0.5:
-        recommendations.append(
-            "Low heading overlap - methods detect different document structures"
-        )
+        recommendations.append("Low heading overlap - methods detect different document structures")
     elif metrics.get("heading_overlap_ratio", 0) > 0.8:
-        recommendations.append(
-            "High heading overlap - methods agree on document structure"
-        )
+        recommendations.append("High heading overlap - methods agree on document structure")
 
     if not recommendations:
-        recommendations.append(
-            "Results are comparable - choice depends on specific requirements"
-        )
+        recommendations.append("Results are comparable - choice depends on specific requirements")
 
     return recommendations
 
 
-def run_comparison(
-    pdf_path: str, pages_to_exclude: Optional[List[int]] = None
-) -> ComparisonReport:
+def run_comparison(pdf_path: str, pages_to_exclude: Optional[List[int]] = None) -> ComparisonReport:
     """Run comparison between current pipeline and PyMuPDF4LLM"""
 
     print(f"Running comparison on: {pdf_path}")
@@ -535,9 +505,7 @@ def print_comparison_report(comparison: ComparisonReport) -> None:
     metrics = comparison.comparison_metrics
 
     # Summary table
-    print(
-        f"\n{'EXTRACTION SUMMARY':<30} {'Current':<15} {'PyMuPDF4LLM':<15} {'Difference':<15}"
-    )
+    print(f"\n{'EXTRACTION SUMMARY':<30} {'Current':<15} {'PyMuPDF4LLM':<15} {'Difference':<15}")
     print(f"{'-'*75}")
     print(
         f"{'Text Length':<30} {current.text_length:<15} {pymupdf4llm.text_length:<15} {metrics.get('text_length_difference', 0):<15}"
@@ -627,13 +595,9 @@ def main() -> None:
     pages_to_exclude = None
     if args.pages_to_exclude:
         try:
-            pages_to_exclude = [
-                int(p.strip()) for p in args.pages_to_exclude.split(",")
-            ]
+            pages_to_exclude = [int(p.strip()) for p in args.pages_to_exclude.split(",")]
         except ValueError:
-            print(
-                "ERROR: Invalid pages format. Use comma-separated integers (e.g., 1,2,3)"
-            )
+            print("ERROR: Invalid pages format. Use comma-separated integers (e.g., 1,2,3)")
             sys.exit(1)
 
     # Run comparison

--- a/scripts/find_glued_words.py
+++ b/scripts/find_glued_words.py
@@ -76,12 +76,7 @@ class Correction:
 def enhanced_correction_step(
     words: Iterable[str], texts: List[str], workers: int = 5
 ) -> Dict[Tuple[int, str], str]:
-    pairs = [
-        (i, word, text)
-        for i, text in enumerate(texts)
-        for word in words
-        if word in text
-    ]
+    pairs = [(i, word, text) for i, text in enumerate(texts) for word in words if word in text]
 
     def correct(args: Tuple[int, str, str]) -> Optional[Correction]:
         i, word, text = args
@@ -121,9 +116,7 @@ def main(path: str, output_path: str, summary: bool = True) -> None:
     records = load_jsonl(path)
     texts = [record["text"] for record in records]
 
-    candidates_pipeline = compose(
-        aspell_bad, lambda texts: set(mapcat(extract_candidates, texts))
-    )
+    candidates_pipeline = compose(aspell_bad, lambda texts: set(mapcat(extract_candidates, texts)))
 
     print("[INFO] Extracting suspicious candidates...")
     suspicious = candidates_pipeline(texts)
@@ -139,9 +132,7 @@ def main(path: str, output_path: str, summary: bool = True) -> None:
     cleaned_records = [
         {
             **record,
-            "text": apply_corrections_to_text(
-                record["text"], rec_word_corrections.get(i, {})
-            ),
+            "text": apply_corrections_to_text(record["text"], rec_word_corrections.get(i, {})),
         }
         for i, record in enumerate(records)
     ]

--- a/scripts/fix_newlines.py
+++ b/scripts/fix_newlines.py
@@ -29,9 +29,7 @@ def is_real_word(word: str) -> bool:
     """Return True if `word` is recognized by aspell."""
     # aspell list prints unknown words—so if our word does NOT show up,
     # it’s known.
-    p = subprocess.Popen(
-        SPELLER_CMD, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True
-    )
+    p = subprocess.Popen(SPELLER_CMD, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
     out, _ = p.communicate(word + "\n")
     return out.strip() == ""
 

--- a/scripts/fix_newlines_jsonl.py
+++ b/scripts/fix_newlines_jsonl.py
@@ -24,9 +24,7 @@ SPELLER_CMD = ["aspell", "list"]
 
 def is_real_word(w: str) -> bool:
     """Return True if aspell knows this word."""
-    p = subprocess.Popen(
-        SPELLER_CMD, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True
-    )
+    p = subprocess.Popen(SPELLER_CMD, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
     out, _ = p.communicate(w + "\n")
     return out.strip() == ""
 

--- a/scripts/generate_test_epub.py
+++ b/scripts/generate_test_epub.py
@@ -24,9 +24,7 @@ def create_test_epub() -> str:
     # EPUB is essentially a ZIP file with specific structure
     with zipfile.ZipFile(epub_path, "w", zipfile.ZIP_DEFLATED) as epub:
         # mimetype file (must be first and uncompressed)
-        epub.writestr(
-            "mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED
-        )
+        epub.writestr("mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED)
 
         # META-INF/container.xml
         container_xml = """<?xml version="1.0" encoding="UTF-8"?>

--- a/scripts/generate_test_pdf.py
+++ b/scripts/generate_test_pdf.py
@@ -136,9 +136,7 @@ def create_test_pdf() -> str:
     c.drawString(1 * inch, height - 1 * inch, "Chapter 2: Structured Content")
 
     c.setFont("Helvetica", 11)
-    c.drawString(
-        1 * inch, height - 1.5 * inch, "This page tests structured content processing:"
-    )
+    c.drawString(1 * inch, height - 1.5 * inch, "This page tests structured content processing:")
 
     c.drawString(1 * inch, height - 2 * inch, "1. First numbered item")
     c.drawString(1 * inch, height - 2.3 * inch, "2. Second numbered item")
@@ -154,9 +152,7 @@ def create_test_pdf() -> str:
         height - 4.5 * inch,
         "This content tests the system's ability to handle different",
     )
-    c.drawString(
-        1 * inch, height - 4.8 * inch, "text structures and formatting patterns."
-    )
+    c.drawString(1 * inch, height - 4.8 * inch, "text structures and formatting patterns.")
 
     c.save()
     print(f"Created test PDF: {pdf_path}")
@@ -174,9 +170,7 @@ def create_pdf_placeholder() -> str:
         f.write("TEST PDF PLACEHOLDER\n")
         f.write("===================\n\n")
         f.write("This file serves as a placeholder for sample_test.pdf\n")
-        f.write(
-            "The actual PDF could not be created because reportlab is not available.\n\n"
-        )
+        f.write("The actual PDF could not be created because reportlab is not available.\n\n")
         f.write("To create the test PDF, install reportlab:\n")
         f.write("pip install reportlab\n\n")
         f.write("Then run this script again:\n")

--- a/scripts/parity.py
+++ b/scripts/parity.py
@@ -64,10 +64,7 @@ def _normalize(row: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _canonical_lines(path: Path) -> list[str]:
-    return [
-        json.dumps(_normalize(r), sort_keys=True)
-        for r in _load_rows(path)
-    ]
+    return [json.dumps(_normalize(r), sort_keys=True) for r in _load_rows(path)]
 
 
 def _write_diff(name: str, legacy: Path, new: Path, diffdir: Path) -> None:

--- a/scripts/test_page_boundaries.py
+++ b/scripts/test_page_boundaries.py
@@ -108,9 +108,7 @@ def detect_page_artifacts(blocks: List[Dict[str, Any]]) -> Dict[str, Any]:
 
         # Page numbers (standalone digits)
         if re.match(r"^\d+$", text):
-            artifacts["page_numbers"].append(
-                {"block_index": i, "page": page, "text": text}
-            )
+            artifacts["page_numbers"].append({"block_index": i, "page": page, "text": text})
             continue
 
         # Headers (common patterns at top of pages)
@@ -137,13 +135,9 @@ def detect_page_artifacts(blocks: List[Dict[str, Any]]) -> Dict[str, Any]:
 
         # Other potential artifacts (very short text with specific patterns)
         if len(text.split()) <= 3 and (
-            any(char.isdigit() for char in text)
-            or text.isupper()
-            or re.match(r"^[A-Z\s]+$", text)
+            any(char.isdigit() for char in text) or text.isupper() or re.match(r"^[A-Z\s]+$", text)
         ):
-            artifacts["other_artifacts"].append(
-                {"block_index": i, "page": page, "text": text}
-            )
+            artifacts["other_artifacts"].append({"block_index": i, "page": page, "text": text})
 
     return artifacts
 
@@ -227,12 +221,8 @@ def compare_text_quality(
     """Compare text quality between traditional and PyMuPDF4LLM approaches."""
 
     # Combine text from all blocks
-    traditional_text = "\n\n".join(
-        block.get("text", "") for block in traditional_blocks
-    )
-    pymupdf4llm_text = "\n\n".join(
-        block.get("text", "") for block in pymupdf4llm_blocks
-    )
+    traditional_text = "\n\n".join(block.get("text", "") for block in traditional_blocks)
+    pymupdf4llm_text = "\n\n".join(block.get("text", "") for block in pymupdf4llm_blocks)
 
     # Analyze sentence boundaries
     traditional_sentences = analyze_sentence_boundaries(traditional_text)
@@ -253,9 +243,7 @@ def compare_text_quality(
         # Penalize for sentence issues
         if sentences["total_sentences"] > 0:
             fragment_ratio = sentences["short_fragments"] / sentences["total_sentences"]
-            lowercase_ratio = (
-                sentences["lowercase_starts"] / sentences["total_sentences"]
-            )
+            lowercase_ratio = sentences["lowercase_starts"] / sentences["total_sentences"]
             abrupt_ratio = sentences["abrupt_endings"] / sentences["total_sentences"]
 
             score -= fragment_ratio * 0.3
@@ -308,17 +296,13 @@ def compare_text_quality(
             "block_count_change": len(pymupdf4llm_blocks) - len(traditional_blocks),
             "character_count_change": len(pymupdf4llm_text) - len(traditional_text),
             "better_approach": (
-                "PyMuPDF4LLM"
-                if pymupdf4llm_score > traditional_score
-                else "Traditional"
+                "PyMuPDF4LLM" if pymupdf4llm_score > traditional_score else "Traditional"
             ),
         },
     }
 
 
-def generate_comparison_report(
-    comparison_results: Dict[str, Any], pdf_path: str
-) -> str:
+def generate_comparison_report(comparison_results: Dict[str, Any], pdf_path: str) -> str:
     """Generate a detailed comparison report."""
     report = []
     report.append("=" * 80)
@@ -405,17 +389,13 @@ def generate_comparison_report(
 
     # Print Flow Issue Ratio for both columns in a single line
     if trad["flow"]["total_transitions"] > 0:
-        trad_flow_ratio = (
-            trad["flow"]["total_flow_issues"] / trad["flow"]["total_transitions"]
-        )
+        trad_flow_ratio = trad["flow"]["total_flow_issues"] / trad["flow"]["total_transitions"]
         trad_ratio_str = f"{trad_flow_ratio:>11.3f}"
     else:
         trad_ratio_str = f"{'N/A':>11s}"
 
     if pymu["flow"]["total_transitions"] > 0:
-        pymu_flow_ratio = (
-            pymu["flow"]["total_flow_issues"] / pymu["flow"]["total_transitions"]
-        )
+        pymu_flow_ratio = pymu["flow"]["total_flow_issues"] / pymu["flow"]["total_transitions"]
         pymu_ratio_str = f"{pymu_flow_ratio:>11.3f}"
     else:
         pymu_ratio_str = f"{'N/A':>11s}"

--- a/scripts/validate_chunk_quality.py
+++ b/scripts/validate_chunk_quality.py
@@ -147,8 +147,7 @@ def detect_short_chunks(
             "index": i,
             "word_count": word_count,
             "char_count": len(text),
-            "text_preview": text[:100].replace("\n", " ")
-            + ("..." if len(text) > 100 else ""),
+            "text_preview": text[:100].replace("\n", " ") + ("..." if len(text) > 100 else ""),
             "full_text": text,
         }
 
@@ -242,9 +241,7 @@ def detect_dialogue_patterns(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
         ):
             response_indicators = [
                 text.strip().endswith("?"),
-                text.strip().startswith(
-                    ("Yes", "No", "Well", "Oh", "Ah", "Indeed", "Certainly")
-                ),
+                text.strip().startswith(("Yes", "No", "Well", "Oh", "Ah", "Indeed", "Certainly")),
                 any(
                     word in text_lower
                     for word in ["indeed", "certainly", "perhaps", "maybe", "probably"]
@@ -435,9 +432,7 @@ def generate_quality_report(
         if total_dialogue_chunks == 0:
             return ("dialogue_handling", 1.0, 0.3)
 
-        fragment_ratio = (
-            len(dialogue_analysis["potential_fragments"]) / total_dialogue_chunks
-        )
+        fragment_ratio = len(dialogue_analysis["potential_fragments"]) / total_dialogue_chunks
         dialogue_score = max(0.0, 1.0 - fragment_ratio)
         return ("dialogue_handling", dialogue_score, 0.3)
 
@@ -466,9 +461,7 @@ def generate_quality_report(
             issues.append(
                 f"High ratio of short chunks (≤{VALIDATION_THRESHOLDS['short']} words): {short_ratio:.1%}"
             )
-            recommendations.append(
-                "Review conversational text handling and chunk merging"
-            )
+            recommendations.append("Review conversational text handling and chunk merging")
 
     # Factor 2: Text flow quality (0.4 weight)
     flow_score = flow_analysis["flow_score"]
@@ -476,14 +469,10 @@ def generate_quality_report(
 
     if flow_score < 0.8:
         issues.append(f"Poor text flow continuity: {flow_score:.2f}")
-        recommendations.append(
-            "Improve page boundary handling and sentence reconstruction"
-        )
+        recommendations.append("Improve page boundary handling and sentence reconstruction")
 
     if len(flow_analysis["abrupt_transitions"]) > 0:
-        issues.append(
-            f"{len(flow_analysis['abrupt_transitions'])} abrupt transitions detected"
-        )
+        issues.append(f"{len(flow_analysis['abrupt_transitions'])} abrupt transitions detected")
         recommendations.append("Review semantic chunking boundaries")
 
     # Factor 3: Dialogue handling (0.3 weight)
@@ -579,9 +568,7 @@ def detect_word_gluing_issues(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
                         "chunk_index": i,
                         "example": quote_gluing[0],
                         "context": text[
-                            max(0, text.find(quote_gluing[0]) - 20) : text.find(
-                                quote_gluing[0]
-                            )
+                            max(0, text.find(quote_gluing[0]) - 20) : text.find(quote_gluing[0])
                             + 30
                         ],
                     }
@@ -589,9 +576,7 @@ def detect_word_gluing_issues(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
 
         # Check for potential page boundary issues (very long words that might be glued)
         long_words = re.findall(r"\b\w{15,}\b", text)
-        suspicious_long_words = [
-            word for word in long_words if re.search(r"[a-z][A-Z]", word)
-        ]
+        suspicious_long_words = [word for word in long_words if re.search(r"[a-z][A-Z]", word)]
         if suspicious_long_words:
             gluing_issues["page_boundary_gluing"] += len(suspicious_long_words)
             chunk_has_issues = True
@@ -602,9 +587,9 @@ def detect_word_gluing_issues(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
                         "chunk_index": i,
                         "example": suspicious_long_words[0],
                         "context": text[
-                            max(
-                                0, text.find(suspicious_long_words[0]) - 20
-                            ) : text.find(suspicious_long_words[0])
+                            max(0, text.find(suspicious_long_words[0]) - 20) : text.find(
+                                suspicious_long_words[0]
+                            )
                             + 30
                         ],
                     }
@@ -723,9 +708,7 @@ def validate_text_processing_quality(chunks: List[Dict[str, Any]]) -> Dict[str, 
     )
 
     if validation_results["total_chunks"] > 0:
-        quality_score = max(
-            0.0, 1.0 - (total_issues / validation_results["total_chunks"])
-        )
+        quality_score = max(0.0, 1.0 - (total_issues / validation_results["total_chunks"]))
         validation_results["overall_quality_score"] = quality_score
 
     # Generate recommendations
@@ -754,13 +737,9 @@ def validate_text_processing_quality(chunks: List[Dict[str, Any]]) -> Dict[str, 
 
 def print_text_processing_validation_report(validation_results: Dict[str, Any]) -> None:
     """Print a detailed text processing validation report."""
-    print(
-        "================================================================================"
-    )
+    print("================================================================================")
     print("TEXT PROCESSING QUALITY VALIDATION REPORT")
-    print(
-        "================================================================================"
-    )
+    print("================================================================================")
 
     print(f"Total Chunks Analyzed: {validation_results['total_chunks']}")
     print(f"Overall Quality Score: {validation_results['overall_quality_score']:.3f}")
@@ -809,9 +788,7 @@ def print_text_processing_validation_report(validation_results: Dict[str, Any]) 
         print()
 
 
-def compare_quality_reports(
-    report1: Dict[str, Any], report2: Dict[str, Any]
-) -> Dict[str, Any]:
+def compare_quality_reports(report1: Dict[str, Any], report2: Dict[str, Any]) -> Dict[str, Any]:
     """Compare two quality reports and generate improvement analysis."""
     comparison = {
         "file1": report1["filename"],
@@ -870,13 +847,9 @@ def compare_quality_reports(
         if factor_name in factors2:
             improvement = factors2[factor_name] - factors1[factor_name]
             if improvement > 0.05:
-                comparison["improvements"].append(
-                    f"Improved {factor_name}: {improvement:+.3f}"
-                )
+                comparison["improvements"].append(f"Improved {factor_name}: {improvement:+.3f}")
             elif improvement < -0.05:
-                comparison["regressions"].append(
-                    f"Degraded {factor_name}: {improvement:+.3f}"
-                )
+                comparison["regressions"].append(f"Degraded {factor_name}: {improvement:+.3f}")
 
     return comparison
 
@@ -910,16 +883,10 @@ def print_quality_report(
         reordering = validation_results["text_reordering_issues"]
         print("TEXT REORDERING ISSUES")
         print("----------------------------------------")
-        print(
-            f"Quote Splitting Issues:  {reordering['quote_splitting_issues']} instances"
-        )
-        print(
-            f"Sentence Fragmentation:  {reordering['sentence_fragmentation']} instances"
-        )
+        print(f"Quote Splitting Issues:  {reordering['quote_splitting_issues']} instances")
+        print(f"Sentence Fragmentation:  {reordering['sentence_fragmentation']} instances")
         print(f"Suspicious Starts:       {reordering['suspicious_starts']} instances")
-        print(
-            f"JSON Escaping Issues:    {reordering['json_escaping_issues']} instances"
-        )
+        print(f"JSON Escaping Issues:    {reordering['json_escaping_issues']} instances")
         print(f"Chunks Affected:         {reordering['total_chunks_affected']}")
         print()
 
@@ -930,9 +897,7 @@ def print_quality_report(
             print("----------------------------------------")
             for i, example in enumerate(all_examples[:5]):  # Show up to 5 examples
                 print(f"Example {i+1} ({example['type']}):")
-                print(
-                    f"  Chunk {example['chunk_index']}: {example.get('example', 'N/A')}"
-                )
+                print(f"  Chunk {example['chunk_index']}: {example.get('example', 'N/A')}")
                 if "context" in example:
                     print(f"  Context: ...{example['context']}...")
                 if "issue" in example:
@@ -978,9 +943,7 @@ def print_quality_report(
     print("-" * 40)
     for factor in report.get("quality_factors", []):
         factor_name, score, weight = factor
-        print(
-            f"{factor_name.replace('_', ' ').title():<20} {score:.3f} (weight: {weight:.1f})"
-        )
+        print(f"{factor_name.replace('_', ' ').title():<20} {score:.3f} (weight: {weight:.1f})")
     print()
 
     # Issues and recommendations
@@ -1031,18 +994,10 @@ def print_quality_report(
         if any(dialogue.values()):
             print("DIALOGUE ANALYSIS")
             print("-" * 40)
-            print(
-                f"Quoted Speech Chunks:      {len(dialogue.get('quoted_speech', []))}"
-            )
-            print(
-                f"Dialogue Attribution:      {len(dialogue.get('dialogue_attribution', []))}"
-            )
-            print(
-                f"Conversational Responses:  {len(dialogue.get('conversational_responses', []))}"
-            )
-            print(
-                f"Potential Fragments:       {len(dialogue.get('potential_fragments', []))}"
-            )
+            print(f"Quoted Speech Chunks:      {len(dialogue.get('quoted_speech', []))}")
+            print(f"Dialogue Attribution:      {len(dialogue.get('dialogue_attribution', []))}")
+            print(f"Conversational Responses:  {len(dialogue.get('conversational_responses', []))}")
+            print(f"Potential Fragments:       {len(dialogue.get('potential_fragments', []))}")
             print()
 
         # Flow analysis
@@ -1129,17 +1084,13 @@ def generate_chunks_from_pdf(
         os.environ["PDF_CHUNKER_USE_PYMUPDF4LLM"] = "false"
         min_chunk_size = None  # Use default large chunk size
         enable_dialogue_detection = False
-        print(
-            f"Using traditional approach: PyMuPDF4LLM disabled, dialogue detection disabled"
-        )
+        print(f"Using traditional approach: PyMuPDF4LLM disabled, dialogue detection disabled")
     else:
         # Enhanced: enable PyMuPDF4LLM and conversational text handling
         os.environ["PDF_CHUNKER_USE_PYMUPDF4LLM"] = "true"
         min_chunk_size = 8  # Use small minimum chunk size for conversational merging
         enable_dialogue_detection = True
-        print(
-            f"Using enhanced approach: PyMuPDF4LLM enabled, dialogue detection enabled"
-        )
+        print(f"Using enhanced approach: PyMuPDF4LLM enabled, dialogue detection enabled")
 
     try:
         # Process the document
@@ -1179,9 +1130,7 @@ def save_chunks_to_jsonl(chunks: List[Dict[str, Any]], output_path: str) -> None
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Validate chunk quality from JSONL output"
-    )
+    parser = argparse.ArgumentParser(description="Validate chunk quality from JSONL output")
 
     # Main operation modes
     group = parser.add_mutually_exclusive_group(required=True)
@@ -1199,9 +1148,7 @@ def main() -> None:
         metavar="BASELINE_JSONL",
         help="Baseline JSONL file for comparison",
     )
-    parser.add_argument(
-        "--detailed", action="store_true", help="Show detailed analysis"
-    )
+    parser.add_argument("--detailed", action="store_true", help="Show detailed analysis")
 
     # Options for PDF generation
 
@@ -1251,9 +1198,7 @@ def main() -> None:
             enhanced = args.enhanced
 
         # Generate the chunks
-        chunks = generate_chunks_from_pdf(
-            pdf_path, traditional=traditional, enhanced=enhanced
-        )
+        chunks = generate_chunks_from_pdf(pdf_path, traditional=traditional, enhanced=enhanced)
 
         # Determine output path
         if args.save_jsonl:
@@ -1265,12 +1210,8 @@ def main() -> None:
         # Analyze
         report = generate_quality_report(chunks, f"{pdf_path} ({approach})")
         # Generate validation_results and pass to print_quality_report
-        validation_results = (
-            validate_text_processing_quality(chunks) if args.detailed else None
-        )
-        print_quality_report(
-            report, detailed=args.detailed, validation_results=validation_results
-        )
+        validation_results = validate_text_processing_quality(chunks) if args.detailed else None
+        print_quality_report(report, detailed=args.detailed, validation_results=validation_results)
 
         if args.detailed and validation_results:
             print("\n")
@@ -1286,9 +1227,7 @@ def main() -> None:
         chunks2 = load_jsonl(file2)
 
         if not chunks1 or not chunks2:
-            print(
-                "Error: Could not load chunks from one or both files", file=sys.stderr
-            )
+            print("Error: Could not load chunks from one or both files", file=sys.stderr)
             sys.exit(1)
 
         # Generate reports
@@ -1296,12 +1235,8 @@ def main() -> None:
         report2 = generate_quality_report(chunks2, file2)
 
         # Generate validation_results for both files if detailed
-        validation_results1 = (
-            validate_text_processing_quality(chunks1) if args.detailed else None
-        )
-        validation_results2 = (
-            validate_text_processing_quality(chunks2) if args.detailed else None
-        )
+        validation_results1 = validate_text_processing_quality(chunks1) if args.detailed else None
+        validation_results2 = validate_text_processing_quality(chunks2) if args.detailed else None
 
         # Print individual reports
         print(f"\nAnalysis of {file1}:")
@@ -1329,12 +1264,8 @@ def main() -> None:
         chunks = load_jsonl(jsonl_file)
         report = generate_quality_report(chunks, jsonl_file)
         # Generate validation_results and pass to print_quality_report
-        validation_results = (
-            validate_text_processing_quality(chunks) if args.detailed else None
-        )
-        print_quality_report(
-            report, detailed=args.detailed, validation_results=validation_results
-        )
+        validation_results = validate_text_processing_quality(chunks) if args.detailed else None
+        print_quality_report(report, detailed=args.detailed, validation_results=validation_results)
 
         if args.detailed and validation_results:
             print("\n")
@@ -1351,9 +1282,7 @@ def main() -> None:
                 baseline_chunks = load_jsonl(args.baseline)
 
                 if baseline_chunks:
-                    baseline_report = generate_quality_report(
-                        baseline_chunks, args.baseline
-                    )
+                    baseline_report = generate_quality_report(baseline_chunks, args.baseline)
 
                     print(f"\nComparison (Baseline vs Current):")
                     comparison = compare_quality_reports(baseline_report, report)

--- a/scripts/validate_readme_functionality.py
+++ b/scripts/validate_readme_functionality.py
@@ -52,9 +52,7 @@ class READMEValidator:
         self.results.append(result)
 
         # Print immediate feedback
-        status_symbol = {"PASS": "✓", "FAIL": "✗", "MISSING": "?", "PARTIAL": "~"}.get(
-            status, "?"
-        )
+        status_symbol = {"PASS": "✓", "FAIL": "✗", "MISSING": "?", "PARTIAL": "~"}.get(status, "?")
 
         print(f"{status_symbol} {feature}: {status}")
         if details:
@@ -113,34 +111,22 @@ class READMEValidator:
 
             # Test availability check
             available = is_pymupdf4llm_available()
-            self.log_result(
-                "PyMuPDF4LLM availability check", "PASS", f"Available: {available}"
-            )
+            self.log_result("PyMuPDF4LLM availability check", "PASS", f"Available: {available}")
 
             # Test extraction function exists
             if hasattr(extract_with_pymupdf4llm, "__call__"):
-                self.log_result(
-                    "PyMuPDF4LLM extract function", "PASS", "Function is callable"
-                )
+                self.log_result("PyMuPDF4LLM extract function", "PASS", "Function is callable")
             else:
-                self.log_result(
-                    "PyMuPDF4LLM extract function", "FAIL", "Function not callable"
-                )
+                self.log_result("PyMuPDF4LLM extract function", "FAIL", "Function not callable")
 
             # Test cleaning function exists
             if hasattr(clean_text_with_pymupdf4llm, "__call__"):
-                self.log_result(
-                    "PyMuPDF4LLM clean function", "PASS", "Function is callable"
-                )
+                self.log_result("PyMuPDF4LLM clean function", "PASS", "Function is callable")
             else:
-                self.log_result(
-                    "PyMuPDF4LLM clean function", "FAIL", "Function not callable"
-                )
+                self.log_result("PyMuPDF4LLM clean function", "FAIL", "Function not callable")
 
         except ImportError as e:
-            self.log_result(
-                "PyMuPDF4LLM integration", "MISSING", "Module not found", str(e)
-            )
+            self.log_result("PyMuPDF4LLM integration", "MISSING", "Module not found", str(e))
         except Exception as e:
             self.log_result("PyMuPDF4LLM integration", "FAIL", "Import error", str(e))
 
@@ -164,18 +150,12 @@ class READMEValidator:
 
             for func_name, func in functions:
                 if hasattr(func, "__call__"):
-                    self.log_result(
-                        f"PDF function {func_name}", "PASS", "Function is callable"
-                    )
+                    self.log_result(f"PDF function {func_name}", "PASS", "Function is callable")
                 else:
-                    self.log_result(
-                        f"PDF function {func_name}", "FAIL", "Function not callable"
-                    )
+                    self.log_result(f"PDF function {func_name}", "FAIL", "Function not callable")
 
         except ImportError as e:
-            self.log_result(
-                "PDF processing functions", "MISSING", "Module not found", str(e)
-            )
+            self.log_result("PDF processing functions", "MISSING", "Module not found", str(e))
         except Exception as e:
             self.log_result("PDF processing functions", "FAIL", "Import error", str(e))
 
@@ -199,22 +179,16 @@ class READMEValidator:
 
             for func_name, func in functions:
                 if hasattr(func, "__call__"):
-                    self.log_result(
-                        f"EPUB function {func_name}", "PASS", "Function is callable"
-                    )
+                    self.log_result(f"EPUB function {func_name}", "PASS", "Function is callable")
                 else:
-                    self.log_result(
-                        f"EPUB function {func_name}", "FAIL", "Function not callable"
-                    )
+                    self.log_result(f"EPUB function {func_name}", "FAIL", "Function not callable")
 
             # Check for spine discovery functionality
             try:
                 import inspect
 
                 sig = inspect.signature(list_epub_spines)
-                self.log_result(
-                    "EPUB spine discovery", "PASS", f"Function signature: {sig}"
-                )
+                self.log_result("EPUB spine discovery", "PASS", f"Function signature: {sig}")
             except Exception as e:
                 self.log_result(
                     "EPUB spine discovery",
@@ -224,9 +198,7 @@ class READMEValidator:
                 )
 
         except ImportError as e:
-            self.log_result(
-                "EPUB processing functions", "MISSING", "Module not found", str(e)
-            )
+            self.log_result("EPUB processing functions", "MISSING", "Module not found", str(e))
         except Exception as e:
             self.log_result("EPUB processing functions", "FAIL", "Import error", str(e))
 
@@ -250,22 +222,16 @@ class READMEValidator:
 
             for func_name, func in functions:
                 if hasattr(func, "__call__"):
-                    self.log_result(
-                        f"AI function {func_name}", "PASS", "Function is callable"
-                    )
+                    self.log_result(f"AI function {func_name}", "PASS", "Function is callable")
                 else:
-                    self.log_result(
-                        f"AI function {func_name}", "FAIL", "Function not callable"
-                    )
+                    self.log_result(f"AI function {func_name}", "FAIL", "Function not callable")
 
             # Check for tag configuration loading
             try:
                 import inspect
 
                 sig = inspect.signature(_load_tag_configs)
-                self.log_result(
-                    "Tag configuration loading", "PASS", f"Function signature: {sig}"
-                )
+                self.log_result("Tag configuration loading", "PASS", f"Function signature: {sig}")
             except Exception as e:
                 self.log_result(
                     "Tag configuration loading",
@@ -275,9 +241,7 @@ class READMEValidator:
                 )
 
         except ImportError as e:
-            self.log_result(
-                "AI enrichment functions", "MISSING", "Module not found", str(e)
-            )
+            self.log_result("AI enrichment functions", "MISSING", "Module not found", str(e))
         except Exception as e:
             self.log_result("AI enrichment functions", "FAIL", "Import error", str(e))
 
@@ -303,18 +267,12 @@ class READMEValidator:
 
             for func_name, func in cleaning_functions:
                 if hasattr(func, "__call__"):
-                    self.log_result(
-                        f"Text cleaning {func_name}", "PASS", "Function is callable"
-                    )
+                    self.log_result(f"Text cleaning {func_name}", "PASS", "Function is callable")
                 else:
-                    self.log_result(
-                        f"Text cleaning {func_name}", "FAIL", "Function not callable"
-                    )
+                    self.log_result(f"Text cleaning {func_name}", "FAIL", "Function not callable")
 
         except ImportError as e:
-            self.log_result(
-                "Text cleaning functions", "MISSING", "Module not found", str(e)
-            )
+            self.log_result("Text cleaning functions", "MISSING", "Module not found", str(e))
         except Exception as e:
             self.log_result("Text cleaning functions", "FAIL", "Import error", str(e))
 
@@ -334,18 +292,12 @@ class READMEValidator:
 
             for func_name, func in processing_functions:
                 if hasattr(func, "__call__"):
-                    self.log_result(
-                        f"Text processing {func_name}", "PASS", "Function is callable"
-                    )
+                    self.log_result(f"Text processing {func_name}", "PASS", "Function is callable")
                 else:
-                    self.log_result(
-                        f"Text processing {func_name}", "FAIL", "Function not callable"
-                    )
+                    self.log_result(f"Text processing {func_name}", "FAIL", "Function not callable")
 
         except ImportError as e:
-            self.log_result(
-                "Text processing functions", "MISSING", "Module not found", str(e)
-            )
+            self.log_result("Text processing functions", "MISSING", "Module not found", str(e))
         except Exception as e:
             self.log_result("Text processing functions", "FAIL", "Import error", str(e))
 
@@ -368,13 +320,9 @@ class READMEValidator:
 
             for func_name, func in chunking_functions:
                 if hasattr(func, "__call__"):
-                    self.log_result(
-                        f"Chunking {func_name}", "PASS", "Function is callable"
-                    )
+                    self.log_result(f"Chunking {func_name}", "PASS", "Function is callable")
                 else:
-                    self.log_result(
-                        f"Chunking {func_name}", "FAIL", "Function not callable"
-                    )
+                    self.log_result(f"Chunking {func_name}", "FAIL", "Function not callable")
 
         except ImportError as e:
             self.log_result("Chunking functions", "MISSING", "Module not found", str(e))
@@ -400,13 +348,9 @@ class READMEValidator:
 
             for func_name, func in utility_functions:
                 if hasattr(func, "__call__"):
-                    self.log_result(
-                        f"Utility {func_name}", "PASS", "Function is callable"
-                    )
+                    self.log_result(f"Utility {func_name}", "PASS", "Function is callable")
                 else:
-                    self.log_result(
-                        f"Utility {func_name}", "FAIL", "Function not callable"
-                    )
+                    self.log_result(f"Utility {func_name}", "FAIL", "Function not callable")
 
         except ImportError as e:
             self.log_result("Utility functions", "MISSING", "Module not found", str(e))
@@ -421,9 +365,7 @@ class READMEValidator:
             from pdf_chunker.core import process_document
 
             if hasattr(process_document, "__call__"):
-                self.log_result(
-                    "Core process_document function", "PASS", "Function is callable"
-                )
+                self.log_result("Core process_document function", "PASS", "Function is callable")
 
                 # Check function signature for expected parameters
                 import inspect
@@ -442,13 +384,9 @@ class READMEValidator:
                         f"Missing expected params: {missing_params}, Found: {params}",
                     )
                 else:
-                    self.log_result(
-                        "Core function parameters", "PASS", f"Parameters: {params}"
-                    )
+                    self.log_result("Core function parameters", "PASS", f"Parameters: {params}")
             else:
-                self.log_result(
-                    "Core process_document function", "FAIL", "Function not callable"
-                )
+                self.log_result("Core process_document function", "FAIL", "Function not callable")
 
         except ImportError as e:
             self.log_result("Core processing", "MISSING", "Module not found", str(e))
@@ -485,9 +423,7 @@ class READMEValidator:
                 )
 
         except Exception as e:
-            self.log_result(
-                "Page exclusion functionality", "FAIL", "Could not validate", str(e)
-            )
+            self.log_result("Page exclusion functionality", "FAIL", "Could not validate", str(e))
 
     def validate_chunk_quality(self):
         """Validate chunk quality validation and size limits"""
@@ -496,9 +432,7 @@ class READMEValidator:
         # Check for existing chunk quality validation script
         quality_script = self.project_root / "scripts" / "validate_chunk_quality.py"
         if quality_script.exists():
-            self.log_result(
-                "Chunk quality script", "PASS", f"Found at {quality_script}"
-            )
+            self.log_result("Chunk quality script", "PASS", f"Found at {quality_script}")
         else:
             self.log_result("Chunk quality script", "MISSING", "Script not found")
 
@@ -524,9 +458,7 @@ class READMEValidator:
             # Check for tags directory
             tags_dir = config_dir / "tags"
             if tags_dir.exists():
-                self.log_result(
-                    "Tags configuration directory", "PASS", f"Found at {tags_dir}"
-                )
+                self.log_result("Tags configuration directory", "PASS", f"Found at {tags_dir}")
 
                 # Check for any tag files
                 tag_files = list(tags_dir.glob("*.yaml")) + list(tags_dir.glob("*.yml"))
@@ -537,13 +469,9 @@ class READMEValidator:
                         f"Found {len(tag_files)} files",
                     )
                 else:
-                    self.log_result(
-                        "Tag configuration files", "MISSING", "No YAML tag files found"
-                    )
+                    self.log_result("Tag configuration files", "MISSING", "No YAML tag files found")
             else:
-                self.log_result(
-                    "Tags configuration directory", "MISSING", "Directory not found"
-                )
+                self.log_result("Tags configuration directory", "MISSING", "Directory not found")
         else:
             self.log_result("Configuration directory", "MISSING", "Directory not found")
 
@@ -579,9 +507,7 @@ class READMEValidator:
         # Check requirements.txt
         requirements_file = self.project_root / "requirements.txt"
         if requirements_file.exists():
-            self.log_result(
-                "Requirements file", "PASS", f"Found at {requirements_file}"
-            )
+            self.log_result("Requirements file", "PASS", f"Found at {requirements_file}")
 
             # Read and check for key dependencies mentioned in README
             try:
@@ -599,9 +525,7 @@ class READMEValidator:
                         missing_deps.append(dep)
 
                 if found_deps:
-                    self.log_result(
-                        "Key dependencies found", "PASS", f"Found: {found_deps}"
-                    )
+                    self.log_result("Key dependencies found", "PASS", f"Found: {found_deps}")
                 if missing_deps:
                     self.log_result(
                         "Key dependencies missing",
@@ -643,16 +567,12 @@ class READMEValidator:
             epub_files = list(self.test_data_dir.glob("*.epub"))
 
         if pdf_files:
-            self.log_result(
-                "Test PDF files", "PASS", f"Found {len(pdf_files)} PDF files"
-            )
+            self.log_result("Test PDF files", "PASS", f"Found {len(pdf_files)} PDF files")
         else:
             self.log_result("Test PDF files", "MISSING", "No PDF test files found")
 
         if epub_files:
-            self.log_result(
-                "Test EPUB files", "PASS", f"Found {len(epub_files)} EPUB files"
-            )
+            self.log_result("Test EPUB files", "PASS", f"Found {len(epub_files)} EPUB files")
         else:
             self.log_result("Test EPUB files", "MISSING", "No EPUB test files found")
 
@@ -678,9 +598,7 @@ class READMEValidator:
                     )
 
             except Exception as e:
-                self.log_result(
-                    "Core processing test", "FAIL", "Could not set up test", str(e)
-                )
+                self.log_result("Core processing test", "FAIL", "Could not set up test", str(e))
 
     def generate_report(self):
         """Generate a comprehensive validation report"""

--- a/tests/bullet_list_test.py
+++ b/tests/bullet_list_test.py
@@ -19,9 +19,7 @@ def test_bullet_list_preservation():
     assert report.boundary_overlaps == []
 
     blob = "\n\n".join(b["text"] for b in blocks)
-    items = [
-        line.strip() for line in blob.splitlines() if line.lstrip().startswith("•")
-    ]
+    items = [line.strip() for line in blob.splitlines() if line.lstrip().startswith("•")]
     assert len(items) == 3
     assert all(not item.rstrip().endswith(".") for item in items)
     assert "•\n\n•" not in blob

--- a/tests/chunk_pdf_integration_test.py
+++ b/tests/chunk_pdf_integration_test.py
@@ -17,13 +17,10 @@ def test_chunk_pdf_generates_jsonl(tmp_path: Path) -> None:
         check=True,
     )
     lines = [
-        json.loads(line)
-        for line in result.stdout.splitlines()
-        if line.strip().startswith("{")
+        json.loads(line) for line in result.stdout.splitlines() if line.strip().startswith("{")
     ]
     assert lines and all(
-        {"text", "metadata"} <= line.keys()
-        and {"chunk_id", "source"} <= line["metadata"].keys()
+        {"text", "metadata"} <= line.keys() and {"chunk_id", "source"} <= line["metadata"].keys()
         for line in lines
     )
     assert not any(tmp_path.iterdir())

--- a/tests/epub_spine_test.py
+++ b/tests/epub_spine_test.py
@@ -20,9 +20,7 @@ def test_epub_spine_exclusion():
         print("Skipping EPUB spine exclusion checks.")
         return True
 
-    print(
-        f"Testing spine-based exclusion functionality with known-good EPUB: {test_epub_path}"
-    )
+    print(f"Testing spine-based exclusion functionality with known-good EPUB: {test_epub_path}")
     success_count = 0
 
     epub_file = test_epub_path
@@ -52,9 +50,7 @@ def test_epub_spine_exclusion():
                 # Test excluding first spine item
                 print(f"  Test 1: Excluding spine item 1")
                 try:
-                    excluded_blocks = extract_structured_text(
-                        epub_file, exclude_pages="1"
-                    )
+                    excluded_blocks = extract_structured_text(epub_file, exclude_pages="1")
                     excluded_spines = set()
                     for block in excluded_blocks:
                         location = block.get("source", {}).get("location")
@@ -65,20 +61,16 @@ def test_epub_spine_exclusion():
                     first_spine_content = [
                         block
                         for block in baseline_blocks
-                        if block.get("source", {}).get("location")
-                        == sorted(spine_items)[0]
+                        if block.get("source", {}).get("location") == sorted(spine_items)[0]
                     ]
                     first_spine_in_excluded = [
                         block
                         for block in excluded_blocks
-                        if block.get("source", {}).get("location")
-                        == sorted(spine_items)[0]
+                        if block.get("source", {}).get("location") == sorted(spine_items)[0]
                     ]
 
                     if first_spine_in_excluded:
-                        print(
-                            f"    ERROR: First spine item content still appears in output!"
-                        )
+                        print(f"    ERROR: First spine item content still appears in output!")
                     else:
                         print(f"    SUCCESS: First spine item successfully excluded")
                         success_count += 1
@@ -111,25 +103,17 @@ def test_epub_spine_exclusion():
 
                         sorted_spines = sorted(spine_items)
                         first_spine_in_chunks = (
-                            sorted_spines[0] in chunk_locations
-                            if sorted_spines
-                            else False
+                            sorted_spines[0] in chunk_locations if sorted_spines else False
                         )
 
                         if first_spine_in_chunks:
-                            print(
-                                f"    ERROR: Excluded first spine item appears in final chunks!"
-                            )
+                            print(f"    ERROR: Excluded first spine item appears in final chunks!")
                         else:
-                            print(
-                                f"    SUCCESS: Spine exclusion works in full pipeline"
-                            )
+                            print(f"    SUCCESS: Spine exclusion works in full pipeline")
                             success_count += 1
 
                         print(f"    Final chunks generated: {len(chunks)}")
-                        print(
-                            f"    Spine items in final chunks: {len(chunk_locations)}"
-                        )
+                        print(f"    Spine items in final chunks: {len(chunk_locations)}")
                     else:
                         print(f"    ERROR: No chunks generated in full pipeline")
 

--- a/tests/golden/test_conversion_epub_cli.py
+++ b/tests/golden/test_conversion_epub_cli.py
@@ -11,9 +11,7 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_conversion_epub_cli(tmp_path: Path) -> None:
-    epub_path = materialize_base64(
-        BASE / "samples" / "sample.epub.b64", tmp_path, "sample.epub"
-    )
+    epub_path = materialize_base64(BASE / "samples" / "sample.epub.b64", tmp_path, "sample.epub")
     out_file = tmp_path / "out.jsonl"
     cmd = [
         "python",

--- a/tests/heading_detection_test.py
+++ b/tests/heading_detection_test.py
@@ -27,9 +27,7 @@ class TestHeadingDetectionFallback(unittest.TestCase):
         """Font-emphasized lines ending with punctuation should remain body text."""
         spans = [{"flags": 2}]
         self.assertFalse(
-            _spans_indicate_heading(
-                spans, "Considering this issue, no decision was made."
-            )
+            _spans_indicate_heading(spans, "Considering this issue, no decision was made.")
         )
 
 

--- a/tests/hyphenation_test.py
+++ b/tests/hyphenation_test.py
@@ -15,10 +15,7 @@ def test_hyphenation_fix_with_pymupdf4llm(force_pymupdf4llm):
     sample = "a con-\n tainer and special-\n ists in man-\n agement"
     cleaned = clean_text(sample)
     assert all(word in cleaned for word in ("container", "specialists", "management"))
-    assert all(
-        broken not in cleaned
-        for broken in ("con- tainer", "special- ists", "man- agement")
-    )
+    assert all(broken not in cleaned for broken in ("con- tainer", "special- ists", "man- agement"))
 
 
 @pytest.mark.parametrize(

--- a/tests/indented_block_test.py
+++ b/tests/indented_block_test.py
@@ -6,9 +6,7 @@ import pytest
 from pdf_chunker.pdf_parsing import extract_text_blocks_from_pdf
 
 
-@pytest.mark.skip(
-    reason="sample_book3.pdf no longer contains an indented block example"
-)
+@pytest.mark.skip(reason="sample_book3.pdf no longer contains an indented block example")
 def test_indented_block_no_double_newline():
     blocks = extract_text_blocks_from_pdf("sample_book3.pdf")
     blob = "\n\n".join(b["text"] for b in blocks)

--- a/tests/multiline_numbered_test.py
+++ b/tests/multiline_numbered_test.py
@@ -15,8 +15,7 @@ def test_multiline_numbered_items() -> None:
     )
     chunks = semantic_chunker(text, chunk_size=40, overlap=0)
     assert any(
-        "1. First item is long" in chunk
-        and "Continuation of first item to ensure split." in chunk
+        "1. First item is long" in chunk and "Continuation of first item to ensure split." in chunk
         for chunk in chunks
     )
     assert any(

--- a/tests/numbered_list_test.py
+++ b/tests/numbered_list_test.py
@@ -14,9 +14,7 @@ from pdf_chunker.text_cleaning import (
 def test_numbered_list_preservation():
     blocks = extract_text_blocks_from_pdf("sample_book0-1.pdf")
     blob = "\n\n".join(b["text"] for b in blocks)
-    items = [
-        line.strip() for line in blob.splitlines() if re.match(r"\d+\.", line.strip())
-    ]
+    items = [line.strip() for line in blob.splitlines() if re.match(r"\d+\.", line.strip())]
     assert len(items) == 4
     assert "\n\n2." not in blob
     assert "\n\n3." not in blob
@@ -63,10 +61,7 @@ def test_quoted_question_inside_numbered_item() -> None:
 
 @pytest.mark.parametrize("punct", list(".…"))
 def test_quoted_sentence_endings_inside_numbered_item(punct: str) -> None:
-    text = (
-        f'1. Item with a quote "quoted sentence{punct}" '
-        "Then proceed with more details."
-    )
+    text = f'1. Item with a quote "quoted sentence{punct}" ' "Then proceed with more details."
     cleaned = insert_numbered_list_newlines(text)
     cleaned = collapse_single_newlines(cleaned)
     assert "\n\nThen" not in cleaned
@@ -85,10 +80,7 @@ def test_long_inline_numbered_items() -> None:
 
 
 def test_item_ending_with_chapter_preserves_newline() -> None:
-    text = (
-        "1. Intro text spanning lines\n"
-        "continues and ends with Chapter 2. Second item"
-    )
+    text = "1. Intro text spanning lines\n" "continues and ends with Chapter 2. Second item"
     cleaned = insert_numbered_list_newlines(text)
     cleaned = collapse_single_newlines(cleaned)
     assert "Chapter 2." not in cleaned

--- a/tests/page_artifact_detection_test.py
+++ b/tests/page_artifact_detection_test.py
@@ -92,9 +92,7 @@ class TestPageArtifactDetection(unittest.TestCase):
             "4 Footnote text. The sentence continues here."
         )
         cleaned = remove_page_artifact_lines(text, 115)
-        self.assertEqual(
-            cleaned, "First part of sentence\nThe sentence continues here."
-        )
+        self.assertEqual(cleaned, "First part of sentence\nThe sentence continues here.")
 
     def test_header_inserted_mid_sentence(self):
         text = (
@@ -124,9 +122,7 @@ class TestPageArtifactDetection(unittest.TestCase):
             "|Person Name, PMP<br>Alma, Quebec, Canada|Person Name, PMP<br>Alma, Quebec, Canada|"
         )
         expected = (
-            "This closed car smells of salt fish\n"
-            "Person Name, PMP\n"
-            "Alma, Quebec, Canada"
+            "This closed car smells of salt fish\n" "Person Name, PMP\n" "Alma, Quebec, Canada"
         )
         cleaned = remove_page_artifact_lines(table_text, 1)
         self.assertEqual(cleaned, expected)

--- a/tests/parity/normalize.py
+++ b/tests/parity/normalize.py
@@ -1,4 +1,5 @@
 """Normalization utilities for row comparison in parity tests."""
+
 from __future__ import annotations
 
 import json
@@ -12,11 +13,7 @@ VOLATILE_FIELDS = frozenset({"timings"})
 def load_rows(path: str | Path) -> Iterator[dict[str, Any]]:
     """Yield JSON objects from ``path`` line by line."""
     with Path(path).open(encoding="utf-8") as handle:
-        yield from (
-            json.loads(line)
-            for line in handle
-            if line.strip()
-        )
+        yield from (json.loads(line) for line in handle if line.strip())
 
 
 def _strip(value: Any) -> Any:
@@ -30,11 +27,7 @@ def normalize(row: Mapping[str, Any]) -> dict[str, Any]:
     - Leading/trailing whitespace is removed from string values.
     - Volatile fields (e.g., timings) are excluded.
     """
-    return {
-        key: _strip(value)
-        for key, value in sorted(row.items())
-        if key not in VOLATILE_FIELDS
-    }
+    return {key: _strip(value) for key, value in sorted(row.items()) if key not in VOLATILE_FIELDS}
 
 
 def canonical_rows(path: str | Path) -> Iterator[dict[str, Any]]:

--- a/tests/pdf_extraction_test.py
+++ b/tests/pdf_extraction_test.py
@@ -19,9 +19,7 @@ def test_pdf_extraction():
                 test_files.append(os.path.join(root, file))
 
     if not test_files:
-        print(
-            "No PDF files found for testing. Please add a PDF file to test the extraction."
-        )
+        print("No PDF files found for testing. Please add a PDF file to test the extraction.")
         return False
 
     print(f"Found {len(test_files)} PDF file(s) for testing:")
@@ -59,14 +57,10 @@ def test_pdf_extraction():
                         print(
                             f"  WARNING: Found {len(long_lines)} lines longer than 1000 characters"
                         )
-                        print(
-                            f"    Longest line: {len(max(long_lines, key=len))} characters"
-                        )
+                        print(f"    Longest line: {len(max(long_lines, key=len))} characters")
 
                     if space_density < 0.05:
-                        print(
-                            f"  WARNING: Very low space density detected ({space_density:.3f})"
-                        )
+                        print(f"  WARNING: Very low space density detected ({space_density:.3f})")
 
                     # Show sample text from first few blocks
                     print(f"  Sample text from first block:")
@@ -80,20 +74,12 @@ def test_pdf_extraction():
                         print(f"  Extraction method: {method}")
 
                     # Check heading detection
-                    headings = [
-                        block for block in blocks if block.get("type") == "heading"
-                    ]
-                    paragraphs = [
-                        block for block in blocks if block.get("type") == "paragraph"
-                    ]
-                    print(
-                        f"  Block types: {len(headings)} headings, {len(paragraphs)} paragraphs"
-                    )
+                    headings = [block for block in blocks if block.get("type") == "heading"]
+                    paragraphs = [block for block in blocks if block.get("type") == "paragraph"]
+                    print(f"  Block types: {len(headings)} headings, {len(paragraphs)} paragraphs")
 
                     if headings:
-                        print(
-                            f'  Sample heading: "{headings[0].get("text", "")[:100]}..."'
-                        )
+                        print(f'  Sample heading: "{headings[0].get("text", "")[:100]}..."')
 
                     success_count += 1
                 else:

--- a/tests/sample_local_pdf_list_test.py
+++ b/tests/sample_local_pdf_list_test.py
@@ -14,16 +14,12 @@ def test_sample_local_pdf_lists_have_newlines():
     assert "\n2. Second numbered item" in blob
     assert "\n3. Third numbered item\n\nBullet points:" in blob
 
-    numbered = [
-        line.strip() for line in blob.splitlines() if re.match(r"\d+\.", line.strip())
-    ]
+    numbered = [line.strip() for line in blob.splitlines() if re.match(r"\d+\.", line.strip())]
     assert numbered[0] == "1. First numbered item"
     assert numbered[1] == "2. Second numbered item"
     assert numbered[2] == "3. Third numbered item"
 
-    bullets = [
-        line.strip() for line in blob.splitlines() if line.strip().startswith("•")
-    ]
+    bullets = [line.strip() for line in blob.splitlines() if line.strip().startswith("•")]
     assert "• First bullet point" in bullets
     assert "• Second bullet point" in bullets
     assert any(b.startswith("• Third bullet point") for b in bullets)

--- a/tests/source_matchers_test.py
+++ b/tests/source_matchers_test.py
@@ -17,7 +17,5 @@ def test_find_source_block_uses_injected_matcher():
     def always_match(chunk_start, block, blocks):
         return True
 
-    result = utils._find_source_block(
-        chunk, {}, blocks, matchers=[("custom", always_match)]
-    )
+    result = utils._find_source_block(chunk, {}, blocks, matchers=[("custom", always_match)])
     assert result == blocks[0]

--- a/tests/split_semantic_pass_test.py
+++ b/tests/split_semantic_pass_test.py
@@ -15,14 +15,18 @@ def _doc(text: str) -> dict:
 def test_enforces_limits_and_structure(monkeypatch) -> None:
     captured: dict[str, tuple[int, int, int]] = {}
 
-    def fake_semantic_chunker(text: str, chunk_size: int, overlap: int, *, min_chunk_size: int) -> list[str]:
+    def fake_semantic_chunker(
+        text: str, chunk_size: int, overlap: int, *, min_chunk_size: int
+    ) -> list[str]:
         captured["args"] = (chunk_size, overlap, min_chunk_size)
         return [text]
 
     monkeypatch.setattr("pdf_chunker.splitter.semantic_chunker", fake_semantic_chunker)
 
     long_text = "x" * 30_000
-    art = _SplitSemanticPass(chunk_size=123, overlap=7, min_chunk_size=11)(Artifact(payload=_doc(long_text)))
+    art = _SplitSemanticPass(chunk_size=123, overlap=7, min_chunk_size=11)(
+        Artifact(payload=_doc(long_text))
+    )
 
     chunk = art.payload["items"][0]
     metrics = art.meta["metrics"]["split_semantic"]

--- a/tests/test_text_processing.py
+++ b/tests/test_text_processing.py
@@ -181,8 +181,7 @@ class TestTextCorruptionDetection(unittest.TestCase):
         text = "This hasWordGluing and moreIssues here."
         # This test passes - it's testing detection
         gluing_detected = any(
-            i > 0 and text[i - 1].islower() and text[i].isupper()
-            for i in range(len(text))
+            i > 0 and text[i - 1].islower() and text[i].isupper() for i in range(len(text))
         )
         self.assertTrue(gluing_detected)
 
@@ -198,10 +197,7 @@ class TestTextCorruptionDetection(unittest.TestCase):
         text = "This is well-formatted text with proper spacing and punctuation."
         # This test passes - it's testing validation
         issues = []
-        if any(
-            i > 0 and text[i - 1].islower() and text[i].isupper()
-            for i in range(len(text))
-        ):
+        if any(i > 0 and text[i - 1].islower() and text[i].isupper() for i in range(len(text))):
             issues.append("word_gluing")
         if '",' in text:
             issues.append("json_escaping")

--- a/tests/text_clean_pass_test.py
+++ b/tests/text_clean_pass_test.py
@@ -9,7 +9,7 @@ def _build_doc() -> dict:
             {
                 "page": 1,
                 "blocks": [
-                    {"text": "Foo\u00A0bar"},
+                    {"text": "Foo\u00a0bar"},
                     {"text": "One-\nline"},
                 ],
             }


### PR DESCRIPTION
## Summary
- apply `black` formatting across `pdf_chunker`, `scripts`, and `tests`

## Testing
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: numerous E501 line too long and other style warnings)*
- `mypy --follow-imports=skip --cache-dir=/tmp/mypy pdf_chunker/` *(fails: pdf_chunker/core.py incompatible types)*
- `bash scripts/validate_chunks.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68ace3ee76408325b31786755810cb03