### PR TITLE
Clamp JSONL rows under line limit

### DIFF
--- a/pdf_chunker/passes/emit_jsonl.py
+++ b/pdf_chunker/passes/emit_jsonl.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import os
 import re
-from typing import Any
+import json
+from typing import Any, Iterable
 
 from pdf_chunker.framework import Artifact, register
+from pdf_chunker.utils import _truncate_chunk
 
 Row = dict[str, Any]
 Doc = dict[str, Any]
@@ -22,19 +24,53 @@ def _compat_chunk_id(chunk_id: str) -> str:
     return f"{chunk_id[: match.start(1)]}{page}{chunk_id[match.end(1):]}"
 
 
-def _row(item: dict[str, Any]) -> Row:
+def _max_chars() -> int:
+    return int(os.getenv("PDF_CHUNKER_JSONL_MAX_CHARS", "8000"))
+
+
+def _split(text: str, limit: int) -> list[str]:
+    def parts(t: str) -> Iterable[str]:
+        while t:
+            chunk = _truncate_chunk(t, limit)
+            yield chunk
+            t = t[len(chunk) :].lstrip()
+
+    return list(parts(text))
+
+
+def _rows_from_item(item: dict[str, Any]) -> list[Row]:
     meta_key = _metadata_key()
-    base = {"text": item.get("text", "")}
+    max_chars = _max_chars()
     meta = item.get("meta")
-    if not meta:
-        return base
-    chunk_id = meta.get("chunk_id")
-    meta = {**meta, **({"chunk_id": _compat_chunk_id(chunk_id)} if chunk_id else {})}
-    return base | {meta_key: meta}
+    chunk_id = meta.get("chunk_id") if meta else None
+    if chunk_id:
+        meta = {**meta, "chunk_id": _compat_chunk_id(chunk_id)}
+    base_meta = {meta_key: meta} if meta else {}
+    overhead = len(json.dumps({"text": "", **base_meta}, ensure_ascii=False)) - 2
+    avail = max(max_chars - overhead, 0)
+    pieces = _split(item.get("text", ""), avail)
+
+    def build(idx_piece: tuple[int, str]) -> Row:
+        idx, piece = idx_piece
+        meta_part = (
+            {meta_key: {**meta, "chunk_part": idx}}
+            if meta and len(pieces) > 1
+            else base_meta
+        )
+        row = {"text": piece, **meta_part}
+        while len(json.dumps(row, ensure_ascii=False)) > max_chars:
+            allowed = avail - (
+                len(json.dumps(row, ensure_ascii=False)) - max_chars
+            )
+            piece = _truncate_chunk(piece[:allowed], allowed)
+            row = {"text": piece, **meta_part}
+        return row
+
+    return [build(x) for x in enumerate(pieces)]
 
 
 def _rows(doc: Doc) -> list[Row]:
-    return [_row(i) for i in doc.get("items", []) if i.get("text")]
+    return [r for i in doc.get("items", []) if i.get("text") for r in _rows_from_item(i)]
 
 
 def _update_meta(meta: dict[str, Any] | None, count: int) -> dict[str, Any]:

--- a/tests/emit_jsonl_truncation_test.py
+++ b/tests/emit_jsonl_truncation_test.py
@@ -1,0 +1,13 @@
+import json
+
+from pdf_chunker.framework import Artifact
+from pdf_chunker.passes.emit_jsonl import emit_jsonl
+
+
+def test_emit_jsonl_splits_and_clamps_rows():
+    long_text = "a" * 9000
+    artifact = Artifact(payload={"type": "chunks", "items": [{"text": long_text}]})
+    rows = emit_jsonl(artifact).payload
+    assert len(rows) > 1
+    assert "".join(r["text"] for r in rows) == long_text
+    assert all(len(json.dumps(r, ensure_ascii=False)) <= 8000 for r in rows)


### PR DESCRIPTION
## Summary
- split oversized chunk text into multiple rows and carry over chunk metadata
- ensure JSONL serialization stays within configurable `PDF_CHUNKER_JSONL_MAX_CHARS`
- test that rows are split and clamped below the 8k line length

## Testing
- `pytest tests/emit_jsonl_truncation_test.py -q`
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: Command pytest -q tests failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b643e3315c8325af27f517e1885d2b