### PR TITLE
fix: avoid heading-only JSONL rows

### DIFF
--- a/tests/emit_jsonl_semantics_test.py
+++ b/tests/emit_jsonl_semantics_test.py
@@ -1,0 +1,29 @@
+from pdf_chunker.framework import Artifact
+from pdf_chunker.passes.emit_jsonl import emit_jsonl
+
+
+def test_emit_jsonl_merges_heading_with_text():
+    doc = {
+        "type": "chunks",
+        "items": [
+            {"text": "Chapter 1"},
+            {"text": "This paragraph has enough words to be valid."},
+        ],
+    }
+    rows = emit_jsonl(Artifact(payload=doc)).payload
+    assert len(rows) == 1
+    assert rows[0]["text"].startswith("Chapter 1\n\nThis paragraph has enough words")
+
+
+def test_emit_jsonl_merges_incomplete_sentences():
+    doc = {
+        "type": "chunks",
+        "items": [
+            {"text": "This is the beginning of a sentence that lacks an ending"},
+            {"text": "and adds more context to meet length rules."},
+        ],
+    }
+    rows = emit_jsonl(Artifact(payload=doc)).payload
+    assert len(rows) == 1
+    assert rows[0]["text"].startswith("This is the beginning of a sentence")
+    assert rows[0]["text"].endswith("rules.")


### PR DESCRIPTION
## Summary
- coalesce short or partial chunk items into full sentences before emitting JSONL rows
- cover heading-only and truncated sentence scenarios in JSONL emission

## Testing
- `black pdf_chunker/passes/emit_jsonl.py tests/emit_jsonl_semantics_test.py`
- `flake8 pdf_chunker/passes/emit_jsonl.py tests/emit_jsonl_semantics_test.py`
- `mypy pdf_chunker/passes/emit_jsonl.py`
- `black pdf_chunker/ scripts/ tests/ --check` *(fails: would reformat pdf_chunker/cli.py and 6 more)*
- `flake8 pdf_chunker/ scripts/ tests/ | head -n 20` *(fails: E501, F811, etc.)*
- `mypy pdf_chunker/ | head -n 20` *(fails: _warn_unknown_options already defined, union-attr)*
- `bash scripts/validate_chunks.sh output_chunks.json`
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: multiple assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b64c724dc083259db9724534275f34