### PR TITLE
Document golden refresh verification

### DIFF
--- a/docs/test_stabilization_plan.md
+++ b/docs/test_stabilization_plan.md
@@ -11,6 +11,7 @@
 * `nox -s lint` fails because `black --check` wants to reformat `pdf_chunker/passes/split_semantic.py` even though the logic is pure.【61c927†L1-L8】
 * `nox -s typecheck` succeeds with no mypy issues.【428704†L1-L4】
 * `nox -s tests` fails on eight assertions covering footer joins, numbered-list formatting, CLI overrides, sentence-boundary guarantees, parity, and stale goldens.【0c3fcc†L1-L420】
+* Golden fixtures verified via `python scripts/refresh_goldens.py --approve`; script reported all targets up-to-date without rewriting fixtures.【157e4c†L1-L4】
 
 ## Next Steps to Reach Green
 1. **Restore lint compliance**  


### PR DESCRIPTION
## Summary
- note in the stabilization plan that the golden fixtures were refreshed via `scripts/refresh_goldens.py --approve`, with no rewrites required

## Testing
- python scripts/refresh_goldens.py --approve
- pytest tests/refresh_goldens_test.py tests/test_readability.py tests/epub_cli_regression_test.py
- nox -s lint
- nox -s typecheck
- nox -s tests *(fails: tests/footer_artifact_test.py::test_footer_and_subfooter_removed, tests/footer_artifact_test.py::test_bullet_footer_removed, tests/golden/test_conversion.py::test_conversion[pdf-b64_path0], tests/golden/test_conversion_epub_cli.py::test_conversion_epub_cli, tests/golden/test_golden_pdf.py::test_golden_pdf, tests/hyphen_bullet_list_test.py::test_hyphen_bullet_lists_preserved, tests/split_semantic_pass_test.py::test_enforces_limits_and_structure)*

------
https://chatgpt.com/codex/tasks/task_e_68dc49a6a58c83259fc2aaf264e1ba4e