### PR TITLE
Recalculate split_semantic min chunk size and stabilize short-text splitting

### DIFF
--- a/pdf_chunker/adapters/emit_jsonl.py
+++ b/pdf_chunker/adapters/emit_jsonl.py
@@ -13,12 +13,9 @@ def _rows(payload: Any) -> Iterable[dict[str, Any]]:
     return payload if isinstance(payload, list) else []
 
 
-def _sanitize_meta(meta: dict[str, Any]) -> dict[str, Any]:
-    """Copy metadata and repair empty ``utterance_type`` entries."""
-    sanitized = meta.copy()
-    if isinstance(sanitized.get("utterance_type"), dict) and not sanitized["utterance_type"]:
-        sanitized["utterance_type"] = {"classification": "error", "tags": []}
-    return sanitized
+def _copy_meta(meta: dict[str, Any]) -> dict[str, Any]:
+    """Return a shallow metadata copy without mutating ``meta``."""
+    return {k: v for k, v in meta.items()}
 
 
 def _maybe_drop_meta(rows: Iterable[dict[str, Any]], drop: bool) -> Iterable[dict[str, Any]]:
@@ -31,7 +28,7 @@ def _maybe_drop_meta(rows: Iterable[dict[str, Any]], drop: bool) -> Iterable[dic
             key: value
             for key, value in [
                 ("text", text),
-                ("meta", _sanitize_meta(meta) if meta else None),
+                ("meta", _copy_meta(meta) if meta else None),
             ]
             if key == "text" or (not drop and meta)
         }

--- a/pdf_chunker/splitter.py
+++ b/pdf_chunker/splitter.py
@@ -493,9 +493,9 @@ def _split_text_into_chunks(text: str, chunk_size: int, overlap: int) -> List[st
     tokens = _tokenize_with_newlines(text)
     if not tokens or chunk_size <= 0:
         return []
-    if len(tokens) <= chunk_size * 2:
-        return _split_short_text(text)
-    step = max(1, chunk_size - overlap + 1)
+    if len(tokens) <= chunk_size:
+        return [_detokenize_with_newlines(tokens)]
+    step = max(1, chunk_size - overlap)
     windows = (
         tokens[i : i + chunk_size]
         for i in range(0, len(tokens) - chunk_size + 1, step)

--- a/tests/parity/EXCEPTIONS.md
+++ b/tests/parity/EXCEPTIONS.md
@@ -23,12 +23,12 @@ Current candidates:
   `tiny_b.pdf` – stray newline removed during normalization; accept the
   sanitized output.
 - `pipeline_parity_test.test_new_matches_legacy` on `tiny.pdf` – new
-  pipeline emits `meta` and `utterance_type` fields absent in legacy;
-  accept the enriched metadata.
+  pipeline emits a `meta` field absent in legacy; accept the enriched
+  metadata.
 - `pipeline_parity_test.test_new_matches_legacy` on `tiny_a.pdf` – new
-  pipeline emits `meta` and `utterance_type` fields absent in legacy;
-  accept the enriched metadata.
+  pipeline emits a `meta` field absent in legacy; accept the enriched
+  metadata.
 - `pipeline_parity_test.test_new_matches_legacy` on `tiny_b.pdf` – new
-  pipeline emits `meta` and `utterance_type` fields absent in legacy;
-  accept the enriched metadata.
+  pipeline emits a `meta` field absent in legacy; accept the enriched
+  metadata.
 ```

--- a/tests/splitter_transform_test.py
+++ b/tests/splitter_transform_test.py
@@ -11,4 +11,4 @@ def test_splitter_size_and_overlap():
     text = " ".join(f"w{i}" for i in range(20))
     chunks = _split_text_into_chunks(text, chunk_size=10, overlap=2)
     assert [len(c.split()) for c in chunks] == [10, 10]
-    assert chunks[1].split()[0] == "w9"
+    assert chunks[1].split()[0] == "w8"


### PR DESCRIPTION
## Summary
- ensure dataclass passes recompute `min_chunk_size` when `chunk_size` is overridden
- derive minimal chunk size functionally in `split_semantic` and reset during pass configuration
- remove default `utterance_type` injection during JSONL emission
- prevent over-splitting of short passages and compute correct overlap step in text splitter

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `pytest tests/heading_merge_rule_test.py::test_heading_followed_by_paragraph -q`
- `pytest tests/splitter_transform_test.py::test_splitter_size_and_overlap -q`
- `pytest tests/metadata_propagation_test.py::test_metadata_propagation -q`
- `pytest tests/golden/test_conversion.py::test_conversion[pdf-b64_path0] -q` *(missing file_regression fixture)*
- `pytest tests/golden/test_conversion_epub_cli.py::test_conversion_epub_cli -q` *(fails: assert actual == expected)*
- `nox -s tests` *(fails: see tail for failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b35ec44ee083259a1ae5a84ce717d0