### PR TITLE
Ensure sentence boundaries in semantic chunks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,15 @@ It is important to rely on well-supported libraries and keep them pinned to avoi
   ```
 - Trace a specific phrase through the pipeline to debug loss or duplication:
   ```bash
-  pdf_chunker convert ./platform-eng-excerpt.pdf --spec pipeline.yaml --out ./data/platform-eng.jsonl --no-enrich --trace "Most engineers"
-  ```
-  Snapshot JSON files for passes containing the phrase will be written under `artifacts/trace/<run_id>/`.
+    pdf_chunker convert ./platform-eng-excerpt.pdf --spec pipeline.yaml --out ./data/platform-eng.jsonl --no-enrich --trace "Most engineers"
+    ```
+    Snapshot JSON files for passes containing the phrase will be written under `artifacts/trace/<run_id>/`.
+
+### Debugging Directions
+- When JSONL lines begin mid-sentence or phrases like "Most engineers" repeat, inspect the `split_semantic` pass before focusing on downstream emission or deduplication.
+- Ensure `_get_split_fn` pipes `semantic_chunker` through `merge_conversational_chunks` prior to `iter_word_chunks` and `_soft_segments`; skipping this step truncates or duplicates sentences.
+- Use `pdf_chunker convert ... --trace <phrase>` or run `tests/emit_jsonl_coalesce_test.py::test_split_does_not_duplicate` to pinpoint which pass introduces the anomaly.
+- `emit_jsonl` deduplication can mask upstream defects, so validate semantic split outputs first to avoid chasing the wrong component.
 
 ## Pass Responsibilities
 

--- a/pdf_chunker/passes/split_semantic.py
+++ b/pdf_chunker/passes/split_semantic.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, field, replace
-from functools import partial
+from functools import partial, reduce
 from itertools import chain
+import re
 from typing import Any, TypedDict, cast
 
 from pdf_chunker.framework import Artifact, Pass, register
@@ -36,6 +37,22 @@ def _soft_segments(text: str, max_size: int = SOFT_LIMIT) -> list[str]:
         yield from _split(tail)
 
     return list(_split(text))
+
+
+_ENDS_SENTENCE = re.compile(r"[.?!][\"')\]]*\s*$")
+
+
+def _merge_sentence_fragments(chunks: Iterable[str]) -> list[str]:
+    """Merge sequential ``chunks`` so each ends at a sentence boundary."""
+
+    def _merge(acc: list[str], chunk: str) -> list[str]:
+        return (
+            acc[:-1] + [f"{acc[-1]} {chunk}".strip()]
+            if acc and not _ENDS_SENTENCE.search(acc[-1].rstrip())
+            else acc + [chunk]
+        )
+
+    return reduce(_merge, chunks, [])
 
 
 Doc = dict[str, Any]
