### PR TITLE
docs: document replay and bisect scripts

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -29,6 +29,17 @@ Please, keep this file up-to-date with the latest code structure. If you notice 
   ```bash
   python -m scripts.chunk_pdf --no-metadata ./platform-eng-excerpt.pdf > data/platform-eng.jsonl
   ```
+- Replay remaining passes from a snapshot and optionally check for duplicates:
+  ```bash
+  python scripts/replay_from_snapshot.py \
+    --snapshot artifacts/trace/<run_id>/pdf_parse.json \
+    --from pdf_parse --spec pipeline.yaml \
+    --out /tmp/replay.jsonl --check-dups
+  ```
+- Locate the first pass that introduces duplicates using a trace bundle:
+  ```bash
+  python scripts/bisect_dups.py --dir artifacts/trace/<run_id> --spec pipeline.yaml
+  ```
 
 ## Known Issues
 - Command-line help may be outdated.


### PR DESCRIPTION
## Summary
- document usage of replay_from_snapshot.py and bisect_dups.py in scripts AGENTS guide

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: FAILED tests/emit_jsonl_truncation_test.py::test_emit_jsonl_splits_and_clamps_rows ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c595d5de048325a5aa3d2d2dc3efa1