### PR TITLE
Fix hyphenated join to preserve compounds and letters

### DIFF
--- a/tests/hyphenation_test.py
+++ b/tests/hyphenation_test.py
@@ -15,7 +15,14 @@ def test_hyphenation_fix_with_pymupdf4llm(force_pymupdf4llm):
     sample = "a con-\n tainer and special-\n ists in man-\n agement"
     cleaned = clean_text(sample)
     assert all(word in cleaned for word in ("container", "specialists", "management"))
-    assert all(broken not in cleaned for broken in ("con- tainer", "special- ists", "man- agement"))
+    assert all(
+        broken not in cleaned
+        for broken in (
+            "con- tainer",
+            "special- ists",
+            "man- agement",
+        )
+    )
 
 
 @pytest.mark.parametrize(
@@ -50,3 +57,13 @@ def test_bullet_hyphen_continuation():
     cleaned = clean_text(text)
     assert "ambiguous" in cleaned
     assert cleaned.count("*") == 1
+
+
+def test_join_preserves_double_letters():
+    text = "bal-\n loon"
+    assert clean_text(text) == "balloon"
+
+
+def test_crossline_hyphen_preserved():
+    text = "business-\ncritical systems"
+    assert "business-critical systems" in clean_text(text)


### PR DESCRIPTION
## Summary
- improve hyphenated-word joining by choosing between hyphenated and unhyphenated forms via frequency
- cover double-letter merges and cross-line compounds with new tests
- guard numbered-suffix merging against missing markers to satisfy mypy

## Testing
- `black pdf_chunker/text_cleaning.py pdf_chunker/pdf_blocks.py tests/hyphenation_test.py`
- `flake8 tests/hyphenation_test.py`
- `mypy pdf_chunker/text_cleaning.py pdf_chunker/pdf_blocks.py`
- `mypy pdf_chunker/` *(fails: 49 errors in 16 files)*
- `pytest tests/hyphenation_test.py`
- `bash scripts/validate_chunks.sh`
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2cc793b883259596bf57f210f5bb