### PR TITLE
Prevent mid-sentence JSONL tail fragments

### DIFF
--- a/tests/emit_jsonl_semantics_test.py
+++ b/tests/emit_jsonl_semantics_test.py
@@ -27,3 +27,17 @@ def test_emit_jsonl_merges_incomplete_sentences():
     assert len(rows) == 1
     assert rows[0]["text"].startswith("This is the beginning of a sentence")
     assert rows[0]["text"].endswith("rules.")
+
+
+def test_emit_jsonl_merges_tail_fragment():
+    doc = {
+        "type": "chunks",
+        "items": [
+            {"text": "All prior context resolves a sentence."},
+            {"text": "continues the thought and ends properly."},
+        ],
+    }
+    rows = emit_jsonl(Artifact(payload=doc)).payload
+    assert len(rows) == 1
+    assert rows[0]["text"].startswith("All prior context")
+    assert rows[0]["text"].endswith("ends properly.")


### PR DESCRIPTION
## Summary
- ensure emit_jsonl merges trailing fragments and validates row coherence
- add regression test for tail fragment merging

## Testing
- `flake8 tests/emit_jsonl_semantics_test.py pdf_chunker/passes/emit_jsonl.py`
- `mypy --follow-imports=skip pdf_chunker/passes/emit_jsonl.py`
- `python -m nox -s lint`
- `python -m nox -s typecheck`
- `python -m nox -s tests` *(fails: metadata_propagation_test etc.)*
- `bash scripts/validate_chunks.sh`
- `pytest tests/emit_jsonl_semantics_test.py::test_emit_jsonl_merges_tail_fragment -q`


------
https://chatgpt.com/codex/tasks/task_e_68be2f70da7c83258ab1604d559e6362