### PR TITLE
Add tests covering config overrides and core chunk helpers

### DIFF
--- a/tests/config_warning_test.py
+++ b/tests/config_warning_test.py
@@ -1,6 +1,8 @@
 import textwrap
 import warnings
 
+import pytest
+
 from pdf_chunker.config import load_spec
 
 
@@ -19,3 +21,57 @@ def test_disabled_pass_option_suppresses_warning(tmp_path):
     with warnings.catch_warnings(record=True) as w:
         load_spec(cfg)
     assert not w
+
+
+def test_enabled_unknown_option_emits_warning(tmp_path):
+    cfg = tmp_path / "pipeline.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            """
+            pipeline: [pdf_parse]
+            options:
+              pdf_parse:
+                engine: native
+              extra_pass:
+                foo: 1
+            """
+        )
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        load_spec(cfg)
+
+    assert [w.message.args[0] for w in caught] == ["Unknown pipeline options: extra_pass"]
+
+
+def test_load_spec_merges_env_and_cli_overrides(tmp_path, monkeypatch):
+    cfg = tmp_path / "pipeline.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            """
+            pipeline: [pdf_parse, split_semantic]
+            options:
+              pdf_parse:
+                engine: native
+                retries: 2
+              split_semantic:
+                target_tokens: 800
+            """
+        )
+    )
+    monkeypatch.setenv("PDF_PARSE__ENGINE", "pymupdf4llm")
+    overrides = {"split_semantic": {"target_tokens": 900, "overlap": 25}}
+
+    spec = load_spec(cfg, overrides=overrides)
+
+    assert spec.pipeline == ["pdf_parse", "split_semantic"]
+    assert spec.options["pdf_parse"] == {"engine": "pymupdf4llm", "retries": 2}
+    assert spec.options["split_semantic"] == {"target_tokens": 900, "overlap": 25}
+
+
+def test_non_mapping_yaml_raises(tmp_path, monkeypatch):
+    cfg = tmp_path / "pipeline.yaml"
+    cfg.write_text("- not-a-mapping\n- still-not-a-mapping\n")
+
+    with pytest.raises(TypeError, match="top-level mapping"):
+        load_spec(cfg)

--- a/tests/core_helper_test.py
+++ b/tests/core_helper_test.py
@@ -1,0 +1,74 @@
+import logging
+from collections import Counter
+
+from pdf_chunker import core
+from pdf_chunker.framework import Artifact
+
+
+def test_parse_exclusions_success():
+    assert core.parse_exclusions("1, 3-4") == {1, 3, 4}
+
+
+def test_parse_exclusions_logs_error_on_failure(monkeypatch, caplog):
+    caplog.set_level(logging.ERROR, logger=core.logger.name)
+
+    def boom(_spec: str) -> set[int]:
+        raise ValueError("boom")
+
+    monkeypatch.setattr("pdf_chunker.page_utils.parse_page_ranges", boom)
+
+    assert core.parse_exclusions("1-2") == set()
+    assert any("Error parsing" in rec.message for rec in caplog.records)
+
+
+def test_filter_blocks_removes_excluded_pages(caplog):
+    caplog.set_level(logging.DEBUG, logger=core.logger.name)
+    blocks = (
+        {"source": {"page": 1}, "text": "keep"},
+        {"source": {"page": 2}, "text": "drop"},
+        {"source": {}, "text": "missing"},
+    )
+
+    remaining = core.filter_blocks(blocks, {2})
+
+    assert [block["text"] for block in remaining] == ["keep", "missing"]
+    assert any("After filtering excluded pages" in rec.message for rec in caplog.records)
+
+
+def test_chunk_text_invokes_splitter(monkeypatch):
+    captured = []
+
+    class DummySplit:
+        def __init__(self, **kwargs):
+            captured.append(kwargs)
+
+        def __call__(self, artifact: Artifact) -> Artifact:
+            captured.append(artifact.payload)
+            return Artifact(payload={"items": [{"text": "first"}, {"text": ""}, {"text": "second"}]})
+
+    monkeypatch.setattr(core, "_SplitSemanticPass", DummySplit)
+
+    blocks = (
+        {"text": "alpha", "source": {"page": 2, "index": 1}},
+        {"text": "beta", "source": {"page": 1, "index": 0}},
+    )
+
+    chunks = core.chunk_text(blocks, 1000, 50, min_chunk_size=12, enable_dialogue_detection=False)
+
+    assert chunks == ["first", "second"]
+    params, payload = captured
+    assert params["chunk_size"] == 1000
+    assert params["overlap"] == 50
+    assert params["min_chunk_size"] == 12
+    assert payload["pages"][0]["page"] == 1
+    assert [page["page"] for page in payload["pages"]] == [1, 2]
+
+
+def test_log_chunk_stats_emits_warning_for_tiny_chunks(caplog):
+    caplog.set_level(logging.WARNING, logger=core.logger.name)
+
+    core.log_chunk_stats(["This chunk has many words", "tiny"], label="Snippet")
+
+    messages = Counter(rec.levelname for rec in caplog.records)
+    assert messages["WARNING"] == 1
+    assert any("Very short chunks" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add regression tests for pipeline config warnings and option merging
- cover core helper flows for exclusions, chunking, and logging

## Testing
- pytest tests/config_warning_test.py tests/core_helper_test.py

------
https://chatgpt.com/codex/tasks/task_e_68d8a5e224f08325a3b10f9e220c416c