### PR TITLE
feat: preserve numbered list tails

### DIFF
--- a/pdf_chunker/passes/emit_jsonl.py
+++ b/pdf_chunker/passes/emit_jsonl.py
@@ -57,6 +57,10 @@ def _coherent(text: str, min_chars: int = 40) -> bool:
     )
 
 
+def _is_numbered_line(text: str) -> bool:
+    return re.search(r"^\s*\d+[.)]\s", text, re.MULTILINE) is not None
+
+
 def _trim_overlap(prev: str, curr: str, max_len: int = 80) -> str:
     """Remove duplicated prefix from ``curr`` that already exists in ``prev``."""
 
@@ -110,8 +114,7 @@ def _coalesce(items: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
     merged: list[dict[str, Any]] = []
     for i in cleaned:
         merged = step(merged, i)
-
-    return [m for m in merged if _coherent(m["text"])]
+    return [m for m in merged if _coherent(m["text"]) or _is_numbered_line(m["text"]) ]
 
 
 def _rows_from_item(item: dict[str, Any]) -> list[Row]:

--- a/tests/emit_jsonl_semantics_test.py
+++ b/tests/emit_jsonl_semantics_test.py
@@ -104,3 +104,45 @@ def test_emit_jsonl_merges_short_items():
     rows = emit_jsonl(Artifact(payload=doc)).payload
     assert len(rows) == 1
     assert len(rows[0]["text"].split()) >= 50
+
+
+def test_emit_jsonl_retains_numbered_punctuated_item(monkeypatch):
+    monkeypatch.setenv("PDF_CHUNKER_JSONL_MIN_WORDS", "1")
+    doc = {
+        "type": "chunks",
+        "items": [
+            {
+                "text": (
+                    "1. First item has enough words to be considered coherent and ends."
+                )
+            },
+            {
+                "text": (
+                    "2. Second item has enough words to be coherent as well."
+                )
+            },
+        ],
+    }
+    rows = emit_jsonl(Artifact(payload=doc)).payload
+    assert rows[1]["text"].startswith("2. Second item")
+
+
+def test_emit_jsonl_retains_numbered_tail_without_punctuation(monkeypatch):
+    monkeypatch.setenv("PDF_CHUNKER_JSONL_MIN_WORDS", "1")
+    doc = {
+        "type": "chunks",
+        "items": [
+            {
+                "text": (
+                    "1. First item has enough words to be considered coherent and ends."
+                )
+            },
+            {
+                "text": (
+                    "2. Second item continues with sufficient words but lacks punctuation"
+                )
+            },
+        ],
+    }
+    rows = emit_jsonl(Artifact(payload=doc)).payload
+    assert rows[1]["text"].startswith("2. Second item continues")


### PR DESCRIPTION
## Summary
- ensure numbered list items without punctuation survive coalescing
- guard _coalesce against dropping final list numbers with new tests

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: assert [{'metadata':...t document.'}...] )*

------
https://chatgpt.com/codex/tasks/task_e_68bf99ac7c9483258b1641801f877884