### PR TITLE
Relax soft limit gating in sentence fusion

### DIFF
--- a/pdf_chunker/passes/sentence_fusion.py
+++ b/pdf_chunker/passes/sentence_fusion.py
@@ -139,10 +139,21 @@ def _merge_sentence_fragments(
         *,
         dense_fragments: bool,
     ) -> bool:
-        if budget.hard_limit is not None and budget.effective_total > budget.hard_limit:
+        hard_cap_exceeded = (
+            budget.hard_limit is not None and budget.effective_total > budget.hard_limit
+        )
+        if hard_cap_exceeded:
             return True
+
         if budget.limit is None or budget.effective_total <= budget.limit:
             return False
+
+        soft_cap_overflow_within_hard_cap = (
+            budget.hard_limit is not None and budget.effective_total <= budget.hard_limit
+        )
+        if soft_cap_overflow_within_hard_cap:
+            return False
+
         return not dense_fragments
 
     def _should_merge(


### PR DESCRIPTION
## Summary
- allow the sentence fusion budget to overflow the soft limit when the merged fragment stays within the hard cap
- keep the original hard limit guard so dense fragments still respect the configured chunk size

## Testing
- pytest tests/semantic_chunking_test.py::test_sentence_merge_allows_soft_limit_overflow tests/semantic_chunking_test.py::test_sentence_merge_large_chunks_respect_hard_cap

------
https://chatgpt.com/codex/tasks/task_e_68d7424a3858832588a1b1d3ac040422