### PR TITLE
Skip CLI smoke test when prerequisites missing

### DIFF
--- a/tests/e2e/test_cli_smoke.py
+++ b/tests/e2e/test_cli_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import importlib.util
 import json
 import subprocess
 from pathlib import Path
@@ -8,10 +9,20 @@ from shutil import which
 
 import pytest
 
-# Skip if heavy PDF dependency or CLI is missing
-pytest.importorskip("fitz")
-if which("pdf_chunker") is None:
-    pytest.skip("pdf_chunker CLI not installed", allow_module_level=True)
+
+def _is_cli_prerequisite_available() -> bool:
+    return all(
+        (
+            importlib.util.find_spec("fitz") is not None,
+            which("pdf_chunker") is not None,
+        )
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    not _is_cli_prerequisite_available(),
+    reason="PyMuPDF (fitz) and pdf_chunker CLI required for smoke test",
+)
 
 
 def _materialize_sample_pdf() -> Path:


### PR DESCRIPTION
## Summary
- add a pure helper that checks for PyMuPDF and the pdf_chunker CLI in the CLI smoke test module
- replace module-level import-and-skip logic with a pytest skipif that reports the skip instead of a usage error

## Testing
- pytest -q tests/e2e/test_cli_smoke.py::test_cli_smoke -q
- nox -s lint
- nox -s typecheck
- nox -s tests *(fails: multiple existing regression tests under tests/ currently failing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf67dc8450832594721e873f1d513c