### PR TITLE
Preserve list introductions during JSONL splitting

### DIFF
--- a/tests/jsonl_list_rebalance_test.py
+++ b/tests/jsonl_list_rebalance_test.py
@@ -5,6 +5,7 @@ from pdf_chunker.passes.emit_jsonl import (
     _is_list_line,
     _merge_text,
     _rebalance_lists,
+    _rows_from_item,
     _split,
 )
 
@@ -54,3 +55,22 @@ def test_split_moves_list_after_long_prefix():
     chunks = _split(text, 8000)
     assert chunks == [prefix, "Intro\n- a\n- b"]
     assert not _is_list_line(_first_non_empty_line(chunks[1]))
+
+
+def test_split_preserves_intro_label_with_colon():
+    text = "Intro summary\n\nIntro:\n- a\n- b"
+    limit = len("Intro summary")
+    chunks = _split(text, limit)
+    assert chunks == ["Intro summary", "Intro:\n- a\n- b"]
+
+
+def test_rows_from_item_keeps_list_kind_metadata():
+    item = {
+        "text": "Intro\n- a\n- b",
+        "meta": {
+            "list_kind": "bullet",
+        },
+    }
+    rows = _rows_from_item(item)
+    assert rows
+    assert {row["metadata"]["list_kind"] for row in rows} == {"bullet"}


### PR DESCRIPTION
## Summary
- teach `_reserve_for_list` to carry an intro hint alongside the remainder and fall back to moving the trailing preamble line when a list follows directly
- update `_split` to propagate the intro hint, join list blocks back to their carried introduction, and skip overlap trimming for list or carried intro chunks so the list text stays intact
- extend the JSONL list rebalance tests with colon/metadata regressions to ensure intros stay attached and `list_kind` metadata survives splitting

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests`
- `pytest tests/jsonl_list_rebalance_test.py::test_split_reserves_intro_for_list tests/jsonl_list_rebalance_test.py::test_split_moves_list_after_long_prefix tests/multiline_bullet_test.py::test_multiline_bullet_items tests/numbered_list_test.py::test_abbreviation_inside_numbered_item tests/numbered_list_test.py::test_lowercase_chapter_followed_by_next_number tests/sample_local_pdf_list_test.py::test_sample_local_pdf_lists_have_newlines`


------
https://chatgpt.com/codex/tasks/task_e_68cb236c3924832599ebd800dc31189e