### PR TITLE
Refine semantic chunking and footer preservation

### DIFF
--- a/pdf_chunker/page_artifacts.py
+++ b/pdf_chunker/page_artifacts.py
@@ -150,7 +150,7 @@ def _strip_page_header_prefix(text: str) -> str:
             idx += 1
             continue
         break
-    if idx == 0 or (not comma_seen and title_count < 3):
+    if idx == 0 or idx >= len(tokens) or (not comma_seen and title_count < 3):
         return text
     remainder = " ".join(t.strip(",") for t in tokens[idx:])
     if remainder and remainder[0].islower():

--- a/tests/e2e/test_cli_smoke.py
+++ b/tests/e2e/test_cli_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import importlib.util
 import json
 import subprocess
 from pathlib import Path
@@ -8,10 +9,20 @@ from shutil import which
 
 import pytest
 
-# Skip if heavy PDF dependency or CLI is missing
-pytest.importorskip("fitz")
-if which("pdf_chunker") is None:
-    pytest.skip("pdf_chunker CLI not installed", allow_module_level=True)
+
+def _is_cli_prerequisite_available() -> bool:
+    return all(
+        (
+            importlib.util.find_spec("fitz") is not None,
+            which("pdf_chunker") is not None,
+        )
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    not _is_cli_prerequisite_available(),
+    reason="PyMuPDF (fitz) and pdf_chunker CLI required for smoke test",
+)
 
 
 def _materialize_sample_pdf() -> Path:


### PR DESCRIPTION
## Summary
- refine `_merge_sentence_fragments` to respect custom `min_chunk_size`, drop the eager `iter_word_chunks` fallback, and introduce colon/list guards so semantic splitting stops joining list entries or heading scaffolds
- ensure `_strip_page_header_prefix` leaves real content intact when it would otherwise erase the entire line, preserving address-style footer text

## Testing
- pytest tests/semantic_chunking_test.py -q
- pytest tests/footer_artifact_test.py -q
- pytest tests/hyphen_bullet_list_test.py -q
- pytest tests/golden/test_conversion_epub_cli.py -q
- nox -s lint
- nox -s typecheck
- nox -s tests *(fails: numerous pre-existing regression tests still red, e.g. CLI EPUB structure, footer cleanup counts, numbered list quoting, markdown table normalization)*

------
https://chatgpt.com/codex/tasks/task_e_68cf67dc8450832594721e873f1d513c