### PR TITLE
feat: detect overlapping text via n-gram hashes

### DIFF
--- a/tests/dups_subset_test.py
+++ b/tests/dups_subset_test.py
@@ -1,19 +1,20 @@
 from pdf_chunker.diagnostics.dups import find_dups_pageblocks, find_dups_chunks
 
 
-def test_pageblock_subset_detected():
+def test_pageblock_overlap_detected():
     blocks = [
-        {"text": "alpha beta gamma", "page": 1},
-        {"text": "beta gamma", "page": 2},
+        {"text": "zero one two three four five six", "page": 1},
+        {"text": "alpha zero one two three four five", "page": 2},
     ]
     dups = find_dups_pageblocks(blocks)
-    assert dups and dups[0]["first"]["page"] == 1 and dups[0]["second"]["page"] == 2
+    pages = {d["first"]["page"] for d in dups} | {d["second"]["page"] for d in dups}
+    assert pages == {1, 2}
 
 
-def test_chunk_subset_detected():
+def test_chunk_overlap_detected():
     chunks = [
-        {"text": "hello world from chunk", "metadata": {"chunk_id": 1}},
-        {"text": "world from", "metadata": {"chunk_id": 2}},
+        {"text": "a b c d e f g", "metadata": {"chunk_id": 1}},
+        {"text": "x a b c d e y", "metadata": {"chunk_id": 2}},
     ]
     dups = find_dups_chunks(chunks)
     ids = {d["first"].get("chunk_id") for d in dups} | {d["second"].get("chunk_id") for d in dups}


### PR DESCRIPTION
## Summary
- add normalized 5-token n-gram fingerprints and an `overlap_dups` helper
- use `overlap_dups` in page block and chunk duplicate detection
- test that overlapping text snippets are treated as duplicates

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: FAILED tests/emit_jsonl_semantics_test.py::test_emit_jsonl_drops_incoherent_tail - AssertionError: assert [{'text': 'Th...ati...)*
- `pytest tests/dups_subset_test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5f80888988325a033fdbd1f66520b