### PR TITLE
Preserve hyphens when cross-line compounds are real

### DIFF
--- a/pdf_chunker/text_cleaning.py
+++ b/pdf_chunker/text_cleaning.py
@@ -180,10 +180,60 @@ HYPHEN_BREAK_RE = re.compile(
 )
 HYPHEN_SPACE_RE = re.compile(rf"([A-Za-z]+)[{HYPHEN_CHARS_ESC}]\s+{_HYPHEN_BULLET_OPT}([A-Za-z]+)")
 
+_LINEBREAK_HYPHEN_MARGIN = 1.5
+_LINEBREAK_LOWER_SUFFIXES = frozenset(
+    {
+        "ing",
+        "ings",
+        "ed",
+        "er",
+        "ers",
+        "est",
+        "ly",
+        "ally",
+        "ment",
+        "ments",
+        "ness",
+        "less",
+        "ful",
+        "ity",
+        "ities",
+        "ous",
+        "ive",
+        "tion",
+        "tions",
+        "sion",
+        "sions",
+        "able",
+        "ible",
+        "ance",
+        "ances",
+        "ence",
+        "ences",
+        "ism",
+        "ist",
+        "ists",
+        "ship",
+        "ships",
+        "hood",
+        "out",
+    }
+)
+
 
 # ---------------------------------------------------------------------------
 # Hyphenation and word glue fixes
 # ---------------------------------------------------------------------------
+
+
+def _hyphenation_scores(head: str, tail: str) -> Tuple[str, str, float, float]:
+    """Return join candidates and their corpus frequencies."""
+
+    joined = head + tail
+    hyphenated = f"{head}-{tail}"
+    joined_freq = zipf_frequency(joined.lower(), "en")
+    hyphen_freq = zipf_frequency(hyphenated.lower(), "en")
+    return joined, hyphenated, joined_freq, hyphen_freq
 
 
 def _choose_hyphenation(head: str, tail: str) -> str:
@@ -194,11 +244,36 @@ def _choose_hyphenation(head: str, tail: str) -> str:
     while still repairing line-break hyphenation artifacts.
     """
 
-    joined = head + tail
-    hyphenated = f"{head}-{tail}"
-    joined_freq = zipf_frequency(joined, "en")
-    hyphen_freq = zipf_frequency(hyphenated, "en")
+    joined, hyphenated, joined_freq, hyphen_freq = _hyphenation_scores(head, tail)
     return hyphenated if hyphen_freq > joined_freq else joined
+
+
+def _should_keep_linebreak_hyphen(
+    head: str, tail: str, joined_freq: float, hyphen_freq: float
+) -> bool:
+    """Decide whether a newline-spanning hyphen should be preserved."""
+
+    if joined_freq <= 0:
+        return True
+    if len(head) <= 2 or len(tail) <= 2:
+        return hyphen_freq > joined_freq
+    return hyphen_freq - joined_freq >= _LINEBREAK_HYPHEN_MARGIN
+
+
+def _normalize_linebreak_join_case(head: str, tail: str, joined: str) -> str:
+    """Lower-case obvious continuations after dropping a hyphen."""
+
+    if not tail or not tail.isalpha():
+        return joined
+    if tail == tail.lower():
+        return joined
+    tail_lower = tail.lower()
+    prefix = joined[: -len(tail)] if len(tail) < len(joined) else ""
+    if head.islower():
+        return prefix + tail_lower
+    if tail_lower in _LINEBREAK_LOWER_SUFFIXES:
+        return prefix + tail_lower
+    return joined
 
 
 def _join_hyphenated_words(text: str) -> str:
@@ -213,7 +288,12 @@ def _join_hyphenated_words(text: str) -> str:
     def choose_for_break(match: Match[str]) -> str:
         head, tail = match.group(1), match.group(2)
         hyphen = _hyphen_from_token(match.group(0))
-        return _replace_with_original(_choose_hyphenation(head, tail), hyphen)
+        joined, hyphenated, joined_freq, hyphen_freq = _hyphenation_scores(head, tail)
+        if hyphen_freq > joined_freq and _should_keep_linebreak_hyphen(
+            head, tail, joined_freq, hyphen_freq
+        ):
+            return _replace_with_original(hyphenated, hyphen)
+        return _normalize_linebreak_join_case(head, tail, joined)
 
     def choose_hyphenation(match: Match[str]) -> str:
         head, tail = match.group(1), match.group(2)

--- a/tests/hyphenation_test.py
+++ b/tests/hyphenation_test.py
@@ -77,3 +77,14 @@ def test_join_preserves_double_letters():
 )
 def test_crossline_hyphen_preserved(text, expected):
     assert clean_text(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("provision-\ning", "provisioning"),
+        ("through-\nOut", "throughout"),
+    ],
+)
+def test_crossline_spurious_hyphen_removed(text, expected):
+    assert clean_text(text) == expected

--- a/tests/hyphenation_test.py
+++ b/tests/hyphenation_test.py
@@ -45,6 +45,10 @@ def test_clean_block_hyphen_fix(block, expected):
             "We sell business-critical, off-the-shelf solutions.",
             ("business-critical", "off-the-shelf"),
         ),
+        (
+            "The release schedule is business-\u00adcritical.",
+            ("business-critical",),
+        ),
     ],
 )
 def test_preserve_existing_hyphens(text, expected):
@@ -64,6 +68,12 @@ def test_join_preserves_double_letters():
     assert clean_text(text) == "balloon"
 
 
-def test_crossline_hyphen_preserved():
-    text = "business-\ncritical systems"
-    assert "business-critical systems" in clean_text(text)
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("business-\ncritical systems", "business-critical systems"),
+        ("business\u00ad\ncritical systems", "businesscritical systems"),
+    ],
+)
+def test_crossline_hyphen_preserved(text, expected):
+    assert clean_text(text) == expected


### PR DESCRIPTION
## Summary
- preserve the original hyphen character for line-break joins while still consulting corpus frequencies to decide whether to keep or drop it
- reuse the helper in the newline path via the project’s functional pipeline helpers
- extend the hyphenation regression to cover newline and soft-hyphen samples

## Testing
- nox -s lint *(fails: would reformat pdf_chunker/passes/split_semantic.py)*
- nox -s typecheck
- nox -s tests *(fails: numerous pre-existing golden/parity regressions surface before completion)*
- pytest tests/hyphenation_test.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cb0a4571f8832590ba62c36fcffae4