### PR TITLE
Skip early doc-end markers in truncation logic

### DIFF
--- a/pdf_chunker/passes/detect_doc_end.py
+++ b/pdf_chunker/passes/detect_doc_end.py
@@ -36,19 +36,18 @@ def _is_doc_end_page(blocks: Iterable[Block]) -> bool:
     return bool(DOC_END_RE.fullmatch(_page_text(blocks)))
 
 
-def _should_truncate(total: int, truncated: int) -> bool:
-    return truncated > 0 and (truncated <= 2 or truncated / total <= 0.1)
-
-
 def _truncate_pages(pages: List[Page]) -> Tuple[List[Page], int]:
     total = len(pages)
-    for idx, page in enumerate(pages):
-        if _is_doc_end_page(page.get("blocks", [])):
-            truncated = total - idx - 1
-            if _should_truncate(total, truncated):
-                return pages[: idx + 1], truncated
-            return pages, 0
-    return pages, 0
+    idx = next(
+        (
+            i
+            for i, page in enumerate(pages)
+            if _is_doc_end_page(page.get("blocks", []))
+            and 0 < total - i - 1 <= 2
+        ),
+        None,
+    )
+    return (pages[: idx + 1], total - idx - 1) if idx is not None else (pages, 0)
 
 
 class _DetectDocEndPass:

--- a/tests/test_doc_end_detection.py
+++ b/tests/test_doc_end_detection.py
@@ -60,3 +60,27 @@ def test_skips_truncation_when_removing_too_much():
     assert len(out.payload["pages"]) == 5
     assert out.meta["metrics"]["detect_doc_end"]["truncated_pages"] == 0
 
+
+def test_skips_truncation_when_tail_exceeds_two_pages():
+    pages = [_page([f"p{i}"]) for i in range(36)] + [_page(["THE END"])] + [
+        _page([f"x{i}"]) for i in range(3)
+    ]
+    doc = {"type": "page_blocks", "pages": pages}
+    out = run_step("detect_doc_end", Artifact(doc))
+    assert len(out.payload["pages"]) == 40
+    assert out.meta["metrics"]["detect_doc_end"]["truncated_pages"] == 0
+
+
+def test_ignores_early_end_marker_but_truncates_at_late_one():
+    pages = [
+        _page(["Intro"]),
+        _page(["THE END"]),  # early false positive
+        _page(["p1"]),
+        _page(["THE END"]),
+        _page(["extra"]),
+    ]
+    doc = {"type": "page_blocks", "pages": pages}
+    out = run_step("detect_doc_end", Artifact(doc))
+    assert len(out.payload["pages"]) == 4
+    assert out.meta["metrics"]["detect_doc_end"]["truncated_pages"] == 1
+


### PR DESCRIPTION
## Summary
- use generator expression to find the last acceptable doc-end marker, ignoring early matches with large tails
- exercise early vs late doc-end markers in regression tests

## Testing
- `pytest tests/test_doc_end_detection.py::test_ignores_early_end_marker_but_truncates_at_late_one -q`
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: tests/epub_cli_regression_test.py::test_cli_epub_matches_golden, tests/footer_newline_regression_test.py::test_footer_newlines_joined, tests/golden/test_conversion.py::test_conversion[pdf-b64_path0], tests/golden/test_conversion_epub_cli.py::test_conversion_epub_cli, tests/metadata_propagation_test.py::test_metadata_propagation, tests/multiline_bullet_test.py::test_multiline_bullet_items, tests/newline_cleanup_test.py::TestNewlineCleanup::test_merge_break_in_quoted_title, tests/page_artifact_detection_test.py::TestPageArtifactDetection::test_markdown_table_header_normalization, tests/page_artifact_detection_test.py::TestPageArtifactDetection::test_pymupdf4llm_block_normalization, tests/parity/test_e2e_parity.py::test_emit_jsonl_omits_meta_when_absent, tests/property_based_text_test.py::test_split_text_preserves_non_whitespace, tests/property_based_text_test.py::test_split_roundtrip_cleaning, tests/scripts_cli_test.py::test_convert_cli_writes_jsonl, tests/scripts_cli_test.py::test_cli_chunk_size_overlap_flags)`

------
https://chatgpt.com/codex/tasks/task_e_68b7347224f483259a74445f60023603