### PR TITLE
Refine heading heuristic for quoted colons

### DIFF
--- a/tests/newline_cleanup_test.py
+++ b/tests/newline_cleanup_test.py
@@ -59,6 +59,16 @@ class TestNewlineCleanup(unittest.TestCase):
         expected = '" President Draws Planning Moral: Recalls Army Days to Show Value of Preparedness in Time of Crisis,"'
         self.assertEqual(clean_text(text), expected)
 
+    def test_merge_break_in_fully_quoted_title_with_colon(self):
+        text = (
+            '"The Power of Words: Understanding Language"\n\n'
+            "continues the discussion."
+        )
+        expected = (
+            '"The Power of Words: Understanding Language" continues the discussion.'
+        )
+        self.assertEqual(clean_text(text), expected)
+
     def test_merge_quote_with_author_line(self):
         text = (
             "What recommends commerce to me is its enterprise and bravery.\n\n"


### PR DESCRIPTION
## Summary
- extract reusable helpers for heading length, casing, and colon heuristics in `text_cleaning`
- tighten colon handling so only trailing or title-like colons trigger heading detection, avoiding quoted false positives
- add regression coverage to ensure quoted titles with embedded colons merge as expected

## Testing
- nox -s lint
- nox -s typecheck
- nox -s tests

------
https://chatgpt.com/codex/tasks/task_e_68cd649d81348325b6eba4d453ace062