### PR TITLE
Refactor nox sessions and centralize lint config

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,45 +1,82 @@
 """Nox sessions for linting, type checking, and testing."""
 
+from collections.abc import Iterable
 from pathlib import Path
+from typing import Final
 
 import nox
 
-PY_TARGETS = [
+Command = tuple[str, ...]
+
+ROOT: Final = Path(__file__).parent
+SESSION_DEPENDENCIES: Final = ("-e", ".[dev]")
+QUALITY_PATHS: Final = (
     "pdf_chunker/__init__.py",
     "pdf_chunker/passes/emit_jsonl.py",
     "pdf_chunker/passes/split_semantic.py",
-    "noxfile.py",
-    "tests/bootstrap",
-]
+)
+LINT_EXTRA_PATHS: Final = ("noxfile.py", "tests/bootstrap")
+TEST_TARGETS: Final = ("tests",)
+TYPECHECK_EMPTY_MESSAGE: Final = "No typecheck targets yet."
+
+
+def _existing(paths: Iterable[str]) -> tuple[str, ...]:
+    """Return the subset of ``paths`` that exist, preserving declaration order."""
+
+    return tuple(path for path in dict.fromkeys(paths) if (ROOT / path).exists())
+
+
+def _lint_commands() -> tuple[Command, ...]:
+    targets = _existing((*QUALITY_PATHS, *LINT_EXTRA_PATHS))
+    return (
+        ("ruff", "check", *targets),
+        ("black", "--check", *targets),
+    )
+
+
+def _typecheck_commands() -> tuple[Command, ...]:
+    targets = _existing(QUALITY_PATHS)
+    return (("mypy", *targets),) if targets else ()
+
+
+def _test_commands() -> tuple[Command, ...]:
+    targets = _existing(TEST_TARGETS)
+    return (("pytest", "-q", *targets),) if targets else ()
+
+
+def _run(
+    session: nox.Session,
+    commands: tuple[Command, ...],
+    *,
+    empty_message: str | None = None,
+) -> None:
+    """Install shared dependencies and execute ``commands`` within ``session``."""
+
+    session.install(*SESSION_DEPENDENCIES)
+    if not commands:
+        if empty_message is not None:
+            session.log(empty_message)
+        return
+    for command in commands:
+        session.run(*command)
 
 
 @nox.session
-def lint(session):
-    session.install("-e", ".[dev]")
-    session.run("ruff", "check", "--fix", *PY_TARGETS)
-    session.run("black", "--check", *PY_TARGETS)
+def lint(session: nox.Session) -> None:
+    """Run static analysis via Ruff and Black."""
+
+    _run(session, _lint_commands())
 
 
 @nox.session
-def typecheck(session):
-    session.install("-e", ".[dev]")
-    targets = [
-        t
-        for t in [
-            "pdf_chunker/__init__.py",
-            "pdf_chunker/passes/emit_jsonl.py",
-            "pdf_chunker/passes/split_semantic.py",
-        ]
-        if Path(t).exists()
-    ]
-    if targets:
-        session.run("mypy", "--allow-untyped-globals", *targets)
-    else:
-        session.log("No typecheck targets yet.")
+def typecheck(session: nox.Session) -> None:
+    """Run mypy for the modules that currently have coverage."""
+
+    _run(session, _typecheck_commands(), empty_message=TYPECHECK_EMPTY_MESSAGE)
 
 
 @nox.session
-def tests(session):
-    session.install("-e", ".[dev]")
-    paths = (p.as_posix() for p in [Path("tests")] if p.exists())
-    session.run("pytest", "-q", *paths)
+def tests(session: nox.Session) -> None:
+    """Execute the pytest suite."""
+
+    _run(session, _test_commands())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,9 +55,10 @@ pdf_chunker = "pdf_chunker.cli:app"
 [tool.ruff]
 line-length = 100
 target-version = "py311"
-select = ["E","F","I","UP","B","SIM"]
-ignore = ["E501"] # handled by Black
 fix = true
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
 
 [tool.black]
 line-length = 100
@@ -72,6 +73,7 @@ warn_return_any = true
 warn_unreachable = true
 pretty = true
 show_error_codes = true
+allow_untyped_globals = true
 plugins = []
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary
- refactor the nox sessions into pure helpers so lint/typecheck reuse the same environment setup
- remove the redundant Ruff ignore flag and move the selection config into the dedicated `[tool.ruff.lint]` table
- rely on `pyproject.toml` for mypy configuration by setting `allow_untyped_globals`

## Testing
- nox -s lint
- nox -s typecheck
- nox -s tests *(fails: numerous pre-existing assertions in the suite)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d8c2c19483259a20185d87b37762