### PR TITLE
feat: replay pipeline passes from trace snapshot

### DIFF
--- a/scripts/replay_from_snapshot.py
+++ b/scripts/replay_from_snapshot.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from functools import reduce
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from pdf_chunker.adapters import emit_jsonl
+import pdf_chunker.adapters.emit_trace as emit_trace
+from pdf_chunker.config import PipelineSpec, load_spec
+from pdf_chunker.core_new import configure_pass
+from pdf_chunker.framework import Artifact, registry
+
+
+def _read_json(path: str) -> Any:
+    """Load JSON from ``path`` using UTF-8 encoding."""
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def artifact_from_snapshot(path: str) -> Artifact:
+    """Return Artifact seeded from a snapshot file."""
+    payload = _read_json(path)
+    return Artifact(payload=payload, meta={"input": "<from-snapshot>", "metrics": {}})
+
+
+def passes_after(spec: PipelineSpec, start: str) -> list[str]:
+    """Pass names in ``spec`` occurring after ``start``; error if missing."""
+    try:
+        idx = spec.pipeline.index(start) + 1
+    except ValueError as e:  # pragma: no cover - defensive
+        raise KeyError(f"{start} not in pipeline") from e
+    return spec.pipeline[idx:]
+
+
+def _configured(spec: PipelineSpec, names: Sequence[str]):
+    regs = registry()
+    return [
+        configure_pass(regs[n], spec.options.get(n, {}))
+        for n in names
+        if n in regs
+    ]
+
+
+def run_passes(spec: PipelineSpec, a: Artifact, names: Sequence[str]) -> Artifact:
+    """Apply ``names`` passes from ``spec`` to ``a`` sequentially."""
+    return reduce(lambda acc, p: p(acc), _configured(spec, names), a)
+
+
+def _rows(payload: Any) -> Iterable[Mapping[str, Any]]:
+    """Extract chunk rows from ``payload`` when present."""
+    return (
+        payload
+        if isinstance(payload, list)
+        else payload.get("items", []) if isinstance(payload, Mapping) else []
+    )
+
+
+def replay(
+    snapshot: str,
+    start: str,
+    spec: PipelineSpec,
+    out: str | None,
+    check_dups: bool,
+) -> Artifact:
+    """Replay downstream passes from ``snapshot`` starting after ``start``."""
+    artifact = artifact_from_snapshot(snapshot)
+    steps = passes_after(spec, start)
+    logging.info("passes=%s", ",".join(steps))
+    result = run_passes(spec, artifact, steps)
+    rows = list(_rows(result.payload))
+    emit_jsonl.write(rows, out)
+    if check_dups:
+        info = emit_trace.summarize_duplicates(rows)
+        logging.info("duplicate_rows=%d", len(info.get("dups", [])))
+    return result
+
+
+def _parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Replay remaining pipeline passes")
+    p.add_argument("--snapshot", required=True)
+    p.add_argument("--from", dest="start", required=True)
+    p.add_argument("--spec", default="pipeline.yaml")
+    p.add_argument("--out", required=True)
+    p.add_argument("--check-dups", action="store_true")
+    return p
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    logging.basicConfig(format="[%(levelname)s] %(name)s:%(funcName)s – %(message)s")
+    spec = load_spec(args.spec)
+    replay(args.snapshot, args.start, spec, args.out, args.check_dups)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/tests/replay_from_snapshot_test.py
+++ b/tests/replay_from_snapshot_test.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import json
+
+from pdf_chunker.config import PipelineSpec
+
+from scripts import replay_from_snapshot as replay
+
+
+def test_run_passes_from_snapshot(tmp_path) -> None:
+    snap = {"type": "page_blocks", "pages": [{"page_number": 1, "blocks": [{"text": "ﬁsh"}]}]}
+    snap_path = tmp_path / "snap.json"
+    snap_path.write_text(json.dumps(snap), encoding="utf-8")
+    spec = PipelineSpec(pipeline=["pdf_parse", "text_clean"], options={})
+    art = replay.artifact_from_snapshot(str(snap_path))
+    tail = replay.passes_after(spec, "pdf_parse")
+    result = replay.run_passes(spec, art, tail)
+    text = result.payload["pages"][0]["blocks"][0]["text"]
+    assert text == "fish"


### PR DESCRIPTION
## Summary
- add `scripts/replay_from_snapshot.py` to resume pipeline passes from a saved snapshot and write downstream output
- cover replay helpers with a unit test

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: AssertionError in multiple existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5972af5088325abfce4fff01223ea