### PR TITLE
fix(pdf): restore full page extraction & guard against truncation

### DIFF
--- a/pdf_chunker/adapters/io_pdf.py
+++ b/pdf_chunker/adapters/io_pdf.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from subprocess import CompletedProcess, run
 from typing import Any
 
+import fitz  # PyMuPDF
+
 from pdf_chunker.page_utils import parse_page_ranges
 
 
@@ -108,6 +110,29 @@ def _fallback_blocks(
     )
 
 
+def _page_numbers(path: str) -> range:
+    """Enumerate all PDF page numbers using PyMuPDF."""
+
+    with fitz.open(path) as doc:
+        return range(1, doc.page_count + 1)
+
+
+def _ensure_all_pages(
+    path: str, pages: list[dict[str, Any]], excluded: set[int]
+) -> list[dict[str, Any]]:
+    """Append empty entries for missing pages."""
+
+    existing = {p["page"]: p["blocks"] for p in pages}
+    return [
+        {
+            "page": p,
+            "blocks": existing.get(p, []),
+        }
+        for p in _page_numbers(path)
+        if p not in excluded
+    ]
+
+
 def read(
     path: str,
     exclude_pages: Sequence[int] | str | None = None,
@@ -124,7 +149,8 @@ def read(
     if not blocks:
         blocks = _fallback_blocks(abs_path, sorted(excluded))
     filtered = [b for b in blocks if b.get("source", {}).get("page") not in excluded]
-    pages = [p for p in _group_blocks(filtered) if p["page"] not in excluded]
+    grouped = _group_blocks(filtered)
+    pages = _ensure_all_pages(abs_path, grouped, excluded)
     return {"type": "page_blocks", "source_path": abs_path, "pages": pages}
 
 

--- a/tests/parity/test_page_count_regression.py
+++ b/tests/parity/test_page_count_regression.py
@@ -1,0 +1,47 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+try:  # pragma: no cover - skip if dependency missing
+    from pypdf import PdfReader
+except Exception:  # pragma: no cover
+    PdfReader = None  # type: ignore
+
+ROOT = Path(__file__).resolve().parents[2]
+PDF = ROOT / "platform-eng-excerpt.pdf"
+SENTINEL = "Alignment and trust are challenging"
+
+
+def test_page_count_regression(tmp_path: Path) -> None:
+    out = tmp_path / "platform-eng.jsonl"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pdf_chunker.cli",
+            "convert",
+            str(PDF),
+            "--chunk-size",
+            "1000",
+            "--overlap",
+            "0",
+            "--out",
+            str(out),
+            "--no-enrich",
+        ],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(ROOT)},
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    report = json.loads((tmp_path / "run_report.json").read_text())
+    page_count = report["metrics"]["page_count"]
+    pytest.importorskip("pypdf")
+    truth = len(PdfReader(str(PDF)).pages)
+    assert truth == page_count
+    assert SENTINEL in out.read_text()


### PR DESCRIPTION
## Summary
- ensure PDF adapter enumerates all pages and fills gaps with empty block entries
- add regression test guarding page count and sentinel phrase extraction

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: epub_cli_regression_test, footer_newline_regression_test, golden tests, and others)*
- `bash scripts/validate_chunks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bc92f1e66483259538b4b4a31efc04