### PR TITLE
Normalize bullet stopwords during chunk assembly

### DIFF
--- a/pdf_chunker/core.py
+++ b/pdf_chunker/core.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 from . import parsing
 from .ai_enrichment import classify_chunk_utterance
 from .splitter import semantic_chunker
+from .text_cleaning import normalize_bullet_stopwords
 from .utils import format_chunks_with_metadata as utils_format_chunks_with_metadata
 
 logger = logging.getLogger(__name__)
@@ -147,6 +148,7 @@ def chunk_text(
 ) -> list[str]:
     """Chunk blocks of text into semantic units."""
     full_text = "\n\n".join(block.get("text", "") for block in blocks if block.get("text", ""))
+    full_text = normalize_bullet_stopwords(full_text)
     chunks = semantic_chunker(
         full_text,
         chunk_size,


### PR DESCRIPTION
## Summary
- add a dedicated stopword normalizer for bullet lines and ensure collapse_single_newlines preserves bullet continuations before flattening
- reuse the new normalizer during semantic chunk assembly so multi-line bullet items keep their mid-sentence casing

## Testing
- pytest -q tests/multiline_bullet_test.py::test_multiline_bullet_items -q
- nox -s lint
- nox -s typecheck
- nox -s tests (fails)


------
https://chatgpt.com/codex/tasks/task_e_68ce17f49c9c8325b5beb7c0824a8782