### PR TITLE
feat: add trace snapshot adapter

### DIFF
--- a/pdf_chunker/adapters/emit_trace.py
+++ b/pdf_chunker/adapters/emit_trace.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+_RUN_ID = uuid4().hex
+
+
+def _path(step: str) -> Path:
+    base = Path("artifacts") / "trace" / _RUN_ID
+    base.mkdir(parents=True, exist_ok=True)
+    return base / f"{step}.json"
+
+
+def write_snapshot(step: str, data: Any) -> None:
+    """Persist ``data`` for ``step`` under a unique run directory."""
+    _path(step).write_text(
+        json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
+    )

--- a/pdf_chunker/cli.py
+++ b/pdf_chunker/cli.py
@@ -64,6 +64,7 @@ def _run_convert(
     no_metadata: bool,
     spec: str,
     verbose: bool,
+    trace: str | None,
 ) -> None:
     _input_artifact, run_convert, _ = _core_helpers(enrich)
     s = load_spec(
@@ -78,7 +79,7 @@ def _run_convert(
         ),
     )
     s = _enrich_spec(s) if enrich else s
-    _, timings = run_convert(_input_artifact(str(input_path), s), s)
+    _, timings = run_convert(_input_artifact(str(input_path), s), s, trace=trace)
     if verbose:
         print(_format_timings(timings))
     print("convert: OK")
@@ -204,6 +205,7 @@ if typer:
         no_metadata: bool = typer.Option(False, "--no-metadata"),
         spec: str = typer.Option("pipeline.yaml", "--spec"),
         verbose: bool = typer.Option(False, "--verbose"),
+        trace: str | None = typer.Option(None, "--trace"),
     ) -> None:
         _safe(
             lambda: _run_convert(
@@ -216,6 +218,7 @@ if typer:
                 no_metadata,
                 spec,
                 verbose,
+                trace,
             )
         )
 
@@ -240,6 +243,7 @@ else:
         conv.add_argument("--no-metadata", action="store_true")
         conv.add_argument("--spec", default="pipeline.yaml")
         conv.add_argument("--verbose", action="store_true")
+        conv.add_argument("--trace")
         conv.set_defaults(
             enrich=False,
             func=lambda ns: _safe(
@@ -253,6 +257,7 @@ else:
                     ns.no_metadata,
                     ns.spec,
                     ns.verbose,
+                    ns.trace,
                 )
             ),
         )

--- a/tests/trace_snapshot_test.py
+++ b/tests/trace_snapshot_test.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pdf_chunker.config import PipelineSpec
+from pdf_chunker.core_new import run_convert
+from pdf_chunker.framework import Artifact
+
+
+def _doc(blocks: list[str]) -> dict:
+    return {
+        "type": "page_blocks",
+        "source_path": "src.pdf",
+        "pages": [{"page": 1, "blocks": [{"text": b} for b in blocks]}],
+    }
+
+
+def test_trace_snapshots(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    def fake_chunker(text: str, chunk_size: int, overlap: int, *, min_chunk_size: int):
+        return ["foo part", "rest"]
+
+    monkeypatch.setattr("pdf_chunker.splitter.semantic_chunker", fake_chunker)
+    art = Artifact(payload=_doc(["foo one", "two"]), meta={"input": "doc.pdf"})
+    spec = PipelineSpec(
+        pipeline=["text_clean", "split_semantic"],
+        options={"run_report": {"output_path": str(tmp_path / "r.json")}},
+    )
+    run_convert(art, spec, trace="foo")
+
+    trace_root = Path("artifacts/trace")
+    run_dir = next(trace_root.iterdir())
+    steps = {p.stem for p in run_dir.iterdir()}
+    assert steps == {"text_clean", "split_semantic"}
+
+    clean = json.loads((run_dir / "text_clean.json").read_text())
+    assert clean["pages"][0]["blocks"] == [{"text": "foo one"}]
+
+    chunks = json.loads((run_dir / "split_semantic.json").read_text())
+    assert chunks and all("foo" in c["text"] for c in chunks)


### PR DESCRIPTION
## Summary
- add `--trace` option to CLI and plumb through to pipeline
- capture per-pass snapshots when trace substring provided
- write filtered snapshots via new `emit_trace` adapter

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: missing golden artifacts and baseline assertions)*
- `pytest tests/trace_snapshot_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf947dc4b88325bae6bcbb670bb4db