### PR TITLE
test(scope): exclude legacy parity suite by default

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -41,7 +41,7 @@ def _typecheck_commands() -> tuple[Command, ...]:
 
 def _test_commands() -> tuple[Command, ...]:
     targets = _existing(TEST_TARGETS)
-    return (("pytest", "-q", *targets),) if targets else ()
+    return (("pytest", "-q", "-m", "not legacy_parity", *targets),) if targets else ()
 
 
 def _run(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+  legacy_parity: legacy-equivalence tests (skipped by default)

--- a/tests/parity/conftest.py
+++ b/tests/parity/conftest.py
@@ -10,6 +10,21 @@ import pytest
 
 from scripts import parity as sp
 
+_PARITY_ROOT = Path(__file__).parent
+
+
+def _is_parity_test(item: pytest.Item) -> bool:
+    try:
+        Path(str(item.fspath)).resolve().relative_to(_PARITY_ROOT.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    marker = pytest.mark.legacy_parity
+    tuple(item.add_marker(marker) for item in items if _is_parity_test(item))
+
 
 def pytest_sessionstart(session: pytest.Session) -> None:
     os.environ.update({"PDF_CHUNKER_ENRICH": "0", "AI_ENRICH_ENABLED": "0"})


### PR DESCRIPTION
## Summary
- add a pytest marker configuration for the legacy parity suite
- mark tests under tests/parity/ as legacy_parity during collection
- update the nox tests session to skip the legacy parity suite by default

## Testing
- pytest -q -m legacy_parity --collect-only tests/parity

------
https://chatgpt.com/codex/tasks/task_e_68d96f0718ac8325abafad5231c8ef1c