### PR TITLE
Add parity tests for split semantic pipeline

### DIFF
--- a/tests/passes/test_split_semantic_parity.py
+++ b/tests/passes/test_split_semantic_parity.py
@@ -1,0 +1,152 @@
+"""Regression parity checks for semantic splitting.
+
+These tests exercise both the refactored chunk pipeline utilities and the
+existing :class:`_SplitSemanticPass`.  The goal is to demonstrate that the new
+functional pipeline preserves canonical chunk text and metadata for fixtures
+such as ``platform-eng-excerpt.pdf``.  Maintaining this invariance is a
+prerequisite for rolling the modular pipeline out across the CLI.
+
+Invariants covered here:
+
+* Sentence continuations remain merged across page boundaries.
+* List metadata (``list_kind``) survives the refactor.
+* Split metrics – notably ``soft_limit_hits`` – are identical between the two
+  implementations.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+from pdf_chunker.adapters.io_pdf import read
+from pdf_chunker.framework import Artifact
+from pdf_chunker.passes.chunk_options import SplitOptions
+from pdf_chunker.passes.chunk_pipeline import (
+    attach_headings as attach_headings_pipeline,
+)
+from pdf_chunker.passes.chunk_pipeline import (
+    chunk_records as chunk_records_pipeline,
+)
+from pdf_chunker.passes.chunk_pipeline import (
+    iter_blocks as iter_blocks_pipeline,
+)
+from pdf_chunker.passes.chunk_pipeline import (
+    merge_adjacent_blocks as merge_adjacent_blocks_pipeline,
+)
+from pdf_chunker.passes.split_semantic import (
+    DEFAULT_SPLITTER,
+    _block_text,
+    _inject_continuation_context,
+    _merge_blocks,
+    _merge_heading_texts,
+    _stitch_block_continuations,
+    _get_split_fn,
+    _is_heading,
+    build_chunk,
+    build_chunk_with_meta,
+)
+
+
+def _manual_pipeline(doc: dict) -> tuple[list[dict], dict[str, int]]:
+    """Compose the functional chunk pipeline mirroring ``_SplitSemanticPass``."""
+
+    options = SplitOptions.from_base(
+        DEFAULT_SPLITTER.chunk_size,
+        DEFAULT_SPLITTER.overlap,
+        DEFAULT_SPLITTER.min_chunk_size,
+    )
+    split_fn, metric_fn = _get_split_fn(
+        options.chunk_size, options.overlap, options.min_chunk_size
+    )
+    limit = options.compute_limit()
+    records = merge_adjacent_blocks_pipeline(
+        iter_blocks_pipeline(doc),
+        text_of=_block_text,
+        fold=_merge_blocks,
+        split_fn=split_fn,
+    )
+    headed = attach_headings_pipeline(
+        records,
+        is_heading=_is_heading,
+        merge_block_text=_merge_heading_texts,
+    )
+    stitched = _stitch_block_continuations(headed, limit)
+    build_meta = partial(
+        build_chunk_with_meta,
+        filename=doc.get("source_path"),
+    )
+    base_chunks = chunk_records_pipeline(
+        stitched,
+        generate_metadata=DEFAULT_SPLITTER.generate_metadata,
+        build_plain=build_chunk,
+        build_with_meta=build_meta,
+    )
+    items = list(_inject_continuation_context(base_chunks, limit))
+    return items, {"chunks": len(items), **metric_fn()}
+
+
+def _legacy_chunks(doc: dict) -> tuple[list[dict], dict[str, int]]:
+    """Run the registered split pass and expose its metrics."""
+
+    artifact = DEFAULT_SPLITTER(Artifact(payload=doc))
+    items = artifact.payload["items"]
+    metrics = (artifact.meta or {}).get("metrics", {}).get("split_semantic", {})
+    return items, {k: int(v) for k, v in metrics.items() if isinstance(v, int)}
+
+
+def _texts(items: Iterable[dict]) -> list[str]:
+    return [item.get("text", "") for item in items]
+
+
+def _metas(items: Iterable[dict]) -> list[dict]:
+    return [item.get("meta", {}) for item in items]
+
+
+def _pdf(path: str) -> dict:
+    return read(path)
+
+
+@pytest.mark.usefixtures("_nltk_data")
+def test_platform_eng_parity() -> None:
+    pytest.importorskip("fitz")
+    doc = _pdf(str(Path("platform-eng-excerpt.pdf")))
+
+    legacy_items, legacy_metrics = _legacy_chunks(doc)
+    refactored_items, refactored_metrics = _manual_pipeline(doc)
+
+    assert _texts(refactored_items) == _texts(legacy_items)
+    assert _metas(refactored_items) == _metas(legacy_items)
+    assert refactored_metrics == legacy_metrics
+
+    continuation = "ownership of operating the application's infrastructure"
+    assert any(continuation in chunk for chunk in _texts(legacy_items))
+
+    list_meta = [meta for meta in _metas(legacy_items) if meta.get("list_kind")]
+    assert list_meta, "expected list metadata to be present"
+    assert list_meta == [
+        meta for meta in _metas(refactored_items) if meta.get("list_kind")
+    ]
+
+
+def test_sample_book_list_metadata() -> None:
+    pytest.importorskip("fitz")
+    doc = _pdf(str(Path("sample_book-bullets.pdf")))
+
+    legacy_items, legacy_metrics = _legacy_chunks(doc)
+    refactored_items, refactored_metrics = _manual_pipeline(doc)
+
+    assert _texts(refactored_items) == _texts(legacy_items)
+    assert _metas(refactored_items) == _metas(legacy_items)
+    assert refactored_metrics == legacy_metrics
+
+    kinds = {meta.get("list_kind") for meta in _metas(legacy_items) if meta.get("list_kind")}
+    assert kinds == {"bullet"}
+    assert kinds == {
+        meta.get("list_kind")
+        for meta in _metas(refactored_items)
+        if meta.get("list_kind")
+    }


### PR DESCRIPTION
## Summary
- add regression tests that compare the legacy split pass with the modular chunk pipeline helpers
- cover canonical PDF and bullet-heavy samples to ensure text, metadata, and metrics parity
- document migration expectations and invariants directly in the test module docstring

## Testing
- `nox -s lint`
- `nox -s typecheck`
- `nox -s tests` *(fails: see test suite output for existing upstream regressions)*


------
https://chatgpt.com/codex/tasks/task_e_68d08b57770c832588adf8d682315988