### PR TITLE
Avoid splitting list items across JSONL chunks

### DIFF
--- a/tests/jsonl_list_rebalance_test.py
+++ b/tests/jsonl_list_rebalance_test.py
@@ -1,0 +1,31 @@
+import pytest
+
+from pdf_chunker.passes.emit_jsonl import _merge_text, _rebalance_lists
+
+
+@pytest.mark.parametrize(
+    "raw, rest, expected",
+    [
+        (
+            "Intro\n- a\n",
+            "- b\nTail",
+            ("Intro", "- a\n- b\nTail"),
+        ),
+        (
+            "Intro\n1. one\n",
+            "\n2. two\nTail",
+            ("Intro", "1. one\n2. two\nTail"),
+        ),
+        (
+            "Intro\n1. one\n",
+            "\n\n2. two\nTail",
+            ("Intro", "1. one\n2. two\nTail"),
+        ),
+    ],
+)
+def test_rebalance_lists(raw, rest, expected):
+    assert _rebalance_lists(raw, rest) == expected
+
+
+def test_merge_text_collapses_list_gap():
+    assert _merge_text("1. one", "2. two") == "1. one\n2. two"


### PR DESCRIPTION
## Summary
- collapse blank lines before bullets or numbers during JSONL emission
- expand list rebalancing tests and ensure merge helpers respect list formatting

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(interrupted: session tests interrupted)*
- `bash scripts/validate_chunks.sh`
- `python -m pdf_chunker.cli convert platform-eng-excerpt.pdf --spec pipeline.yaml --out platform-eng.jsonl --no-enrich`
- `python - <<'PY'\nimport json, re\nwith open('platform-eng.jsonl') as f:\n    for i,line in enumerate(f,1):\n        text=json.loads(line)["text"].lstrip()\n        if re.match(r'^[-\\u2022\\*]|^\\d+\\.', text):\n            print(i, text[:80])\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68c71c1888308325b9add257e02c0f25