### PR TITLE
Fix environment default and adapter parameter union

### DIFF
--- a/pdf_chunker/adapters/ai_enrich.py
+++ b/pdf_chunker/adapters/ai_enrich.py
@@ -54,7 +54,8 @@ def _load_tag_configs(config_dir: str = "config/tags") -> dict[str, list[str]]:
         acc: dict[str, list[str]],
         nxt: dict[str, list[str]],
     ) -> dict[str, list[str]]:
-        return {key: acc.get(key, []) + nxt.get(key, []) for key in set(acc) | set(nxt)}
+        keys = set(acc).union(nxt)
+        return {key: acc.get(key, []) + nxt.get(key, []) for key in keys}
 
     merged: dict[str, list[str]] = reduce(
         merge_dicts,

--- a/pdf_chunker/adapters/io_pdf.py
+++ b/pdf_chunker/adapters/io_pdf.py
@@ -91,7 +91,7 @@ def _primary_blocks(
     with _env("PDF_CHUNKER_USE_PYMUPDF4LLM", "1" if use_pymupdf4llm else "0"):
         from pdf_chunker.pdf_parsing import extract_text_blocks_from_pdf
 
-        return extract_text_blocks_from_pdf(path, exclude_pages=exclude)
+        return extract_text_blocks_from_pdf(path, exclude)
 
 
 def _fallback_blocks(

--- a/pdf_chunker/config.py
+++ b/pdf_chunker/config.py
@@ -54,7 +54,7 @@ def _merge_options(
     base: Dict[str, Dict[str, Any]], override: Dict[str, Dict[str, Any]]
 ) -> Dict[str, Dict[str, Any]]:
     """Shallow-merge per-step options with comprehension; override wins."""
-    sources = set(base) | set(override)
+    sources = set(base).union(override)
     return {s: {**base.get(s, {}), **override.get(s, {})} for s in sources}
 
 

--- a/pdf_chunker/env_utils.py
+++ b/pdf_chunker/env_utils.py
@@ -4,4 +4,6 @@ import os
 def use_pymupdf4llm() -> bool:
     """Return True if PyMuPDF4LLM should be enabled based on env var."""
     val = os.getenv("PDF_CHUNKER_USE_PYMUPDF4LLM")
-    return str(val).lower() in ("true", "1", "yes", "on")
+    if val is None:
+        return True
+    return val.lower() in {"true", "1", "yes", "on"}

--- a/pdf_chunker/heading_detection.py
+++ b/pdf_chunker/heading_detection.py
@@ -29,10 +29,12 @@ def _detect_heading_fallback(text: str) -> bool:
     text = text.strip()
     words = text.split()
 
-    # Very short text (1-3 words) without a terminal period is likely a heading.
-    # Short sentences such as "It ended." should remain part of the body text
-    # rather than being treated as headings.
+    # Very short text (1-3 words) without a terminal period is likely a heading
+    # but single words like "Body" should only qualify when they are explicit
+    # structural starters or are fully capitalized.
     if len(words) <= 3 and not text.endswith(TRAILING_PUNCTUATION):
+        if len(words) == 1 and not (text.isupper() or _has_heading_starter(words)):
+            return False
         return True
 
     # Text that's all uppercase might be a heading


### PR DESCRIPTION
## Summary
- Enable PyMuPDF4LLM by default when PDF_CHUNKER_USE_PYMUPDF4LLM is unset
- Use set union helpers and positional parameters for cleaner config merging and PDF extraction
- Refine heading fallback detection to avoid flagging generic single words as headings

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/ scripts/ tests/` *(fails: E501 line too long, F541 f-string issues, etc.)*
- `mypy pdf_chunker/` *(interrupted)*
- `pytest tests/env_utils_test.py tests/footer_artifact_test.py tests/heading_detection_test.py tests/io_pdf_adapter_test.py tests/newline_cleanup_test.py -q`
- `pytest tests -q` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c56f94408325b195fb3600932ec9