### PR TITLE
fix: detect subset duplicates

### DIFF
--- a/pdf_chunker/diagnostics/dups.py
+++ b/pdf_chunker/diagnostics/dups.py
@@ -21,6 +21,38 @@ def _group(items: Sequence[Mapping[str, Any]], pos_fn):
     return groups
 
 
+def _subset_dups(items: Sequence[Mapping[str, Any]], pos_fn):
+    fps: list[str] = []
+    token_map: dict[str, set[int]] = defaultdict(set)
+    seen: set[tuple[int, int]] = set()
+    records: list[Mapping[str, Any]] = []
+    for idx, item in enumerate(items):
+        fp = _fingerprint(str(item.get("text", "")))
+        tokens = fp.split()
+        candidates = {i for t in tokens for i in token_map.get(t, set())}
+        for j in candidates:
+            other = fps[j]
+            pair = (j, idx) if j < idx else (idx, j)
+            if fp and other and fp != other and (fp in other or other in fp) and pair not in seen:
+                short_fp, short_item = (fp, item) if len(fp) <= len(other) else (other, items[j])
+                records.append(
+                    {
+                        "fp": short_fp,
+                        "text": short_item.get("text", "")[:80],
+                        "count": 2,
+                        "first": pos_fn(items[j], j) if len(fp) > len(other) else pos_fn(item, idx),
+                        "second": pos_fn(item, idx)
+                        if len(fp) > len(other)
+                        else pos_fn(items[j], j),
+                    }
+                )
+                seen.add(pair)
+        fps.append(fp)
+        for t in set(tokens):
+            token_map[t].add(idx)
+    return records
+
+
 def _format(items: Sequence[Mapping[str, Any]], groups: Mapping[str, list[Mapping[str, Any]]]):
     return [
         {
@@ -37,27 +69,23 @@ def _format(items: Sequence[Mapping[str, Any]], groups: Mapping[str, list[Mappin
 
 def find_dups_pageblocks(blocks: Sequence[Mapping[str, Any]]):
     """Return duplicate page blocks based on normalized text."""
-    groups = _group(
-        blocks,
-        lambda b, i: {
-            "index": i,
-            **{k: b.get(k) for k in ("page", "bbox") if b.get(k) is not None},
-        },
-    )
-    return _format(blocks, groups)
+    pos = lambda b, i: {
+        "index": i,
+        **{k: b.get(k) for k in ("page", "bbox") if b.get(k) is not None},
+    }
+    groups = _group(blocks, pos)
+    return _format(blocks, groups) + _subset_dups(blocks, pos)
 
 
 def find_dups_chunks(chunks: Sequence[Mapping[str, Any]]):
     """Return duplicate chunks based on normalized text."""
-    groups = _group(
-        chunks,
-        lambda c, i: {
-            "index": i,
-            **(
-                {"chunk_id": c.get("metadata", {}).get("chunk_id")}
-                if c.get("metadata", {}).get("chunk_id")
-                else {}
-            ),
-        },
-    )
-    return _format(chunks, groups)
+    pos = lambda c, i: {
+        "index": i,
+        **(
+            {"chunk_id": c.get("metadata", {}).get("chunk_id")}
+            if c.get("metadata", {}).get("chunk_id")
+            else {}
+        ),
+    }
+    groups = _group(chunks, pos)
+    return _format(chunks, groups) + _subset_dups(chunks, pos)

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -10,7 +10,7 @@ Please, keep this file up-to-date with the latest code structure. If you notice 
 - ```chunk_pdf.py`: Full pipeline runner.
 - `validate_chunks.sh`: Semantic and size checks.
 - `detect_duplicates.py`: Overlap/duplicate analysis.
-- `bisect_dups.py`: Locate first pass introducing duplicates via snapshot replay.
+- `bisect_dups.py`: Locate first pass introducing duplicates via snapshot replay (checks `pdf_parse`→`text_clean`→`heading_detect`→`list_detect`→`split_semantic`).
 - `_apply.sh`: Batch orchestration.
 - `parity.py`: Run legacy and new pipelines for comparison.
 - `epoche_platform_eng.py`: Trace harness verifying duplicate and pass execution counts.
@@ -29,6 +29,26 @@ Please, keep this file up-to-date with the latest code structure. If you notice 
   ```bash
   python -m scripts.chunk_pdf --no-metadata ./platform-eng-excerpt.pdf > data/platform-eng.jsonl
   ```
+- Replay remaining passes from a snapshot and optionally check for duplicates:
+  ```bash
+  python scripts/replay_from_snapshot.py \
+    --snapshot artifacts/trace/<run_id>/pdf_parse.json \
+    --from pdf_parse --spec pipeline.yaml \
+    --out /tmp/replay.jsonl --check-dups
+  ```
+  Flags:
+  - `--snapshot PATH`: snapshot JSON file to seed replay.
+  - `--from STEP`: pass name matching the snapshot.
+  - `--spec FILE`: pipeline specification (default `pipeline.yaml`).
+  - `--out PATH`: destination for the replayed JSONL.
+  - `--check-dups`: enable duplicate detection and write `<final_pass>_dups.json`.
+- Locate the first pass that introduces duplicates using a trace bundle:
+  ```bash
+  python scripts/bisect_dups.py --dir artifacts/trace/<run_id> --spec pipeline.yaml
+  ```
+  Flags:
+  - `--dir PATH`: directory containing per-pass snapshots.
+  - `--spec FILE`: pipeline specification (default `pipeline.yaml`).
 
 ## Known Issues
 - Command-line help may be outdated.

--- a/scripts/bisect_dups.py
+++ b/scripts/bisect_dups.py
@@ -22,7 +22,13 @@ from pdf_chunker.diagnostics.dups import find_dups_chunks, find_dups_pageblocks
 from pdf_chunker.framework import Artifact, registry
 
 
-STEPS = ("pdf_parse", "text_clean", "heading_detect", "split_semantic")
+STEPS = (
+    "pdf_parse",
+    "text_clean",
+    "heading_detect",
+    "list_detect",
+    "split_semantic",
+)
 
 
 def _read_json(path: Path) -> Any:
@@ -38,7 +44,9 @@ def _rows(payload: Any) -> Iterable[Mapping[str, Any]]:
     return (
         payload
         if isinstance(payload, list)
-        else payload.get("items", []) if isinstance(payload, Mapping) else []
+        else payload.get("items", [])
+        if isinstance(payload, Mapping)
+        else []
     )
 
 
@@ -52,11 +60,7 @@ def _passes_after(spec: PipelineSpec, start: str) -> list[str]:
 
 def _run_passes(spec: PipelineSpec, art: Artifact, names: Sequence[str]) -> Artifact:
     regs = registry()
-    configured = (
-        configure_pass(regs[n], spec.options.get(n, {}))
-        for n in names
-        if n in regs
-    )
+    configured = (configure_pass(regs[n], spec.options.get(n, {})) for n in names if n in regs)
     return reduce(lambda acc, p: p(acc), configured, art)
 
 

--- a/tests/dups_subset_test.py
+++ b/tests/dups_subset_test.py
@@ -1,0 +1,20 @@
+from pdf_chunker.diagnostics.dups import find_dups_pageblocks, find_dups_chunks
+
+
+def test_pageblock_subset_detected():
+    blocks = [
+        {"text": "alpha beta gamma", "page": 1},
+        {"text": "beta gamma", "page": 2},
+    ]
+    dups = find_dups_pageblocks(blocks)
+    assert dups and dups[0]["first"]["page"] == 1 and dups[0]["second"]["page"] == 2
+
+
+def test_chunk_subset_detected():
+    chunks = [
+        {"text": "hello world from chunk", "metadata": {"chunk_id": 1}},
+        {"text": "world from", "metadata": {"chunk_id": 2}},
+    ]
+    dups = find_dups_chunks(chunks)
+    ids = {d["first"].get("chunk_id") for d in dups} | {d["second"].get("chunk_id") for d in dups}
+    assert ids == {1, 2}


### PR DESCRIPTION
## Summary
- broaden duplicate finder to flag overlapping text between blocks and chunks
- add regression tests ensuring subset duplicates are reported
- extend bisect helper to scan list_detect and speed up subset checks with token index

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: tests/epub_cli_regression_test.py::test_cli_epub_matches_golden, tests/footer_artifact_test.py::test_footer_and_subfooter_removed, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c595d5de048325a5aa3d2d2dc3efa1