@@ -67,7 +84,11 @@ def _get_split_fn(
     soft_hits = 0
 
     try:
-        from pdf_chunker.splitter import iter_word_chunks, semantic_chunker
+        from pdf_chunker.splitter import (
+            iter_word_chunks,
+            merge_conversational_chunks,
+            semantic_chunker,
+        )
 
         semantic = partial(
             semantic_chunker,
@@ -78,22 +99,25 @@ def _get_split_fn(
 
         def split(text: str) -> list[str]:
             nonlocal soft_hits
-            raw = semantic(text)
-            soft_hits += sum(len(c) > SOFT_LIMIT for c in raw)
-            return [
+            merged, _ = merge_conversational_chunks(semantic(text), min_chunk_size)
+            raw = [
                 seg
-                for c in raw
+                for c in merged
                 for sub in iter_word_chunks(c, chunk_size)
                 for seg in _soft_segments(sub)
             ]
+            final = _merge_sentence_fragments(raw)
+            soft_hits += sum(len(c) > SOFT_LIMIT for c in final)
+            return final
 
     except Exception:  # pragma: no cover - safety fallback
 
         def split(text: str) -> list[str]:
             nonlocal soft_hits
             raw = _soft_segments(text)
-            soft_hits += sum(len(seg) > SOFT_LIMIT for seg in raw)
-            return raw
+            final = _merge_sentence_fragments(raw)
+            soft_hits += sum(len(seg) > SOFT_LIMIT for seg in final)
+            return final
 
     def metrics() -> dict[str, int]:
         return {"soft_limit_hits": soft_hits}
@@ -112,14 +136,30 @@ def _iter_blocks(doc: Doc) -> Iterable[tuple[int, Block]]:
 
 
 def _block_texts(doc: Doc, split_fn: SplitFn) -> Iterator[tuple[int, Block, str]]:
-    """Yield ``(page, block, text)`` triples from a document."""
+    """Yield ``(page, block, text)`` triples after merging sentence fragments."""
 
-    return (
-        (page, block, text)
-        for page, block in _iter_blocks(doc)
-        for text in split_fn(block.get("text", ""))
-        if text
+    def _merge(
+        acc: list[tuple[int, Block, str]],
+        cur: tuple[int, Block, str],
+    ) -> list[tuple[int, Block, str]]:
+        page, block, text = cur
+        if acc and (not _ENDS_SENTENCE.search(acc[-1][2].rstrip()) or cur[2][:1].islower()):
+            prev_page, prev_block, prev_text = acc[-1]
+            acc[-1] = (
+                prev_page,
+                prev_block,
+                f"{prev_text} {text}".strip(),
+            )
+            return acc
+        return acc + [cur]
+
+    merged: list[tuple[int, Block, str]] = reduce(
+        _merge,
+        ((p, b, b.get("text", "")) for p, b in _iter_blocks(doc)),
+        cast(list[tuple[int, Block, str]], []),
     )
+
+    return ((page, block, text) for page, block, raw in merged for text in split_fn(raw) if text)
 
 
 def _is_heading(block: Block) -> bool:

--- a/tests/semantic_chunking_test.py
+++ b/tests/semantic_chunking_test.py
@@ -1,5 +1,7 @@
 from pdf_chunker.framework import Artifact
+from pdf_chunker.passes.emit_jsonl import _dedupe
 from pdf_chunker.passes.split_semantic import _SplitSemanticPass
+import re
 
 
 def _doc(text: str) -> dict:
@@ -38,3 +40,42 @@ def test_parameter_propagation() -> None:
     counts = [len(t.split()) for t in texts]
     assert counts == [5, 5, 5, 5, 4]
     assert texts[1].split()[0] == "w4"
+
+
+def test_no_chunk_starts_mid_sentence() -> None:
+    """Chunks begin at sentence boundaries and never start mid-sentence."""
+    end_re = re.compile(r"[.?!][\"')\]]*$")
+    long_sentence = " ".join(f"w{i}" for i in range(120)) + "."
+    text = f"{long_sentence} Next one."
+    art = _SplitSemanticPass(chunk_size=10, overlap=0)(Artifact(payload=_doc(text)))
+    chunks = [c["text"] for c in art.payload["items"]]
+    assert all(end_re.search(prev.rstrip()) for prev in chunks[:-1])
+
+
+def test_blocks_merge_into_sentence() -> None:
+    """Adjacent blocks merge so chunks don't start mid-sentence."""
+    doc = {
+        "type": "page_blocks",
+        "pages": [
+            {
+                "page": 1,
+                "blocks": [
+                    {"text": "Cloud"},
+                    {"text": "development envs are new."},
+                ],
+            }
+        ],
+    }
+    art = _SplitSemanticPass()(Artifact(payload=doc))
+    texts = [c["text"] for c in art.payload["items"]]
+    assert texts == ["Cloud development envs are new."]
+
+
+def test_dedupe_preserves_sentence_start() -> None:
+    """Dedupe merges fragments so outputs don't start mid-sentence."""
+    items = [
+        {"text": "Prime numbers are tricky"},
+        {"text": "are tricky to reason about."},
+    ]
+    texts = [r["text"] for r in _dedupe(items)]
+    assert texts == ["Prime numbers are tricky to reason about."]


### PR DESCRIPTION
## Summary
- merge conversational chunks and dedupe fragments to avoid mid‑sentence JSONL rows
- add regression test confirming dedupe outputs start with full sentences
- document debugging directions so future agents inspect semantic splitting before emission

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: Command pytest -q tests failed with exit code 1)*
- `bash scripts/validate_chunks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c625a11fd08325beb758376e8f7aeb