### PR TITLE
Improve inline footnote handling in page artifact cleanup

### DIFF
--- a/tests/page_artifact_detection_test.py
+++ b/tests/page_artifact_detection_test.py
@@ -96,6 +96,8 @@ class TestPageArtifactDetection(unittest.TestCase):
         )
         cleaned = remove_page_artifact_lines(text, 115)
         self.assertEqual(cleaned, "First part of sentence\nThe sentence continues here.")
+        self.assertIn("First part of sentence", cleaned)
+        self.assertTrue(cleaned.endswith("The sentence continues here."))
 
     def test_header_inserted_mid_sentence(self):
         text = (
@@ -161,6 +163,12 @@ class TestPageArtifactDetection(unittest.TestCase):
         self.assertIn("Most engineers", cleaned)
         self.assertIn("Infrastructure setup", cleaned)
         self.assertNotIn("\n1.\n", cleaned)
+
+    def test_trailing_bullet_without_footer_context_preserved(self):
+        text = "Paragraph lead\n\n• Keep me"
+        cleaned = remove_page_artifact_lines(text, 0)
+        self.assertTrue(cleaned.endswith("Keep me"))
+        self.assertIn("Paragraph lead", cleaned)
 
 
 if __name__ == "__main__":

--- a/tests/property_based_text_test.py
+++ b/tests/property_based_text_test.py
@@ -3,6 +3,7 @@ from typing import Callable, TypeVar
 
 from hypothesis import given, strategies as st
 from pdf_chunker import splitter
+from pdf_chunker.page_artifacts import remove_page_artifact_lines
 from pdf_chunker.text_cleaning import clean_text
 
 
@@ -41,3 +42,10 @@ def test_split_roundtrip_cleaning(sample: str) -> None:
         clean_text,
     )
     assert pipeline(sample) == clean_text(sample)
+
+
+def test_inline_footnote_continuation_preserved() -> None:
+    sample = "Lead in.\n3 Footnote text. The continuation survives."
+    cleaned = remove_page_artifact_lines(sample, 3)
+    assert cleaned.endswith("The continuation survives.")
+    assert "Lead in." in cleaned


### PR DESCRIPTION
## Summary
- tighten bullet footer removal by requiring footer-like context and retaining inline footnote continuations
- ensure remove_page_artifact_lines keeps continuation sentences by stripping only the leading footnote prefix
- add targeted assertions and helpers in footer, page artifact detection, and property-based tests to guard non-artifact content

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`
- `pytest tests/page_artifact_detection_test.py::TestPageArtifactDetection::test_trailing_bullet_without_footer_context_preserved -q`
- `pytest tests/footer_artifact_test.py::test_footer_and_subfooter_removed -q`
- `pytest tests/page_artifact_detection_test.py::TestPageArtifactDetection::test_remove_header_and_footnote -q`
- `pytest tests/property_based_text_test.py::test_inline_footnote_continuation_preserved -q`


------
https://chatgpt.com/codex/tasks/task_e_68caf04f53d48325bdb1888c576d0d0f