### PR TITLE
Refine footer pruning for chunk splitter

### DIFF
--- a/tests/property_based_text_test.py
+++ b/tests/property_based_text_test.py
@@ -48,6 +48,12 @@ def test_split_text_preserves_non_whitespace(sample: str) -> None:
     assert strip_ws(joined) == strip_ws(sample)
 
 
+def test_split_text_preserves_intro_bullet_newline() -> None:
+    sample = "Intro:\n• item"
+    chunks = splitter._split_text_into_chunks(sample, chunk_size=2, overlap=0)
+    assert "".join(chunks) == sample
+
+
 @given(st.text(min_size=1))
 def test_split_roundtrip_cleaning(sample: str) -> None:
     pipeline = compose(

--- a/tests/property_based_text_test.py
+++ b/tests/property_based_text_test.py
@@ -54,6 +54,24 @@ def test_split_text_preserves_intro_bullet_newline() -> None:
     assert "".join(chunks) == sample
 
 
+def test_split_text_discards_pruned_footer_tail(monkeypatch) -> None:
+    sample = "one two three four tail"
+
+    monkeypatch.setattr(
+        splitter,
+        "_remove_footer_artifacts",
+        lambda text: "" if text.endswith(" tail") else text,
+    )
+    monkeypatch.setattr(
+        splitter,
+        "_should_prune_footer",
+        lambda text, is_last: is_last,
+    )
+
+    chunks = splitter._split_text_into_chunks(sample, chunk_size=3, overlap=1)
+    assert chunks == ["one two three "]
+
+
 @given(st.text(min_size=1))
 def test_split_roundtrip_cleaning(sample: str) -> None:
     pipeline = compose(


### PR DESCRIPTION
## Summary
- delay footer pruning until the final chunk and avoid trimming mid-list slices
- add helpers to detect mid-list endings before pruning footer artifacts
- cover the intro bullet newline regression with a focused unit test

## Testing
- pytest tests/property_based_text_test.py

------
https://chatgpt.com/codex/tasks/task_e_68f54e2758248325a614027c53ba622d