### PR TITLE
Merge conversational segments before word splitting

### DIFF
--- a/tests/semantic_chunking_test.py
+++ b/tests/semantic_chunking_test.py
@@ -38,3 +38,11 @@ def test_parameter_propagation() -> None:
     counts = [len(t.split()) for t in texts]
     assert counts == [5, 5, 5, 5, 4]
     assert texts[1].split()[0] == "w4"
+
+
+def test_no_chunk_starts_mid_sentence() -> None:
+    """Chunks begin at sentence boundaries."""
+    text = 'Hello there," she said. "Hi," he replied. It was a sunny day.'
+    art = _SplitSemanticPass(chunk_size=10, overlap=0)(Artifact(payload=_doc(text)))
+    chunks = [c["text"] for c in art.payload["items"]]
+    assert all(not t.lstrip()[:1].islower() for t in chunks[1:])


### PR DESCRIPTION
## Summary
- merge conversational chunks prior to word-based segmentation to avoid mid-sentence starts
- test that semantic chunking never begins a chunk mid-sentence

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: AssertionError in multiple tests)*
- `flake8 tests/semantic_chunking_test.py`
- `mypy pdf_chunker/passes/split_semantic.py`


------
https://chatgpt.com/codex/tasks/task_e_68c625a11fd08325beb758376e8f7aeb