### PR TITLE
Ensure page-leading blocks preserve sentence casing

### DIFF
--- a/pdf_chunker/pdf_parsing.py
+++ b/pdf_chunker/pdf_parsing.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import os
 import logging
-from dataclasses import asdict
-from typing import Iterable
+from dataclasses import asdict, replace
+from typing import Iterable, Iterator, Tuple
 
 import fitz
 
@@ -13,6 +13,7 @@ from .page_utils import validate_page_exclusions, parse_page_ranges
 from .page_artifacts import strip_artifacts
 from .pdf_blocks import Block, read_pages, merge_continuation_blocks
 from .fallbacks import apply_fallbacks
+from .text_cleaning import restore_leading_capitalization
 
 logger = logging.getLogger(__name__)
 
@@ -26,25 +27,53 @@ def _excluded_pages(filepath: str, exclude: str | None) -> set[int]:
     )
 
 
+def _block_pages(block: Block) -> Tuple[int, ...]:
+    source = block.source if isinstance(block.source, dict) else {}
+    page_range = source.get("page_range")
+    if (
+        isinstance(page_range, tuple)
+        and len(page_range) == 2
+        and all(isinstance(num, int) for num in page_range)
+    ):
+        start, end = page_range
+        return tuple(range(start, end + 1))
+
+    page = source.get("page")
+    return (page,) if isinstance(page, int) else ()
+
+
+def _restore_page_leading_case(blocks: Iterable[Block]) -> Iterator[Block]:
+    seen: set[int] = set()
+
+    for block in blocks:
+        pages = _block_pages(block)
+        if pages and any(page not in seen for page in pages):
+            restored = restore_leading_capitalization(block.text)
+            if restored != block.text:
+                block = replace(block, text=restored)
+        seen.update(pages)
+        yield block
+
+
 def _block_pipeline(filepath: str, excluded: set[int]) -> list[Block]:
     """Return merged blocks for ``filepath`` respecting ``excluded`` pages."""
 
-    return list(
-        merge_continuation_blocks(
-            apply_fallbacks(
-                strip_artifacts(
-                    (
-                        blk
-                        for page in read_pages(filepath, excluded)
-                        for blk in page.blocks
-                    ),
-                    None,
+    merged = merge_continuation_blocks(
+        apply_fallbacks(
+            strip_artifacts(
+                (
+                    blk
+                    for page in read_pages(filepath, excluded)
+                    for blk in page.blocks
                 ),
-                filepath,
-                excluded,
-            )
+                None,
+            ),
+            filepath,
+            excluded,
         )
     )
+
+    return list(_restore_page_leading_case(merged))
 
 
 def extract_text_blocks_from_pdf(


### PR DESCRIPTION
## Summary
- add a helper to detect the first alphabetic character in cleaned text and restore capitalization when the leading word is entirely lowercase
- apply the capitalization fix only to the first block per page during PDF parsing so list introductions retain sentence casing while existing cleaners remain unchanged
- expose the helper for reuse without perturbing the core cleaning pipeline

## Testing
- pytest tests/bullet_list_test.py::test_bullet_list_preservation
- nox -s lint
- nox -s typecheck
- nox -s tests *(fails: multiple known baseline regressions such as golden conversion parity and semantic split parity)*

------
https://chatgpt.com/codex/tasks/task_e_68d4752796e883258ac8d1fc33b9f24c