### PR TITLE
Skip early doc-end markers in truncation logic

### DIFF
--- a/tests/test_doc_end_detection.py
+++ b/tests/test_doc_end_detection.py
@@ -60,3 +60,27 @@ def test_skips_truncation_when_removing_too_much():
     assert len(out.payload["pages"]) == 5
     assert out.meta["metrics"]["detect_doc_end"]["truncated_pages"] == 0
 
+
+def test_skips_truncation_when_tail_exceeds_two_pages():
+    pages = [_page([f"p{i}"]) for i in range(36)] + [_page(["THE END"])] + [
+        _page([f"x{i}"]) for i in range(3)
+    ]
+    doc = {"type": "page_blocks", "pages": pages}
+    out = run_step("detect_doc_end", Artifact(doc))
+    assert len(out.payload["pages"]) == 40
+    assert out.meta["metrics"]["detect_doc_end"]["truncated_pages"] == 0
+
+
+def test_ignores_early_end_marker_but_truncates_at_late_one():
+    pages = [
+        _page(["Intro"]),
+        _page(["THE END"]),  # early false positive
+        _page(["p1"]),
+        _page(["THE END"]),
+        _page(["extra"]),
+    ]
+    doc = {"type": "page_blocks", "pages": pages}
+    out = run_step("detect_doc_end", Artifact(doc))
+    assert len(out.payload["pages"]) == 4
+    assert out.meta["metrics"]["detect_doc_end"]["truncated_pages"] == 1
+


### PR DESCRIPTION
## Summary
- restrict doc-end detection to last pages only
- ignore table-of-contents entries by requiring a solitary end marker

## Testing
- `pytest tests/test_doc_end_detection.py::test_ignores_early_end_marker_but_truncates_at_late_one -q` *(fails: pytest: No such file or directory)*
- `nox -s lint` *(fails: nox: No such file or directory)*
- `nox -s typecheck` *(fails: nox: No such file or directory)*
- `nox -s tests` *(fails: nox: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b7347224f483259a74445f60023603