### PR TITLE
Avoid splitting list items across JSONL chunks

### DIFF
--- a/pdf_chunker/passes/emit_jsonl.py
+++ b/pdf_chunker/passes/emit_jsonl.py
@@ -6,9 +6,11 @@ import os
 import re
 from collections.abc import Iterable
 from functools import reduce
+from itertools import dropwhile
 from typing import Any, cast
 
 from pdf_chunker.framework import Artifact, register
+from pdf_chunker.list_detection import starts_with_bullet, starts_with_number
 from pdf_chunker.utils import _truncate_chunk
 
 Row = dict[str, Any]
@@ -39,6 +41,65 @@ def _max_chars() -> int:
     return int(os.getenv("PDF_CHUNKER_JSONL_MAX_CHARS", "8000"))
 
 
+def _is_list_line(line: str) -> bool:
+    stripped = line.lstrip()
+    return starts_with_bullet(stripped) or starts_with_number(stripped)
+
+
+def _first_non_empty_line(text: str) -> str:
+    return next((ln for ln in text.splitlines() if ln.strip()), "")
+
+
+def _last_non_empty_line(text: str) -> str:
+    return next((ln for ln in reversed(text.splitlines()) if ln.strip()), "")
+
+
+def _trim_trailing_empty(lines: list[str]) -> list[str]:
+    return list(reversed(list(dropwhile(lambda ln: not ln.strip(), reversed(lines)))))
+
+
+_LIST_GAP_RE = re.compile(r"\n{2,}(?=(?:\s*(?:[-\*\u2022]|\d+\.)))")
+
+
+def _collapse_list_gaps(text: str) -> str:
+    return _LIST_GAP_RE.sub("\n", text)
+
+
+def _rebalance_lists(raw: str, rest: str) -> tuple[str, str]:
+    """Shift trailing context or list block into ``rest`` when it starts with a list."""
+
+    if not rest or not _is_list_line(_first_non_empty_line(rest)):
+        return raw, rest
+
+    lines = _trim_trailing_empty(raw.splitlines())
+    has_list = any(_is_list_line(ln) for ln in lines)
+
+    # Determine split point: last non-list line if ``raw`` already contains list items,
+    # otherwise the preceding blank line so that list introductions move with the list.
+    # fmt: off
+    idx = next(
+        (
+            i
+            for i, ln in enumerate(reversed(lines))
+            if (
+                (ln.strip() and not _is_list_line(ln))
+                if has_list
+                else not ln.strip()
+            )
+        ),
+        len(lines),
+    )
+    # fmt: on
+    start = len(lines) - idx
+    block = lines[start:]
+    if not block:
+        return raw, rest
+
+    moved = "\n".join(block).strip()
+    kept = "\n".join(lines[:start]).rstrip()
+    return kept, f"{moved}\n{rest.lstrip()}".strip("\n")
+
+
 def _split(text: str, limit: int) -> list[str]:
     """Yield ``text`` slices no longer than ``limit`` using soft boundaries."""
 
@@ -46,9 +107,20 @@ def _split(text: str, limit: int) -> list[str]:
     t = text
     while t:
         raw = _truncate_chunk(t, limit)
+        rest = t[len(raw) :]
+        raw, rest = _collapse_list_gaps(raw), _collapse_list_gaps(rest)
+        raw, rest = _rebalance_lists(raw, rest)
         trimmed = _trim_overlap(pieces[-1], raw) if pieces else raw
-        pieces = [*pieces, trimmed] if trimmed else pieces
-        t = t[len(raw) :].lstrip()
+        if trimmed:
+            if pieces and _is_list_line(_first_non_empty_line(trimmed)):
+                merged = f"{pieces[-1].rstrip()}\n{trimmed.lstrip()}"
+                if len(merged) <= limit:
+                    pieces[-1] = merged
+                else:
+                    pieces.append(trimmed)
+            else:
+                pieces.append(trimmed)
+        t = rest.lstrip()
     return pieces
 
 
@@ -107,10 +179,17 @@ def _starts_mid_sentence(text: str) -> bool:
 
 
 def _merge_text(prev: str, curr: str) -> str:
