### PR TITLE
feat: refine numbered list chunk merge

### DIFF
--- a/tests/numbered_list_chunk_test.py
+++ b/tests/numbered_list_chunk_test.py
@@ -2,10 +2,10 @@ import sys
 
 sys.path.insert(0, ".")
 
-from pdf_chunker.splitter import semantic_chunker
-from pdf_chunker.framework import Artifact
-from pdf_chunker.passes.list_detect import list_detect
-from pdf_chunker.passes.split_semantic import split_semantic
+from pdf_chunker.splitter import semantic_chunker  # noqa: E402
+from pdf_chunker.framework import Artifact  # noqa: E402
+from pdf_chunker.passes.list_detect import list_detect  # noqa: E402
+from pdf_chunker.passes.split_semantic import split_semantic  # noqa: E402
 
 
 def test_numbered_list_not_split_across_chunks():
@@ -21,6 +21,11 @@ def test_numbered_list_not_split_across_chunks():
     chunk = chunks[0]
     for n in range(1, 5):
         assert str(n) in chunk
+
+
+def test_numbered_list_merge_collapses_blank_lines():
+    text = "1. first\n\n2. second"
+    assert semantic_chunker(text, chunk_size=3, overlap=0) == ["1. first\n2. second"]
 
 
 def test_list_kind_propagates_to_chunk_metadata():


### PR DESCRIPTION
## Summary
- collapse extra blank lines when stitching numbered list chunks
- insert a newline before digit-starting list continuations
- cover list merging behavior with regression test

## Testing
- `black pdf_chunker/splitter.py tests/numbered_list_chunk_test.py`
- `flake8 tests/numbered_list_chunk_test.py`
- `mypy pdf_chunker/splitter.py`
- `nox -s lint`
- `nox -s typecheck`
- `pytest tests/numbered_list_chunk_test.py::test_numbered_list_merge_collapses_blank_lines -q`
- `nox -s tests` *(fails: tests/numbered_list_test.py::test_abbreviation_inside_numbered_item, tests/numbered_list_test.py::test_lowercase_chapter_followed_by_next_number, tests/page_artifact_detection_test.py::TestPageArtifactDetection::test_remove_header_and_footnote, tests/parity/test_e2e_parity.py::test_exclude_pages_yields_no_rows[pdf0], tests/pass_options_propagation_test.py::test_run_passes_respects_spec_options, tests/passes/test_split_semantic_options.py::test_cli_flags_affect_split_semantic, tests/passes/test_split_semantic_options.py::test_split_counts_change_with_overrides[overrides0-gt], tests/passes/test_split_semantic_options.py::test_split_counts_change_with_overrides[overrides1-lt], tests/property_based_text_test.py::test_clean_text_idempotent, tests/property_based_text_test.py::test_split_text_preserves_non_whitespace, tests/property_based_text_test.py::test_split_roundtrip_cleaning, tests/sample_local_pdf_list_test.py::test_sample_local_pdf_lists_have_newlines, tests/scripts_cli_test.py::test_convert_cli_writes_jsonl, tests/scripts_cli_test.py::test_cli_chunk_size_overlap_flags, tests/semantic_chunking_test.py::test_limits_and_metrics, tests/semantic_chunking_test.py::test_parameter_propagation, tests/split_semantic_pass_test.py::test_enforces_limits_and_structure, tests/text_clean_pass_test.py::test_text_clean_normalizes_blocks)`
- `bash scripts/validate_chunks.sh` *(fails: Chunk 0 has unbalanced quotes)*

------
https://chatgpt.com/codex/tasks/task_e_68c62fa6e6a08325b14b1c8dd790b2e5