### PR TITLE
Normalize numbered list spacing in split semantic pass

### DIFF
--- a/pdf_chunker/passes/split_semantic.py
+++ b/pdf_chunker/passes/split_semantic.py
@@ -1057,9 +1057,15 @@ def _collapse_numbered_list_spacing(text: str) -> str:
     return "\n".join(filtered)
 
 
+def _normalize_numbered_list_text(text: str) -> str:
+    """Normalize numbered list spacing without altering other content."""
+
+    return _collapse_numbered_list_spacing(text) if text else text
+
+
 def _join_record_texts(records: Iterable[tuple[int, Block, str]]) -> str:
     joined = "\n\n".join(part.strip() for _, _, part in records if part.strip()).strip()
-    return _collapse_numbered_list_spacing(joined) if joined else joined
+    return _normalize_numbered_list_text(joined) if joined else joined
 
 
 def _apply_overlap_within_segment(
@@ -1162,7 +1168,7 @@ def _emit_individual_records(
         (
             page,
             _with_chunk_index(block, start_index + offset),
-            text,
+            _normalize_numbered_list_text(text),
         )
         for offset, (page, block, text) in enumerate(segment)
     )


### PR DESCRIPTION
## Summary
- normalize numbered list text when emitting individual records in the semantic splitter
- reuse the same normalization helper for merged segments to keep spacing consistent

## Testing
- pytest tests/numbered_list_chunk_test.py::test_numbered_list_merge_collapses_blank_lines
- nox -s lint
- nox -s typecheck
- nox -s tests *(fails: footer_artifact_test::test_footer_and_subfooter_removed, footer_artifact_test::test_bullet_footer_removed, golden/test_conversion.py::test_conversion[pdf-b64_path0], golden/test_conversion_epub_cli.py::test_conversion_epub_cli, golden/test_golden_pdf.py::test_golden_pdf, hyphen_bullet_list_test.py::test_hyphen_bullet_lists_preserved, passes/test_split_semantic_parity.py::test_platform_eng_parity, split_semantic_pass_test.py::test_enforces_limits_and_structure)*

------
https://chatgpt.com/codex/tasks/task_e_68dc26b0450483259e043bbdcd20d62a