### PR TITLE
preserve bullet list newlines as single tokens

### DIFF
--- a/pdf_chunker/splitter.py
+++ b/pdf_chunker/splitter.py
@@ -1,7 +1,7 @@
 import logging
 from collections import Counter
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Match, Optional, Tuple
 
 from .text_cleaning import _is_probable_heading
 from .list_detection import starts_with_bullet
@@ -234,8 +234,8 @@ def _rebalance_bullet_chunks(chunks: List[str]) -> List[str]:
             tlen = len(tail)
             i = tlen
             while i <= len(combined) - tlen:
-                if combined[i:i + tlen] == tail:
-                    combined = combined[:i] + combined[i + tlen:]
+                if combined[i : i + tlen] == tail:
+                    combined = combined[:i] + combined[i + tlen :]
                     break
                 i += 1
             cleaned: List[str] = []
@@ -451,16 +451,44 @@ def _merge_short_chunks(
     return merged_chunks, merge_stats
 
 
+NEWLINE_TOKEN = "[[BR]]"
+_BULLET_AFTER_NEWLINE = re.compile(r"\n\s*([\-\*\u2022]\s+)")
+
+
+def _tokenize_with_newlines(text: str) -> List[str]:
+    """Return tokens while preserving explicit newline and list markers."""
+
+    def _join_newline_bullet(match: Match[str]) -> str:
+        return f" {NEWLINE_TOKEN}{match.group(1)}"
+
+    prepared = _BULLET_AFTER_NEWLINE.sub(_join_newline_bullet, text)
+    return prepared.replace("\n", f" {NEWLINE_TOKEN} ").split()
+
+
+def _detokenize_with_newlines(tokens: Iterable[str]) -> str:
+    """Rebuild text from tokens, restoring newline and list markers."""
+    joined = " ".join(tokens)
+    joined = re.sub(rf"{NEWLINE_TOKEN}([\-\*\u2022])", r"\n\1", joined)
+    joined = joined.replace(NEWLINE_TOKEN, "\n")
+    return re.sub(r"[ \t]*\n[ \t]*", "\n", joined)
+
+
 def _split_text_into_chunks(text: str, chunk_size: int, overlap: int) -> List[str]:
     """Return ``text`` split into word windows respecting ``overlap``."""
 
-    words = text.split()
-    if not words or chunk_size <= 0:
+    tokens = _tokenize_with_newlines(text)
+    if not tokens or chunk_size <= 0:
         return []
+    if len(tokens) <= chunk_size:
+        split_at = text.rfind("\n\n", 0, len(text) // 2)
+        if split_at == -1:
+            return [text.strip()]
+        head, tail = text[:split_at].strip(), text[split_at + 2 :].strip()
+        return [head, tail] if tail else [head]
     step = max(1, chunk_size - overlap + 1)
-    windows = (words[i:i + chunk_size] for i in range(0, len(words) - chunk_size + 1, step))
-    chunks = [" ".join(w) for w in windows]
-    return chunks or [" ".join(words)]
+    windows = (tokens[i : i + chunk_size] for i in range(0, len(tokens) - chunk_size + 1, step))
+    chunks = [_detokenize_with_newlines(w) for w in windows]
+    return chunks or [_detokenize_with_newlines(tokens)]
 
 
 def _fix_quote_splitting_issues(chunks: List[str]) -> List[str]:

--- a/scripts/validate_chunks.sh
+++ b/scripts/validate_chunks.sh
@@ -34,12 +34,27 @@ fi
 JSONL_FILE="${JSONL_FILE:-$DEFAULT_JSONL_FILE}"
 DOCUMENT_FILE="${DOCUMENT_FILE:-$DEFAULT_DOCUMENT_FILE}"
 
+ensure_haystack() {
+    python3 - <<'PY' >/dev/null 2>&1
+import importlib, sys
+try:
+    importlib.import_module("haystack")
+except ModuleNotFoundError:
+    sys.exit(1)
+PY
+    if [[ $? -ne 0 ]]; then
+        echo "Installing haystack dependencies..." >&2
+        python3 -m pip install --quiet haystack-ai==2.15.1 haystack-experimental==0.10.0
+    fi
+}
+
 # Ensure directory exists for the provided path
 mkdir -p "$(dirname "$JSONL_FILE")"
 
 generate_jsonl() {
     local src="$1"
     local dest="$2"
+    ensure_haystack
     PYTHONPATH=. python3 scripts/chunk_pdf.py "$src" > "$dest"
 }
 


### PR DESCRIPTION
## Summary
- ensure newline and bullet markers are tokenized together so list items stay on separate lines during splitting
- auto-install haystack dependencies when validating chunks to avoid missing-module errors

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: footer_artifact_test.py::test_bullet_footer_removed, footer_newline_regression_test.py::test_footer_newlines_joined, golden/test_conversion.py::test_conversion[pdf-b64_path0], hyphenation_test.py::test_clean_block_hyphen_fix[block1-responsibility], multiline_numbered_test.py::test_multiline_numbered_items, newline_cleanup_test.py::TestNewlineCleanup::test_merge_break_in_quoted_headline, newline_cleanup_test.py::TestNewlineCleanup::test_merge_break_in_quoted_title, numbered_list_chunk_test.py::test_numbered_list_not_split_across_chunks, numbered_list_test.py::test_numbered_list_preservation, parity/pipeline_parity_test.py::test_new_matches_legacy, parity/test_e2e_parity.py::test_e2e_parity_flags[base], parity/test_e2e_parity.py::test_e2e_parity_flags[--chunk-size 200], parity/test_e2e_parity.py::test_e2e_parity_flags[--overlap 10], parity/test_e2e_parity.py::test_e2e_parity_flags[--chunk-size 200 --overlap 10], pass_options_propagation_test.py::test_run_passes_respects_spec_options, property_based_text_test.py::test_clean_text_idempotent, property_based_text_test.py::test_split_roundtrip_cleaning, test_text_processing.py::TestWordGluingDetection::test_quote_boundary_gluing, text_cleaning_transform_test.py::test_clean_paragraph_strips_headers_and_footers`)
- `bash scripts/validate_chunks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b2184e25cc83259941dfef1835e86f