### PR TITLE
Skip early doc-end markers and retain suspect chunks

### DIFF
--- a/tests/test_chunk_integrity.py
+++ b/tests/test_chunk_integrity.py
@@ -1,0 +1,13 @@
+import logging
+
+from pdf_chunker import splitter
+
+
+def test_corrupted_chunk_retained(caplog):
+    chunk = ", fragment with leading comma and sufficient length to avoid removal"
+    original = chunk
+    with caplog.at_level(logging.ERROR):
+        out = splitter._validate_chunk_integrity([chunk], original)
+    assert len(out) == 1
+    assert "fragment with leading comma" in out[0]
+    assert any("appears corrupted" in rec.message for rec in caplog.records)

--- a/tests/test_doc_end_detection.py
+++ b/tests/test_doc_end_detection.py
@@ -60,3 +60,27 @@ def test_skips_truncation_when_removing_too_much():
     assert len(out.payload["pages"]) == 5
     assert out.meta["metrics"]["detect_doc_end"]["truncated_pages"] == 0
 
+
+def test_skips_truncation_when_tail_exceeds_two_pages():
+    pages = [_page([f"p{i}"]) for i in range(36)] + [_page(["THE END"])] + [
+        _page([f"x{i}"]) for i in range(3)
+    ]
+    doc = {"type": "page_blocks", "pages": pages}
+    out = run_step("detect_doc_end", Artifact(doc))
+    assert len(out.payload["pages"]) == 40
+    assert out.meta["metrics"]["detect_doc_end"]["truncated_pages"] == 0
+
+
+def test_ignores_early_end_marker_but_truncates_at_late_one():
+    pages = [
+        _page(["Intro"]),
+        _page(["THE END"]),  # early false positive
+        _page(["p1"]),
+        _page(["THE END"]),
+        _page(["extra"]),
+    ]
+    doc = {"type": "page_blocks", "pages": pages}
+    out = run_step("detect_doc_end", Artifact(doc))
+    assert len(out.payload["pages"]) == 4
+    assert out.meta["metrics"]["detect_doc_end"]["truncated_pages"] == 1
+


### PR DESCRIPTION
## Summary
- restrict doc-end detection to last pages only
- ignore table-of-contents entries by requiring a solitary end marker
- log and retain chunks flagged as corrupted instead of dropping them
- add regression test ensuring suspicious chunks remain

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: tests/epub_cli_regression_test.py::test_cli_epub_matches_golden, tests/footer_newline_regression_test.py::test_footer_newlines_joined, tests/golden/test_conversion.py::test_conversion[pdf-b64_path0], tests/golden/test_conversion_epub_cli.py::test_conversion_epub_cli, tests/metadata_propagation_test.py::test_metadata_propagation, tests/multiline_bullet_test.py::test_multiline_bullet_items, tests/newline_cleanup_test.py::TestNewlineCleanup::test_merge_break_in_quoted_title, tests/page_artifact_detection_test.py::TestPageArtifactDetection::test_markdown_table_header_normalization, tests/page_artifact_detection_test.py::TestPageArtifactDetection::test_pymupdf4llm_block_normalization, tests/parity/test_e2e_parity.py::test_emit_jsonl_omits_meta_when_absent, tests/property_based_text_test.py::test_split_text_preserves_non_whitespace, tests/property_based_text_test.py::test_split_roundtrip_cleaning, tests/scripts_cli_test.py::test_convert_cli_writes_jsonl, tests/scripts_cli_test.py::test_cli_chunk_size_overlap_flags)*

------
https://chatgpt.com/codex/tasks/task_e_68b7347224f483259a74445f60023603