### PR TITLE
Fix numbered list newline handling

### DIFF
--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -130,7 +130,7 @@ NUMBERED_INLINE_CANDIDATE_RE = re.compile(
     r"(\d{1,3}[.)](?:[^\n]|\n(?!\n|\d))*?)\s+(?=(\d{1,3}[.)]))"
 )
 NUMBERED_END_RE = re.compile(
-    rf"(\d{{1,3}}[.)][^\n]+?)"
+    rf"(\d{{1,3}}[.)][^\n]*[{re.escape(END_PUNCT)}])"
     rf"(?<![{re.escape(END_PUNCT)}]\")"
     rf"(?=\s+(?:[{BULLET_CHARS_ESC}]|[A-Z][a-z]+\b(?!\s+\d)|$))"
 )
@@ -350,9 +350,12 @@ def _apply_inline_numbered(text: str) -> str:
 
 def insert_numbered_list_newlines(text: str) -> str:
     """Insert newlines around numbered list items and terminate the list with a paragraph break."""
-    text = NUMBERED_AFTER_COLON_RE.sub(r":\n\1", text)
-    text = _apply_inline_numbered(text)
-    return NUMBERED_END_RE.sub(r"\1\n\n", text)
+    return pipe(
+        text,
+        lambda t: NUMBERED_AFTER_COLON_RE.sub(r":\n\1", t),
+        _apply_inline_numbered,
+        lambda t: NUMBERED_END_RE.sub(r"\1\n\n", t),
+    )
 
 
 def _preserve_list_newlines(text: str) -> str:

--- a/tests/numbered_list_test.py
+++ b/tests/numbered_list_test.py
@@ -94,3 +94,14 @@ def test_lowercase_chapter_followed_by_next_number() -> None:
     cleaned = collapse_single_newlines(cleaned)
     assert "chapter. 3." not in cleaned
     assert "chapter.\n3." in cleaned
+
+
+def test_multiline_numbered_item_continuation() -> None:
+    text = (
+        "2. The shortage, combined with people cobbling together their own\n"
+        "Terraform all over the company, often led leadership to centralize the work across multiple teams"
+    )
+    cleaned = insert_numbered_list_newlines(text)
+    cleaned = collapse_single_newlines(cleaned)
+    assert "own\n\nTerraform" not in cleaned
+    assert "own Terraform" in cleaned


### PR DESCRIPTION
## Summary
- tighten numbered list boundary detection to avoid inserting double newlines within items
- refactor numbered list cleanup to use functional pipeline and add regression test for multiline items

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `pytest tests/numbered_list_test.py::test_abbreviation_inside_numbered_item tests/numbered_list_test.py::test_multiline_numbered_item_continuation -q`
- `bash scripts/validate_chunks.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bf1cd193688325bb9ad46ee8faadd3