### PR TITLE
Normalize NBSP variants in clean/split roundtrips

### DIFF
--- a/pdf_chunker/splitter.py
+++ b/pdf_chunker/splitter.py
@@ -4,7 +4,10 @@ import re
 from functools import reduce
 from typing import Any, Dict, Iterable, Iterator, List, Match, Optional, Tuple
 
-from .text_cleaning import _is_probable_heading
+from .text_cleaning import (
+    _is_probable_heading,
+    pipe,
+)
 from .list_detection import starts_with_bullet
 from .page_artifacts import _drop_trailing_bullet_footers
 
@@ -474,10 +477,13 @@ def _tokenize_with_newlines(text: str) -> List[str]:
     def _join_newline_bullet(match: Match[str]) -> str:
         return f" {NEWLINE_TOKEN}{match.group(1)}"
 
-    prepared = _BULLET_AFTER_NEWLINE.sub(_join_newline_bullet, text)
-    prepared = prepared.replace(NBSP, f" {NBSP_TOKEN} ")
-    prepared = prepared.replace("\n", f" {NEWLINE_TOKEN} ")
-    return prepared.split()
+    prepared = pipe(
+        text,
+        lambda s: _BULLET_AFTER_NEWLINE.sub(_join_newline_bullet, s),
+        lambda s: s.replace(NBSP, f" {NBSP_TOKEN} "),
+        lambda s: s.replace("\n", f" {NEWLINE_TOKEN} "),
+    )
+    return [token for token in prepared.split() if token]
 
 
 def _detokenize_with_newlines(tokens: Iterable[str]) -> str:


### PR DESCRIPTION
## Summary
- expose normalize_windows_1252_quotes/normalize_non_breaking_spaces helpers from text_cleaning
- translate a broader set of NBSP-like separators to spaces during cleaning
- reuse the cleaning pipe helper in splitter tokenization to avoid losing normalization context

## Testing
- pytest tests/property_based_text_test.py::test_split_roundtrip_cleaning -q
- nox -s lint
- nox -s typecheck
- nox -s tests *(fails: existing golden, footer, and split parity regressions)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b21a625483259e9c9adadba1e7a0