### PR TITLE
Ensure emit_jsonl truncates oversized rows

### DIFF
--- a/pdf_chunker/passes/emit_jsonl.py
+++ b/pdf_chunker/passes/emit_jsonl.py
@@ -5,6 +5,7 @@ import re
 from typing import Any
 
 from pdf_chunker.framework import Artifact, register
+from pdf_chunker.utils import _truncate_chunk
 
 Row = dict[str, Any]
 Doc = dict[str, Any]
@@ -24,7 +25,8 @@ def _compat_chunk_id(chunk_id: str) -> str:
 
 def _row(item: dict[str, Any]) -> Row:
     meta_key = _metadata_key()
-    base = {"text": item.get("text", "")}
+    text = _truncate_chunk(item.get("text", ""))
+    base = {"text": text}
     meta = item.get("meta")
     if not meta:
         return base

--- a/tests/emit_jsonl_truncation_test.py
+++ b/tests/emit_jsonl_truncation_test.py
@@ -1,0 +1,9 @@
+from pdf_chunker.framework import Artifact
+from pdf_chunker.passes.emit_jsonl import emit_jsonl
+
+
+def test_emit_jsonl_truncates_oversized_text():
+    long_text = "a" * 9000
+    artifact = Artifact(payload={"type": "chunks", "items": [{"text": long_text}]})
+    rows = emit_jsonl(artifact).payload
+    assert len(rows[0]["text"]) <= 8000


### PR DESCRIPTION
## Summary
- prevent oversized text entries by truncating rows in `emit_jsonl`
- add regression test covering JSONL truncation

## Testing
- `pytest tests/emit_jsonl_truncation_test.py -q`
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: Command pytest -q tests failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b643e3315c8325af27f517e1885d2b