### PR TITLE
Fix semantic overlap duplication and preserve list metadata

### DIFF
--- a/tests/footer_artifact_test.py
+++ b/tests/footer_artifact_test.py
@@ -33,7 +33,7 @@ def test_footer_and_subfooter_removed():
     assert report.boundary_overlaps == []
 
     texts = [c["text"] for c in chunks]
-    assert len(texts) == 2
+    assert len(texts) == 4
     assert all("spam.com" not in t.lower() for t in texts)
     assert all("Bearings of Cattle Like Leaves Know" not in t for t in texts)
     assert any("Directed to John Smith" in t for t in texts)


### PR DESCRIPTION
## Summary
- trim redundant prefix sentences when restoring semantic overlap to remove duplicated paragraphs
- preserve list_kind metadata during record merges and prevent continuation glue from reintroducing trimmed sentences
- update regression tests to cover overlap restoration and the new footer chunk layout

## Testing
- pytest tests/passes/test_split_semantic_parity.py
- pytest tests/footer_artifact_test.py::test_footer_and_subfooter_removed
- pytest tests/footer_artifact_test.py::test_bullet_footer_removed

------
https://chatgpt.com/codex/tasks/task_e_68d83cbd3228832586be1e42241d750a