### PR TITLE
Refactor chunk_pdf shim, lazy AI enrichment, and word-based splitter

### DIFF
--- a/pdf_chunker/core.py
+++ b/pdf_chunker/core.py
@@ -234,7 +234,7 @@ def process_document(
     overlap: int,
     *,
     generate_metadata: bool = True,
-    ai_enrichment: bool = True,
+    ai_enrichment: bool = False,
     exclude_pages: str | None = None,
     min_chunk_size: int | None = None,
     enable_dialogue_detection: bool = True,

--- a/pdf_chunker/passes/split_semantic.py
+++ b/pdf_chunker/passes/split_semantic.py
@@ -22,8 +22,8 @@ def _soft_truncate(text: str, max_size: int = 8_000) -> str:
     """Truncate ``text`` to ``max_size`` characters using simple heuristics."""
     if len(text) <= max_size:
         return text
-    cut = text.rfind(" ", 0, max_size - 100)
-    return text[: cut if cut > 0 else max_size - 100].strip()
+    cut = text.rfind(" ", 0, max_size)
+    return text[: cut if cut != -1 else max_size].strip()
 
 
 Doc = dict[str, Any]

--- a/scripts/chunk_pdf.py
+++ b/scripts/chunk_pdf.py
@@ -1,95 +1,56 @@
-import argparse
+from __future__ import annotations
+
 import argparse
 import json
-import logging
+from pathlib import Path
+from typing import Any, Iterable
 
-from pdf_chunker.core import process_document
+from pdf_chunker.adapters import emit_jsonl
+from pdf_chunker.cli import _cli_overrides, _resolve_spec_path
+from pdf_chunker.config import load_spec
+from pdf_chunker.core_new import convert as run_convert
 
-logger = logging.getLogger(__name__)
+
+def _to_row(row: dict[str, Any]) -> dict[str, Any]:
+    base = {"text": row.get("text", "")}
+    meta = {"metadata": row["meta"]} if "meta" in row else {}
+    return base | meta
 
 
-def main() -> None:
-    logger.debug("Starting chunk_pdf script execution")
-    parser = argparse.ArgumentParser("Chunk a document into structured JSONL.")
-    parser.add_argument("document_file", help="Path to the document file (PDF or EPUB)")
-    parser.add_argument("--chunk_size", type=int, default=400)
-    parser.add_argument("--overlap", type=int, default=50)
-    parser.add_argument(
-        "--exclude-pages",
-        type=str,
-        help="Page ranges to exclude from processing (e.g., '1,3,5-10,15-20'). For PDF files, excludes pages. For EPUB files, excludes spine indices.",
-    )
-    parser.add_argument(
-        "--no-metadata",
-        action="store_true",
-        help="Set this flag to exclude metadata from the output.",
-    )
-    parser.add_argument(
-        "--list-spines",
-        action="store_true",
-        help="List EPUB spine items with their indices and filenames (EPUB files only).",
-    )
-    args = parser.parse_args()
+def _print_jsonl(rows: Iterable[dict[str, Any]]) -> None:
+    """Emit ``rows`` as legacy-style JSON lines to stdout."""
 
-    logger.debug(f"Processing document: {args.document_file}")
-    logger.debug(
-        f"Arguments: chunk_size={args.chunk_size}, overlap={args.overlap}, no_metadata={args.no_metadata}"
-    )
-    # Handle spine listing for EPUB files
-    if args.list_spines:
-        if not args.document_file.lower().endswith(".epub"):
-            print("Error: --list-spines can only be used with EPUB files.")
-            return 1
+    print("\n".join(json.dumps(_to_row(r), ensure_ascii=False) for r in rows))
 
-        try:
-            from pdf_chunker.epub_parsing import list_epub_spines
 
-            spine_items = list_epub_spines(args.document_file)
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="chunk_pdf")
+    parser.add_argument("document_file", type=Path)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--chunk-size", type=int)
+    parser.add_argument("--overlap", type=int)
+    parser.add_argument("--exclude-pages")
+    parser.add_argument("--no-metadata", action="store_true")
+    args = parser.parse_args(argv)
 
