### PR TITLE
docs: document replay and bisect scripts

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -29,6 +29,26 @@ Please, keep this file up-to-date with the latest code structure. If you notice 
   ```bash
   python -m scripts.chunk_pdf --no-metadata ./platform-eng-excerpt.pdf > data/platform-eng.jsonl
   ```
+- Replay remaining passes from a snapshot and optionally check for duplicates:
+  ```bash
+  python scripts/replay_from_snapshot.py \
+    --snapshot artifacts/trace/<run_id>/pdf_parse.json \
+    --from pdf_parse --spec pipeline.yaml \
+    --out /tmp/replay.jsonl --check-dups
+  ```
+  Flags:
+  - `--snapshot PATH`: snapshot JSON file to seed replay.
+  - `--from STEP`: pass name matching the snapshot.
+  - `--spec FILE`: pipeline specification (default `pipeline.yaml`).
+  - `--out PATH`: destination for the replayed JSONL.
+  - `--check-dups`: enable duplicate detection and write `<final_pass>_dups.json`.
+- Locate the first pass that introduces duplicates using a trace bundle:
+  ```bash
+  python scripts/bisect_dups.py --dir artifacts/trace/<run_id> --spec pipeline.yaml
+  ```
+  Flags:
+  - `--dir PATH`: directory containing per-pass snapshots.
+  - `--spec FILE`: pipeline specification (default `pipeline.yaml`).
 
 ## Known Issues
 - Command-line help may be outdated.


### PR DESCRIPTION
## Summary
- document usage and flags for replay_from_snapshot.py and bisect_dups.py in scripts AGENTS guide

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: tests/epub_cli_regression_test.py::test_cli_epub_matches_golden, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c595d5de048325a5aa3d2d2dc3efa1