### PR TITLE
Honor CLI chunk overrides and guard sentence boundaries

### DIFF
--- a/pdf_chunker/passes/split_semantic.py
+++ b/pdf_chunker/passes/split_semantic.py
@@ -504,23 +504,41 @@ def _segment_char_limit(chunk_size: int | None) -> int:
 
 
 def _soft_segments(
-    text: str, *, max_chars: int | None = None
+    text: str,
+    *,
+    max_chars: int | None = None,
+    max_words: int | None = None,
 ) -> list[str]:
-    """Split ``text`` into segments of at most ``max_chars`` characters."""
+    """Split ``text`` while honouring character and word ceilings."""
 
     limit = SOFT_LIMIT if max_chars is None or max_chars <= 0 else min(max_chars, SOFT_LIMIT)
+    word_limit = max_words if max_words is not None and max_words > 0 else None
 
     def _split(chunk: str) -> Iterator[str]:
-        if len(chunk) <= limit:
-            trimmed = chunk.strip()
-            if trimmed:
-                yield trimmed
+        trimmed = chunk.strip()
+        if not trimmed:
             return
-        cut = chunk.rfind(" ", 0, limit)
-        head = chunk[: cut if cut != -1 else limit].strip()
-        tail = chunk[len(head) :].lstrip()
+
+        words = tuple(trimmed.split())
+        if word_limit is not None and len(words) > word_limit:
+            head_words = words[:word_limit]
+            tail_words = words[word_limit:]
+            head = " ".join(head_words)
+            tail = " ".join(tail_words)
+            yield from _split(head)
+            if tail:
+                yield from _split(tail)
+            return
+
+        if len(trimmed) <= limit:
+            yield trimmed
+            return
+
+        pivot = trimmed.rfind(" ", 0, limit)
+        head = trimmed[: pivot if pivot != -1 else limit].strip()
+        tail = trimmed[pivot if pivot != -1 else limit :].lstrip()
         if head:
-            yield head
+            yield from _split(head)
         if tail:
             yield from _split(tail)
 
@@ -1368,7 +1386,11 @@ def _get_split_fn(
 
             def _soften(segment: str) -> list[str]:
                 nonlocal soft_hits
-                splits = _soft_segments(segment, max_chars=char_limit)
+                splits = _soft_segments(
+                    segment,
+                    max_chars=char_limit,
+                    max_words=chunk_size,
+                )
                 if len(splits) > 1:
                     soft_hits += 1
                 return splits
@@ -1387,7 +1409,11 @@ def _get_split_fn(
 
         def split(text: str) -> list[str]:
             nonlocal soft_hits
-            raw = _soft_segments(text, max_chars=char_limit)
+            raw = _soft_segments(
+                text,
+                max_chars=char_limit,
+                max_words=chunk_size,
+            )
             final = _merge_sentence_fragments(
                 raw,
                 chunk_size=chunk_size,

--- a/pdf_chunker/passes/split_semantic.py
+++ b/pdf_chunker/passes/split_semantic.py
@@ -519,24 +519,26 @@ def _soft_segments(
         if not trimmed:
             return
 
-        words = tuple(trimmed.split())
-        if word_limit is not None and len(words) > word_limit:
-            head_words = words[:word_limit]
-            tail_words = words[word_limit:]
-            head = " ".join(head_words)
-            tail = " ".join(tail_words)
-            yield from _split(head)
-            if tail:
-                yield from _split(tail)
-            return
+        if word_limit is not None:
+            tokens = tuple(_TOKEN_PATTERN.finditer(trimmed))
+            if len(tokens) > word_limit:
+                split_index = tokens[word_limit - 1].end()
+                head = trimmed[:split_index]
+                tail = trimmed[split_index:]
+                if head:
+                    yield from _split(head)
+                if tail:
+                    yield from _split(tail)
+                return
 
         if len(trimmed) <= limit:
             yield trimmed
             return
 
         pivot = trimmed.rfind(" ", 0, limit)
-        head = trimmed[: pivot if pivot != -1 else limit].strip()
-        tail = trimmed[pivot if pivot != -1 else limit :].lstrip()
+        boundary = pivot if pivot != -1 else limit
+        head = trimmed[:boundary]
+        tail = trimmed[boundary:]
         if head:
             yield from _split(head)
         if tail:

--- a/tests/passes/test_split_semantic_options.py
+++ b/tests/passes/test_split_semantic_options.py
@@ -4,7 +4,11 @@ from pdf_chunker.cli import _cli_overrides
 from pdf_chunker.config import PipelineSpec
 from pdf_chunker.core_new import run_convert
 from pdf_chunker.framework import Artifact
-from pdf_chunker.passes.split_semantic import _collapse_records, split_semantic
+from pdf_chunker.passes.split_semantic import (
+    _collapse_records,
+    _soft_segments,
+    split_semantic,
+)
 
 
 def _observed_overlap(first: list[str], second: list[str]) -> int:
@@ -165,3 +169,11 @@ def test_collapse_records_does_not_span_pages() -> None:
     assert collapsed[0][2].split() == ["alpha", "beta"]
     assert collapsed[1][2] == "gamma"
     assert collapsed[1][1]["source"]["page"] == 2
+
+
+def test_soft_segments_retains_internal_newlines_under_word_budget() -> None:
+    text = "1. First item\n2. Second item\n3. Third item"
+
+    segments = _soft_segments(text, max_chars=40, max_words=4)
+
+    assert "\n2." in segments[0]


### PR DESCRIPTION
## Summary
- teach `_soft_segments` to respect chunk-size overrides so fallback splitting honors CLI configuration
- propagate the override-aware segments through `_get_split_fn` and let sentence fusion overflow when punctuation is still pending

## Testing
- pytest tests/passes/test_split_semantic_options.py::test_cli_flags_affect_split_semantic
- pytest tests/semantic_chunking_test.py::test_no_chunk_starts_mid_sentence
- nox -s lint
- nox -s typecheck
- nox -s tests *(fails on known footer/list/parity/golden regressions)*

------
https://chatgpt.com/codex/tasks/task_e_68dc28af28a083259aa06fddf375b399