### PR TITLE
Avoid splitting list items across JSONL chunks

### DIFF
--- a/pdf_chunker/passes/emit_jsonl.py
+++ b/pdf_chunker/passes/emit_jsonl.py
@@ -6,9 +6,11 @@ import os
 import re
 from collections.abc import Iterable
 from functools import reduce
+from itertools import dropwhile
 from typing import Any, cast
 
 from pdf_chunker.framework import Artifact, register
+from pdf_chunker.list_detection import starts_with_bullet, starts_with_number
 from pdf_chunker.utils import _truncate_chunk
 
 Row = dict[str, Any]
@@ -39,6 +41,44 @@ def _max_chars() -> int:
     return int(os.getenv("PDF_CHUNKER_JSONL_MAX_CHARS", "8000"))
 
 
+def _is_list_line(line: str) -> bool:
+    stripped = line.lstrip()
+    return starts_with_bullet(stripped) or starts_with_number(stripped)
+
+
+def _first_non_empty_line(text: str) -> str:
+    return next((ln for ln in text.splitlines() if ln.strip()), "")
+
+
+def _trim_trailing_empty(lines: list[str]) -> list[str]:
+    return list(reversed(list(dropwhile(lambda ln: not ln.strip(), reversed(lines)))))
+
+
+def _rebalance_lists(raw: str, rest: str) -> tuple[str, str]:
+    """Shift trailing list block from ``raw`` into ``rest`` when appropriate."""
+
+    if not rest or not _is_list_line(_first_non_empty_line(rest)):
+        return raw, rest
+
+    lines = _trim_trailing_empty(raw.splitlines())
+    # fmt: off
+    candidates = [
+        i
+        for i, ln in enumerate(reversed(lines))
+        if ln.strip() and not _is_list_line(ln)
+    ]
+    # fmt: on
+    idx = candidates[0] if candidates else len(lines)
+    start = len(lines) - idx
+    block = lines[start:]
+    if not any(_is_list_line(ln) for ln in block):
+        return raw, rest
+
+    moved = "\n".join(block).lstrip("\n")
+    kept = "\n".join(lines[:start]).rstrip()
+    return kept, f"{moved}\n{rest.lstrip()}"
+
+
 def _split(text: str, limit: int) -> list[str]:
     """Yield ``text`` slices no longer than ``limit`` using soft boundaries."""
 
@@ -46,9 +86,12 @@ def _split(text: str, limit: int) -> list[str]:
     t = text
     while t:
         raw = _truncate_chunk(t, limit)
+        rest = t[len(raw) :]
+        raw, rest = _rebalance_lists(raw, rest)
         trimmed = _trim_overlap(pieces[-1], raw) if pieces else raw
-        pieces = [*pieces, trimmed] if trimmed else pieces
-        t = t[len(raw) :].lstrip()
+        if trimmed:
+            pieces.append(trimmed)
+        t = rest.lstrip()
     return pieces
 
 
@@ -110,7 +153,10 @@ def _merge_text(prev: str, curr: str) -> str:
     return f"{prev}\n\n{curr}".strip()
 
 
-def _merge_sentence_pieces(pieces: Iterable[str], limit: int | None = None) -> list[str]:
+def _merge_sentence_pieces(
+    pieces: Iterable[str],
+    limit: int | None = None,
+) -> list[str]:
     def step(acc: list[str], piece: str) -> list[str]:
         if (
             acc
@@ -152,7 +198,10 @@ def _merge_if_fragment(
     )
 
 
-def _merge_items(acc: list[dict[str, Any]], item: dict[str, Any]) -> list[dict[str, Any]]:
+def _merge_items(
+    acc: list[dict[str, Any]],
+    item: dict[str, Any],
+) -> list[dict[str, Any]]:
     text = item["text"]
     if acc:
         prev = acc[-1]
@@ -199,7 +248,10 @@ def _dedupe(
             if log is not None:
                 log.append(text)
             return state
-        overlap = _overlap_len(acc_norm, text_norm) or _prefix_contained_len(acc_norm, text_norm)
+        overlap = _overlap_len(acc_norm, text_norm) or _prefix_contained_len(
+            acc_norm,
+            text_norm,
+        )
         if overlap:
             if log is not None:
                 log.append(text[:overlap])

--- a/tests/jsonl_list_rebalance_test.py
+++ b/tests/jsonl_list_rebalance_test.py
@@ -1,0 +1,22 @@
+import pytest
+
+from pdf_chunker.passes.emit_jsonl import _rebalance_lists
+
+
+@pytest.mark.parametrize(
+    "raw, rest, expected",
+    [
+        (
+            "Intro\n- a\n",
+            "- b\nTail",
+            ("Intro", "- a\n- b\nTail"),
+        ),
+        (
+            "Intro\n1. one\n",
+            "\n2. two\nTail",
+            ("Intro", "1. one\n2. two\nTail"),
+        ),
+    ],
+)
+def test_rebalance_lists(raw, rest, expected):
+    assert _rebalance_lists(raw, rest) == expected


### PR DESCRIPTION
## Summary
- shift trailing list blocks from the current chunk into the remainder so bullet and numbered lists stay intact
- add a regression test covering bullet and numbered list rebalancing

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: suite interrupts with many failing cases)*
- `python -m scripts.chunk_pdf --no-metadata ./platform-eng-excerpt.pdf > platform-eng.jsonl`
- `python -m mypy pdf_chunker` *(fails: Need type annotation for "pages" in detect_page_artifacts.py)*
- `bash scripts/validate_chunks.sh` *(fails: missing chunk file)*


------
https://chatgpt.com/codex/tasks/task_e_68c71c1888308325b9add257e02c0f25