-    return f"{prev}\n\n{curr}".strip()
+    last = _last_non_empty_line(prev)
+    first = _first_non_empty_line(curr)
+    cond = _is_list_line(last) and _is_list_line(first)
+    sep = "\n" if cond else "\n\n"
+    return f"{prev.rstrip()}{sep}{curr}".strip()
 
 
-def _merge_sentence_pieces(pieces: Iterable[str], limit: int | None = None) -> list[str]:
+def _merge_sentence_pieces(
+    pieces: Iterable[str],
+    limit: int | None = None,
+) -> list[str]:
     def step(acc: list[str], piece: str) -> list[str]:
         if (
             acc
@@ -152,7 +231,10 @@ def _merge_if_fragment(
     )
 
 
-def _merge_items(acc: list[dict[str, Any]], item: dict[str, Any]) -> list[dict[str, Any]]:
+def _merge_items(
+    acc: list[dict[str, Any]],
+    item: dict[str, Any],
+) -> list[dict[str, Any]]:
     text = item["text"]
     if acc:
         prev = acc[-1]
@@ -199,7 +281,10 @@ def _dedupe(
             if log is not None:
                 log.append(text)
             return state
-        overlap = _overlap_len(acc_norm, text_norm) or _prefix_contained_len(acc_norm, text_norm)
+        overlap = _overlap_len(acc_norm, text_norm) or _prefix_contained_len(
+            acc_norm,
+            text_norm,
+        )
         if overlap:
             if log is not None:
                 log.append(text[:overlap])

--- a/tests/jsonl_list_rebalance_test.py
+++ b/tests/jsonl_list_rebalance_test.py
@@ -1,0 +1,42 @@
+import pytest
+
+from pdf_chunker.passes.emit_jsonl import _merge_text, _rebalance_lists, _split
+
+
+@pytest.mark.parametrize(
+    "raw, rest, expected",
+    [
+        (
+            "Intro\n- a\n",
+            "- b\nTail",
+            ("Intro", "- a\n- b\nTail"),
+        ),
+        (
+            "Intro\n1. one\n",
+            "\n2. two\nTail",
+            ("Intro", "1. one\n2. two\nTail"),
+        ),
+        (
+            "Intro\n1. one\n",
+            "\n\n2. two\nTail",
+            ("Intro", "1. one\n2. two\nTail"),
+        ),
+        (
+            "Lead\n\nIntro",
+            "- a\n- b",
+            ("Lead", "Intro\n- a\n- b"),
+        ),
+    ],
+)
+def test_rebalance_lists(raw, rest, expected):
+    assert _rebalance_lists(raw, rest) == expected
+
+
+def test_merge_text_collapses_list_gap():
+    assert _merge_text("1. one", "2. two") == "1. one\n2. two"
+
+
+def test_split_reserves_intro_for_list():
+    text = "Lead\n\nIntro\n- a\n- b"
+    limit = len("Lead\n\nIntro")
+    assert _split(text, limit) == ["Lead", "Intro\n- a\n- b"]


### PR DESCRIPTION
## Summary
- Shift trailing context into following chunk when an upcoming section begins with a list
- Collapse blank lines before rebalancing so list introductions travel with their items
- Add regression tests for list context preservation and split boundaries

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: numbered_list_test::test_abbreviation_inside_numbered_item, numbered_list_test::test_lowercase_chapter_followed_by_next_number, page_artifact_detection_test::TestPageArtifactDetection::test_remove_header_and_footnote, parity/test_e2e_parity.py::test_exclude_pages_yields_no_rows[pdf0], pass_options_propagation_test::test_run_passes_respects_spec_options, passes/test_split_semantic_options.py::test_cli_flags_affect_split_semantic, passes/test_split_semantic_options.py::test_split_counts_change_with_overrides[overrides0-gt], passes/test_split_semantic_options.py::test_split_counts_change_with_overrides[overrides1-lt], property_based_text_test::test_clean_text_idempotent, property_based_text_test::test_split_text_preserves_non_whitespace, property_based_text_test::test_split_roundtrip_cleaning, sample_local_pdf_list_test::test_sample_local_pdf_lists_have_newlines, scripts_cli_test::test_convert_cli_writes_jsonl, scripts_cli_test::test_cli_chunk_size_overlap_flags, semantic_chunking_test::test_limits_and_metrics, semantic_chunking_test::test_parameter_propagation, semantic_chunking_test::test_no_chunk_starts_mid_sentence, split_semantic_pass_test::test_enforces_limits_and_structure, text_clean_pass_test::test_text_clean_normalizes_blocks`)
- `bash scripts/validate_chunks.sh`
- `python -m scripts.chunk_pdf --no-metadata ./platform-eng-excerpt.pdf > platform-eng.jsonl`
- `python - <<'PY'
import json, re
print('scan')
with open('platform-eng.jsonl') as f:
    for i, line in enumerate(f,1):
        text=json.loads(line)['text'].lstrip()
        if re.match(r'^[-\u2022\*]|^\d+\.', text):
            print(i, text[:80])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c71c1888308325b9add257e02c0f25