### PR TITLE
refactor: annotate exclude_pages as str or none

### DIFF
--- a/pdf_chunker/fallbacks.py
+++ b/pdf_chunker/fallbacks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from subprocess import TimeoutExpired
-from typing import Callable, Iterable, Optional, Sequence, Tuple
+from typing import Callable, Iterable, Sequence, Tuple
 
 from .adapters.io_pdf import run_pdftotext
 from .language import default_language
@@ -61,7 +61,7 @@ def _text_to_blocks(text: str, filepath: str, method: str) -> list[dict]:
 
 
 def _extract_with_pdftotext(
-    filepath: str, exclude_pages: Optional[str] = None
+    filepath: str, exclude_pages: str | None = None
 ) -> list[dict]:
     try:
         excluded = parse_page_ranges(exclude_pages) if exclude_pages else set()
@@ -95,7 +95,7 @@ def _extract_with_pdftotext(
 
 
 def _extract_with_pdfminer(
-    filepath: str, exclude_pages: Optional[str] = None
+    filepath: str, exclude_pages: str | None = None
 ) -> list[dict]:
     if not PDFMINER_AVAILABLE:
         return []
@@ -114,8 +114,8 @@ def _extract_with_pdfminer(
 
 def execute_fallback_extraction(
     filepath: str,
-    exclude_pages: Optional[str] = None,
-    fallback_reason: Optional[str] = None,
+    exclude_pages: str | None = None,
+    fallback_reason: str | None = None,
 ) -> list[dict]:
     blocks = _extract_with_pdftotext(filepath, exclude_pages)
     if blocks:
@@ -137,7 +137,7 @@ def apply_fallbacks(
     if quality >= 0.7:
         return primary
 
-    candidates: Sequence[Tuple[str, Callable[[str, Optional[str]], list[dict]]]] = (
+    candidates: Sequence[Tuple[str, Callable[[str, str | None], list[dict]]]] = (
         ("pdftotext", _extract_with_pdftotext),
         ("pdfminer", _extract_with_pdfminer if PDFMINER_AVAILABLE else (lambda *_: [])),
     )

--- a/pdf_chunker/parsing.py
+++ b/pdf_chunker/parsing.py
@@ -11,22 +11,21 @@
 from collections.abc import Callable
 from dataclasses import asdict
 from pathlib import Path
-from typing import Optional
 
 from .epub_parsing import TextBlock, extract_text_blocks_from_epub
 from .pdf_parsing import extract_text_blocks_from_pdf
 
-Extractor = Callable[[Path, Optional[str]], list[TextBlock]]
+Extractor = Callable[[Path, str | None], list[TextBlock]]
 
 
-def _pdf_extractor(path: Path, exclude: Optional[str]) -> list[TextBlock]:
+def _pdf_extractor(path: Path, exclude: str | None) -> list[TextBlock]:
     return [
         asdict(b)
         for b in extract_text_blocks_from_pdf(str(path), exclude_pages=exclude)
     ]
 
 
-def _epub_extractor(path: Path, exclude: Optional[str]) -> list[TextBlock]:
+def _epub_extractor(path: Path, exclude: str | None) -> list[TextBlock]:
     return extract_text_blocks_from_epub(str(path), exclude_spines=exclude)
 
 
@@ -37,7 +36,7 @@ DISPATCH: dict[str, Extractor] = {
 
 
 def extract_structured_text(
-    path: Path | str, exclude_pages: Optional[str] = None
+    path: Path | str, exclude_pages: str | None = None
 ) -> list[TextBlock]:
     """Return text blocks from a PDF or EPUB file.
 

--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import logging
 from dataclasses import asdict
-from typing import Iterable, Optional
+from typing import Iterable
 
 import fitz
 
@@ -16,7 +16,7 @@ from .fallbacks import apply_fallbacks
 
 logger = logging.getLogger(__name__)
 
-def _excluded_pages(filepath: str, exclude: Optional[str]) -> set[int]:
+def _excluded_pages(filepath: str, exclude: str | None) -> set[int]:
     if not exclude:
         return set()
     with fitz.open(filepath) as doc:
@@ -48,7 +48,7 @@ def _block_pipeline(filepath: str, excluded: set[int]) -> list[Block]:
 
 
 def extract_text_blocks_from_pdf(
-    filepath: str, exclude_pages: Optional[str] = None
+    filepath: str, exclude_pages: str | None = None
 ) -> Iterable[Block]:
     """Yield ``Block`` objects from ``filepath`` respecting ``exclude_pages``.
 
@@ -62,7 +62,7 @@ def extract_text_blocks_from_pdf(
 
 
 def extract_text_blocks_from_pdf_list(
-    filepath: str, exclude_pages: Optional[str] = None
+    filepath: str, exclude_pages: str | None = None
 ) -> list[dict]:
     """Deprecated shim returning a materialised list of block dictionaries."""
 
@@ -70,7 +70,7 @@ def extract_text_blocks_from_pdf_list(
 
 
 def _legacy_extract_text_blocks_from_pdf(
-    filepath: str, exclude_pages: Optional[str] = None
+    filepath: str, exclude_pages: str | None = None
 ) -> list[dict]:
     """Backward-compatible shim for older imports."""
 

--- a/scripts/benchmark_extraction.py
+++ b/scripts/benchmark_extraction.py
@@ -18,7 +18,7 @@ import statistics
 import sys
 import os
 import traceback
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 from dataclasses import dataclass, asdict
 from pathlib import Path
 
@@ -53,7 +53,7 @@ class ExtractionMetrics:
     heading_count: int
     avg_chunk_size: float
     quality_score: float
-    error_message: Optional[str] = None
+    error_message: str | None = None
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -452,7 +452,7 @@ def run_benchmark(
     iterations: int = 3,
     chunk_size: int = 8000,
     overlap: int = 200,
-    exclude_pages: Optional[str] = None,
+    exclude_pages: str | None = None,
 ) -> BenchmarkResults:
     """
     Run complete benchmark comparing hybrid vs traditional extraction.


### PR DESCRIPTION
## Summary
- type exclude_pages parameters as `str | None` across fallback extraction and parsing utilities
- update benchmark script to follow new annotation

## Testing
- `mypy pdf_chunker/fallbacks.py`
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: Command pytest -q tests failed with exit code 1)*
- `bash scripts/validate_chunks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c071454124832593923eb62e35c784