### PR TITLE
Preserve list integrity during JSONL emission

### DIFF
--- a/tests/jsonl_split_list_test.py
+++ b/tests/jsonl_split_list_test.py
@@ -1,0 +1,16 @@
+import pytest
+
+from pdf_chunker.passes.emit_jsonl import _split
+
+
+@pytest.mark.parametrize(
+    "items, limit",
+    [
+        (["- a", "- b"], len("Intro\n- a\n")),
+        (["1. one", "2. two"], len("Intro\n1. one\n")),
+    ],
+)
+def test_split_preserves_lists(items, limit):
+    text = "Intro\n" + "\n".join(items) + "\nTail"
+    expected = ["Intro", "\n".join(items) + "\nTail"]
+    assert _split(text, limit) == expected


### PR DESCRIPTION
## Summary
- prevent `_split` from breaking bullet or numbered lists across JSONL lines
- add regression test ensuring list chunks stay intact

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: `tests/multiline_bullet_test.py::test_multiline_bullet_items`, `tests/newline_cleanup_test.py::TestNewlineCleanup::test_merge_break_in_quoted_title`, `tests/numbered_list_test.py::test_abbreviation_inside_numbered_item`, ...)*
- `python -m scripts.chunk_pdf --no-metadata ./platform-eng-excerpt.pdf > platform-eng.jsonl`
- `python - <<'PY'
import json
with open('platform-eng.jsonl') as f:
  for i,line in enumerate(f,1):
    text=json.loads(line)['text']
    if text.lstrip().startswith('-') or text.lstrip().startswith('•'):
      print('line', i, 'starts with bullet')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c71c1888308325b9add257e02c0f25