### PR TITLE
Refine semantic fragment merging and cover long sentences

### DIFF
--- a/tests/semantic_chunking_test.py
+++ b/tests/semantic_chunking_test.py
@@ -71,6 +71,29 @@ def test_blocks_merge_into_sentence() -> None:
     assert texts == ["Cloud development envs are new."]
 
 
+def test_long_sentence_merges_past_limit() -> None:
+    """Fragments continue merging past the nominal limit until punctuation appears."""
+
+    first = " ".join(f"w{i}" for i in range(12))
+    second = " ".join(f"w{i}" for i in range(12, 24)) + "."
+    doc = {
+        "type": "page_blocks",
+        "pages": [
+            {
+                "page": 1,
+                "blocks": [
+                    {"text": first},
+                    {"text": second},
+                ],
+            }
+        ],
+    }
+
+    art = _SplitSemanticPass(chunk_size=12, overlap=0)(Artifact(payload=doc))
+    texts = [c["text"] for c in art.payload["items"]]
+    assert texts == [f"{first} {second}"]
+
+
 def test_dedupe_preserves_sentence_start() -> None:
     """Dedupe merges fragments so outputs don't start mid-sentence."""
     items = [


### PR DESCRIPTION
## Summary
- split `pdf_chunker.passes.split_semantic._merge_sentence_fragments` into reusable helpers that use generator expressions and allow sentence continuations to exceed the nominal size limit when no terminal punctuation is present
- extend semantic chunking regression coverage with a new test that ensures long sentences remain in a single chunk instead of restarting mid-sentence

## Testing
- nox -s lint
- nox -s typecheck
- nox -s tests *(fails: suite already red on main; see tests/emit_jsonl_coalesce_test.py::test_prefix_overlap_trimmed and friends)*

------
https://chatgpt.com/codex/tasks/task_e_68cd75a361ac8325b3a6f802b71c0ed1