### PR TITLE
preserve bullet list newlines and handle short-page splits

### DIFF
--- a/scripts/validate_chunks.sh
+++ b/scripts/validate_chunks.sh
@@ -34,12 +34,27 @@ fi
 JSONL_FILE="${JSONL_FILE:-$DEFAULT_JSONL_FILE}"
 DOCUMENT_FILE="${DOCUMENT_FILE:-$DEFAULT_DOCUMENT_FILE}"
 
+ensure_haystack() {
+    python3 - <<'PY' >/dev/null 2>&1
+import importlib, sys
+try:
+    importlib.import_module("haystack")
+except ModuleNotFoundError:
+    sys.exit(1)
+PY
+    if [[ $? -ne 0 ]]; then
+        echo "Installing haystack dependencies..." >&2
+        python3 -m pip install --quiet haystack-ai==2.15.1 haystack-experimental==0.10.0
+    fi
+}
+
 # Ensure directory exists for the provided path
 mkdir -p "$(dirname "$JSONL_FILE")"
 
 generate_jsonl() {
     local src="$1"
     local dest="$2"
+    ensure_haystack
     PYTHONPATH=. python3 scripts/chunk_pdf.py "$src" > "$dest"
 }
 


### PR DESCRIPTION
## Summary
- guard against collapsing real list items by refining stray-bullet cleanup
- run header/footer stripping before pipe replacement and introduce functional bullet cleanup pipeline
- split short texts at a nearby paragraph or newline to avoid page collapse

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: footer_artifact_test.py::test_footer_and_subfooter_removed and others)*
- `bash scripts/validate_chunks.sh` *(fails: Validation FAILED - anomalies detected in output_chunks_pdf.jsonl)*

------
https://chatgpt.com/codex/tasks/task_e_68b2184e25cc83259941dfef1835e86f