### PR TITLE
Respect full page exclusions

### DIFF
--- a/pdf_chunker/page_utils.py
+++ b/pdf_chunker/page_utils.py
@@ -74,12 +74,15 @@ def validate_page_exclusions(
         )
 
     # Check if all pages would be excluded
-    if len(valid_exclusions) >= total_pages:
+    covers_all = total_pages > 0 and all(
+        page in valid_exclusions for page in range(1, total_pages + 1)
+    )
+    if covers_all:
         print(
-            "Warning: Page exclusions would exclude all pages in "
-            f"'{filename}'. Processing will continue with no exclusions.",
+            "Warning: Page exclusions remove all pages in "
+            f"'{filename}'. Proceeding without emitting page blocks.",
             file=sys.stderr,
         )
-        return set()
+        return valid_exclusions
 
     return valid_exclusions


### PR DESCRIPTION
## Summary
- ensure `validate_page_exclusions` returns the caller-specified set even when every page is excluded so adapters and loaders honour the request
- extend the parity regression to exclude the full page range, assert the validated exclusion set, and verify the input artifact yields no page blocks

## Testing
- `pytest tests/parity/test_e2e_parity.py::test_exclude_pages_yields_no_rows[pdf0]`
- `nox -s lint` *(fails: repository formatting drift in pdf_chunker/passes/split_semantic.py)*
- `nox -s typecheck`
- `nox -s tests` *(fails: baseline expectations across golden fixtures and semantic chunking suite)*

------
https://chatgpt.com/codex/tasks/task_e_68cae8e116c483259d48cf39362a9fbd