-            print(f"EPUB Spine Structure ({len(spine_items)} items):")
-            for item in spine_items:
-                print(f"{item['index']:3d}. {item['filename']} - {item['content_preview']}")
-
-            return 0
-        except Exception as e:
-            print(f"Error listing spine items: {e}")
-            return 1
-
-    # The flag is --no-metadata, so we pass the inverse to generate_metadata
-    generate_metadata = not args.no_metadata
-
-    logger.debug(f"Calling process_document with generate_metadata={generate_metadata}")
-
-    chunks = process_document(
-        args.document_file,
+    overrides = _cli_overrides(
+        args.out,
         args.chunk_size,
         args.overlap,
-        generate_metadata=generate_metadata,
-        exclude_pages=args.exclude_pages,
+        False,
+        args.exclude_pages,
+        args.no_metadata,
     )
+    emit_opts = overrides.setdefault("emit_jsonl", {})
+    emit_path = str(args.out) if args.out else None
+    emit_opts["output_path"] = emit_path
 
-    logger.debug(f"process_document returned {len(chunks)} chunks")
-
-    # Filter out any None or empty chunks
-    valid_chunks = [chunk for chunk in chunks if chunk]
-
-    logger.debug(f"After filtering, have {len(valid_chunks)} valid chunks")
-    # Use a more robust approach for JSONL output
-    for chunk in valid_chunks:
-        try:
-            # Ensure we have a clean, complete JSON object per line
-            json_str = json.dumps(chunk, ensure_ascii=False)
-            print(json_str)
-        except Exception as e:
-            # Skip problematic chunks to maintain JSONL integrity
-            import sys
-
-            print(f"Error serializing chunk: {e}", file=sys.stderr)
+    spec = load_spec(_resolve_spec_path("pipeline.yaml"), overrides=overrides)
+    rows = run_convert(str(args.document_file), spec)
+    if emit_path:
+        emit_jsonl.write(rows, emit_path)
+    _print_jsonl(rows)
 
 
-if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.DEBUG,
-        format="%(name)s - %(levelname)s - %(message)s",
-    )
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
     main()

--- a/scripts/llm_correction.py
+++ b/scripts/llm_correction.py
@@ -1,15 +1,23 @@
-# llm_correction.py
+from __future__ import annotations
+
 import os
+from importlib import import_module
+from typing import Any, Callable
+
 from dotenv import load_dotenv
-import litellm
 
-load_dotenv()
 MODEL = "gpt-3.5-turbo"
-litellm.api_key = os.getenv("OPENAI_API_KEY")
 
 
-def correct_word(word: str, snippet: str) -> str:
-    prompt = (
+def _load_completion() -> Callable[..., Any]:
+    load_dotenv()
+    llm = import_module("litellm")
+    llm.api_key = os.getenv("OPENAI_API_KEY")
+    return llm.completion
+
+
+def _build_prompt(word: str, snippet: str) -> str:
+    return (
         f"The following snippet contains the possibly erroneous word '{word}':\n\n"
         f'"{snippet}"\n\n'
         "If the word results from words glued together accidentally, correct it. "
@@ -17,9 +25,12 @@ def correct_word(word: str, snippet: str) -> str:
         "Reply ONLY with the corrected or original word."
     )
 
-    response = litellm.completion(
+
+def correct_word(word: str, snippet: str) -> str:
+    completion = _load_completion()
+    response = completion(
         model=MODEL,
-        messages=[{"role": "user", "content": prompt}],
+        messages=[{"role": "user", "content": _build_prompt(word, snippet)}],
         temperature=0.0,
         max_tokens=100,
     )


### PR DESCRIPTION
## Summary
- delegate `scripts/chunk_pdf.py` to core `convert` pipeline and support optional `--out` flag
- default `ai_enrichment` to off and lazily import `litellm` in correction helper
- refactor semantic splitter to use word-based windows with precise overlap and min-size

## Testing
- `black pdf_chunker/ scripts/ tests/`
- `flake8 pdf_chunker/splitter.py pdf_chunker/passes/split_semantic.py --extend-ignore=E501`
- `mypy pdf_chunker/`
- `bash scripts/validate_chunks.sh`
- `pytest tests/splitter_transform_test.py::test_splitter_size_and_overlap -q`
- `pytest tests/semantic_chunking_test.py::test_limits_and_metrics -q`
- `pytest tests/semantic_chunking_test.py::test_parameter_propagation -q`
- `pytest tests/split_semantic_pass_test.py::test_enforces_limits_and_structure -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1decd08508325a7376159f1789015