### PR TITLE
Recalculate split_semantic min chunk size when spec overrides chunk_size

### DIFF
--- a/pdf_chunker/adapters/emit_jsonl.py
+++ b/pdf_chunker/adapters/emit_jsonl.py
@@ -13,12 +13,9 @@ def _rows(payload: Any) -> Iterable[dict[str, Any]]:
     return payload if isinstance(payload, list) else []
 
 
-def _sanitize_meta(meta: dict[str, Any]) -> dict[str, Any]:
-    """Copy metadata and repair empty ``utterance_type`` entries."""
-    sanitized = meta.copy()
-    if isinstance(sanitized.get("utterance_type"), dict) and not sanitized["utterance_type"]:
-        sanitized["utterance_type"] = {"classification": "error", "tags": []}
-    return sanitized
+def _copy_meta(meta: dict[str, Any]) -> dict[str, Any]:
+    """Return a shallow metadata copy without mutating ``meta``."""
+    return {k: v for k, v in meta.items()}
 
 
 def _maybe_drop_meta(rows: Iterable[dict[str, Any]], drop: bool) -> Iterable[dict[str, Any]]:
@@ -31,7 +28,7 @@ def _maybe_drop_meta(rows: Iterable[dict[str, Any]], drop: bool) -> Iterable[dic
             key: value
             for key, value in [
                 ("text", text),
-                ("meta", _sanitize_meta(meta) if meta else None),
+                ("meta", _copy_meta(meta) if meta else None),
             ]
             if key == "text" or (not drop and meta)
         }

--- a/tests/parity/EXCEPTIONS.md
+++ b/tests/parity/EXCEPTIONS.md
@@ -23,12 +23,12 @@ Current candidates:
   `tiny_b.pdf` – stray newline removed during normalization; accept the
   sanitized output.
 - `pipeline_parity_test.test_new_matches_legacy` on `tiny.pdf` – new
-  pipeline emits `meta` and `utterance_type` fields absent in legacy;
-  accept the enriched metadata.
+  pipeline emits a `meta` field absent in legacy; accept the enriched
+  metadata.
 - `pipeline_parity_test.test_new_matches_legacy` on `tiny_a.pdf` – new
-  pipeline emits `meta` and `utterance_type` fields absent in legacy;
-  accept the enriched metadata.
+  pipeline emits a `meta` field absent in legacy; accept the enriched
+  metadata.
 - `pipeline_parity_test.test_new_matches_legacy` on `tiny_b.pdf` – new
-  pipeline emits `meta` and `utterance_type` fields absent in legacy;
-  accept the enriched metadata.
+  pipeline emits a `meta` field absent in legacy; accept the enriched
+  metadata.
 ```


### PR DESCRIPTION
## Summary
- ensure dataclass passes recompute `min_chunk_size` when `chunk_size` is overridden
- derive minimal chunk size functionally in `split_semantic` and reset during pass configuration
- remove default `utterance_type` injection during JSONL emission

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `pytest tests/parity/test_e2e_parity.py::test_e2e_parity_flags[base] -q`
- `pytest tests/splitter_transform_test.py::test_splitter_size_and_overlap -q` *(fails: assert [11, 9] == [10, 10])*

------
https://chatgpt.com/codex/tasks/task_e_68b35ec44ee083259a1ae5a84ce717d0